### PR TITLE
[566977] URLS with Diagrams anchors redirection

### DIFF
--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/foundations/AbstractExchangeDocGen.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/foundations/AbstractExchangeDocGen.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.1.201906060805
+//Generated with EGF 1.6.2.202001031546
 package org.polarsys.capella.docgen.foundations;
 
 import org.eclipse.egf.common.helper.*;
@@ -47,11 +47,12 @@ public class AbstractExchangeDocGen extends org.polarsys.capella.docgen.foundati
 			+ NL + "\t\t<script type=\"text/javascript\">" + NL
 			+ "\t\t\tif(parent.location.href == self.location.href) {" + NL
 			+ "\t\t\t\twindow.location.href = 'index.html?";
-	protected final String TEXT_10 = "';" + NL + "\t\t\t}" + NL + "\t\t</script>" + NL + "\t\t" + NL + "\t\t<style>"
-			+ NL + "\t\t\tbody {" + NL + "\t\t\t\tbackground: white;" + NL + "\t\t\t\tfont-family: Arial;" + NL
-			+ "\t\t\t}" + NL + "\t\t\t.treeview {" + NL + "\t\t\t\tbackground-color: white ;" + NL + "\t\t\t}" + NL
-			+ "\t" + NL + "\t\t\t.treeview ul{ /*CSS for Simple Tree Menu*/" + NL + "\t\t\t\tbackground-color: white;"
-			+ NL + "\t\t\t\tfont-size: 12px;" + NL + "\t\t\t}" + NL + "\t" + NL
+	protected final String TEXT_10 = "' + '#' + self.location.href.substring(self.location.href.lastIndexOf(\"#\")+1);"
+			+ NL + "\t\t\t}" + NL + "\t\t</script>" + NL + "\t\t" + NL + "\t\t<style>" + NL + "\t\t\tbody {" + NL
+			+ "\t\t\t\tbackground: white;" + NL + "\t\t\t\tfont-family: Arial;" + NL + "\t\t\t}" + NL
+			+ "\t\t\t.treeview {" + NL + "\t\t\t\tbackground-color: white ;" + NL + "\t\t\t}" + NL + "\t" + NL
+			+ "\t\t\t.treeview ul{ /*CSS for Simple Tree Menu*/" + NL + "\t\t\t\tbackground-color: white;" + NL
+			+ "\t\t\t\tfont-size: 12px;" + NL + "\t\t\t}" + NL + "\t" + NL
 			+ "\t\t\t.treeview li{ /*Style for LI elements in general (excludes an LI that contains sub lists)*/" + NL
 			+ "\t\t\t\tbackground-color: white;" + NL + "\t\t\t}" + NL + "\t\t</style>" + NL + "\t\t" + NL + "\t</head>"
 			+ NL + "\t" + NL + "\t<body>";
@@ -60,6 +61,7 @@ public class AbstractExchangeDocGen extends org.polarsys.capella.docgen.foundati
 			+ NL + "\t\t$(\"#";
 	protected final String TEXT_13 = "\").treeview({ collapsed: false, animated: \"fast\", unique: false, control: \"#treecontrol\"});"
 			+ NL + "\t</script>" + NL + "   </body>" + NL + "</html>";
+	protected final String TEXT_14 = NL;
 
 	public AbstractExchangeDocGen() {
 		//Here is the constructor
@@ -87,8 +89,8 @@ public class AbstractExchangeDocGen extends org.polarsys.capella.docgen.foundati
 			ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
 		}
 
-		stringBuffer.append(TEXT_2);
-		stringBuffer.append(TEXT_2);
+		stringBuffer.append(TEXT_14);
+		stringBuffer.append(TEXT_14);
 		return stringBuffer.toString();
 	}
 

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/foundations/CapellaElementDocGen.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/foundations/CapellaElementDocGen.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.1.201906060805
+//Generated with EGF 1.6.2.202001031546
 package org.polarsys.capella.docgen.foundations;
 
 import org.eclipse.egf.common.helper.*;
@@ -42,9 +42,10 @@ public class CapellaElementDocGen extends org.polarsys.kitalpha.doc.gen.business
 			+ NL + "\t\t<script type=\"text/javascript\">" + NL
 			+ "\t\t\tif(parent.location.href == self.location.href) {" + NL
 			+ "\t\t\t\twindow.location.href = 'index.html?";
-	protected final String TEXT_4 = "';" + NL + "\t\t\t}" + NL + "\t\t</script>" + NL + "\t\t" + NL + "\t\t<style>" + NL
-			+ "\t\t\tbody {" + NL + "\t\t\t\tbackground: white;" + NL + "\t\t\t\tfont-family: Arial;" + NL + "\t\t\t}"
-			+ NL + "\t\t\t.treeview {" + NL + "\t\t\t\tbackground-color: white ;" + NL + "\t\t\t}" + NL + "\t" + NL
+	protected final String TEXT_4 = "' + '#' + self.location.href.substring(self.location.href.lastIndexOf(\"#\")+1);"
+			+ NL + "\t\t\t}" + NL + "\t\t</script>" + NL + "\t\t" + NL + "\t\t<style>" + NL + "\t\t\tbody {" + NL
+			+ "\t\t\t\tbackground: white;" + NL + "\t\t\t\tfont-family: Arial;" + NL + "\t\t\t}" + NL
+			+ "\t\t\t.treeview {" + NL + "\t\t\t\tbackground-color: white ;" + NL + "\t\t\t}" + NL + "\t" + NL
 			+ "\t\t\t.treeview ul{ /*CSS for Simple Tree Menu*/" + NL + "\t\t\t\tbackground-color: white;" + NL
 			+ "\t\t\t\tfont-size: 12px;" + NL + "\t\t\t}" + NL + "\t" + NL
 			+ "\t\t\t.treeview li{ /*Style for LI elements in general (excludes an LI that contains sub lists)*/" + NL

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/index/indexBuilder.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/index/indexBuilder.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.1.201906060805
+//Generated with EGF 1.6.2.202001031546
 package org.polarsys.capella.docgen.index;
 
 import org.eclipse.egf.common.helper.*;
@@ -26,10 +26,13 @@ public class indexBuilder extends org.polarsys.kitalpha.doc.gen.business.core.in
 			+ "document.write('<frameset rows=\"63,*,40\" frameborder=\"0\" framespacing=\"0\" border=\"0\">');" + NL
 			+ "document.write('<frame src=\"header.html\" name=\"header\" marginheight=\"0\" marginwidth=\"0\" scrolling=\"no\" noresize=\"0\"/>');"
 			+ NL + "document.write('<frameset cols=\"22%,*\" border=\"5\" frameborder=\"1\" framespacing=\"1\">');" + NL
-			+ "document.write('<frame src=\"sidebar.html\" name=\"sideBar\"/>');" + NL
-			+ "var locationText = (location.search ? location.search.substring(1):\"";
-	protected final String TEXT_2 = "\");" + NL
-			+ "document.write('<frame src=\"'+ locationText +'.html\" name=\"content\"\\/>');" + NL
+			+ "document.write('<frame src=\"sidebar.html\" name=\"sideBar\"/>');" + NL + "var locationText = \"\";" + NL
+			+ "var anchorText = \"\";" + NL + "if (location.search) {" + NL
+			+ "\tlocationText = location.search.substring(1);" + NL + "\tif (location.href.lastIndexOf(\"#\")>0) {" + NL
+			+ "\t\tanchorText = anchorText + \"#\" + location.href.substring(location.href.lastIndexOf(\"#\")+1);" + NL
+			+ "\t}" + NL + "} else {" + NL + "\tlocationText = \"";
+	protected final String TEXT_2 = "\";" + NL + "}" + NL
+			+ "document.write('<frame src=\"'+ locationText +'.html' + anchorText + '\" name=\"content\"\\/>');" + NL
 			+ "document.write('<noframes>');" + NL + "document.write('Your browser cannot display this page !');" + NL
 			+ "  document.write('</noframes>');" + NL + "document.write('</frameset>');" + NL
 			+ "document.write('<frame src=\"footer.html\" name=\"footer\" scrolling=\"no\" frameborder=\"0\" noresize=\"noresize\"/>');"

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/templates/pattern._ZFI0MIFLEemoWLDLVaBCIQ/method._EWKusIHjEemoWLDLVaBCIQ.pt
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/templates/pattern._ZFI0MIFLEemoWLDLVaBCIQ/method._EWKusIHjEemoWLDLVaBCIQ.pt
@@ -16,7 +16,7 @@
 		<link title="default" rel="stylesheet" type="text/css" media="screen, projection" href="../../css/content.css"></link>
 		<script type="text/javascript">
 			if(parent.location.href == self.location.href) {
-				window.location.href = 'index.html?<%=fileName%>';
+				window.location.href = 'index.html?<%=fileName%>' + '#' + self.location.href.substring(self.location.href.lastIndexOf("#")+1);
 			}
 		</script>
 		

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/templates/pattern._ixj0MN0eEd-Vzvs7Wt1vzQ/method._ALikYLklEemEHKw9GhkeOQ.pt
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/templates/pattern._ixj0MN0eEd-Vzvs7Wt1vzQ/method._ALikYLklEemEHKw9GhkeOQ.pt
@@ -16,7 +16,7 @@
 		<link title="default" rel="stylesheet" type="text/css" media="screen, projection" href="../../css/content.css"></link>
 		<script type="text/javascript">
 			if(parent.location.href == self.location.href) {
-				window.location.href = 'index.html?<%=fileName%>';
+				window.location.href = 'index.html?<%=fileName%>' + '#' + self.location.href.substring(self.location.href.lastIndexOf("#")+1);
 			}
 		</script>
 		

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/templates/pattern._tUx7IJj2EeCWzZ9cimy8hg/method._y3k1UJj2EeCWzZ9cimy8hg.pt
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/templates/pattern._tUx7IJj2EeCWzZ9cimy8hg/method._y3k1UJj2EeCWzZ9cimy8hg.pt
@@ -17,8 +17,17 @@ document.write('<frameset rows="63,*,40" frameborder="0" framespacing="0" border
 document.write('<frame src="header.html" name="header" marginheight="0" marginwidth="0" scrolling="no" noresize="0"/>');
 document.write('<frameset cols="22%,*" border="5" frameborder="1" framespacing="1">');
 document.write('<frame src="sidebar.html" name="sideBar"/>');
-var locationText = (location.search ? location.search.substring(1):"<%=fileName%>");
-document.write('<frame src="'+ locationText +'.html" name="content"\/>');
+var locationText = "";
+var anchorText = "";
+if (location.search) {
+	locationText = location.search.substring(1);
+	if (location.href.lastIndexOf("#")>0) {
+		anchorText = anchorText + "#" + location.href.substring(location.href.lastIndexOf("#")+1);
+	}
+} else {
+	locationText = "<%=fileName%>";
+}
+document.write('<frame src="'+ locationText +'.html' + anchorText + '" name="content"\/>');
 document.write('<noframes>');
 document.write('Your browser cannot display this page !');
   document.write('</noframes>');


### PR DESCRIPTION
Once the HTML has been generated, it is possible to see a list of all
diagrams for a given engineering phase (OA/SA/LA/PA) by clicking on each
engineering level folder.
From this list, it is possible to navigate to each diagram.
But, if instead of navigating, you copy this URL and paste it into a new
tab in your browser, then it would re-create the frame but not point
exactly to the anchor where the diagram is in the page, but rather
display the top of the page.
Basically, the reason for this is because there is a javascript
instruction on each main page that redirect to the top frame if someone
tries to display the page without the frames. But the anchor is lost in
the process.

Bug: 566977

Change-Id: I2781ae08f66108599edbafe366894c7c59680c7f
Signed-off-by: Axel RICHARD <axel.richard@obeo.fr>