### PR TITLE
Bump Capella M2 references + Capella version check

### DIFF
--- a/docgenhtml/plugins/org.polarsys.capella.docgen.commandline/.classpath
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen.commandline/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/docgenhtml/plugins/org.polarsys.capella.docgen.commandline/.settings/org.eclipse.jdt.core.prefs
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen.commandline/.settings/org.eclipse.jdt.core.prefs
@@ -1,8 +1,15 @@
-#Thu Jul 04 08:45:16 CEST 2013
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.6
-org.eclipse.jdt.core.compiler.compliance=1.6
+org.eclipse.jdt.core.compiler.codegen.methodParameters=do not generate
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.6
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=disabled
+org.eclipse.jdt.core.compiler.source=1.8

--- a/docgenhtml/plugins/org.polarsys.capella.docgen.commandline/META-INF/MANIFEST.MF
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen.commandline/META-INF/MANIFEST.MF
@@ -15,6 +15,6 @@ Require-Bundle: org.polarsys.kitalpha.doc.gen.business.core.ui,
  org.polarsys.capella.core.sirius.ui
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.polarsys.capella.docgen.commandline
 Bundle-Localization: plugin

--- a/docgenhtml/plugins/org.polarsys.capella.docgen.configuration.commandline/.classpath
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen.configuration.commandline/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src/"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/docgenhtml/plugins/org.polarsys.capella.docgen.configuration.commandline/.settings/org.eclipse.jdt.core.prefs
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen.configuration.commandline/.settings/org.eclipse.jdt.core.prefs
@@ -1,7 +1,8 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.6
-org.eclipse.jdt.core.compiler.compliance=1.6
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.6
+org.eclipse.jdt.core.compiler.release=disabled
+org.eclipse.jdt.core.compiler.source=1.8

--- a/docgenhtml/plugins/org.polarsys.capella.docgen.configuration.commandline/META-INF/MANIFEST.MF
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen.configuration.commandline/META-INF/MANIFEST.MF
@@ -20,5 +20,5 @@ Bundle-Localization: plugin
 Bundle-Name: %pluginName
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.polarsys.capella.docgen.configuration.commandline;singleton:=true
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 

--- a/docgenhtml/plugins/org.polarsys.capella.docgen.configuration.commandline/src/org/polarsys/capella/docgen/configuration/commandline/HTMLConfigurationCommandLine.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen.configuration.commandline/src/org/polarsys/capella/docgen/configuration/commandline/HTMLConfigurationCommandLine.java
@@ -13,7 +13,6 @@
 
 package org.polarsys.capella.docgen.configuration.commandline;
 
-import java.util.Collection;
 import java.util.List;
 
 import org.eclipse.core.resources.IFolder;
@@ -48,6 +47,7 @@ import org.polarsys.capella.core.commandline.core.CommandLineException;
 import org.polarsys.capella.core.data.capellamodeller.Project;
 import org.polarsys.capella.core.sirius.ui.helper.SessionHelper;
 import org.polarsys.capella.docgen.configuration.ui.utils.ConfigurationUtils;
+import org.polarsys.kitalpha.doc.gen.business.core.exceptions.DocgenRuntimeException;
 import org.polarsys.kitalpha.doc.gen.business.core.scope.GenerationGlobalScope;
 import org.polarsys.kitalpha.doc.gen.business.core.scope.ScopeElementStrategy;
 import org.polarsys.kitalpha.doc.gen.business.core.scope.ScopeException;
@@ -231,7 +231,7 @@ public class HTMLConfigurationCommandLine extends AbstractCommandLine {
 
 	private boolean executeEGFActivity(Activity capellaLauncher, final String outputFolder, final URI uri) {
 
-		boolean success = false;
+		boolean success = true;
 		String prefix = Messages.exec_pb;
 
 		// create output folder in the project
@@ -243,11 +243,11 @@ public class HTMLConfigurationCommandLine extends AbstractCommandLine {
 			} catch (CoreException e) {
 				StringBuilder message = new StringBuilder(prefix).append(e.getMessage());
 				logError(message.toString());
-				return false;
+				success = false;
 			}
 		}
 
-		if (capellaLauncher instanceof FactoryComponent) {
+		if (success && capellaLauncher instanceof FactoryComponent) {
 			String relativeFilePath = getRelativeFilePath(outputFolder);
 			String projectName = getProjectName(outputFolder);
 
@@ -257,25 +257,14 @@ public class HTMLConfigurationCommandLine extends AbstractCommandLine {
 			setDomain(factoryComponent, uri);
 
 			// run the activity
-			try {
-				InvokeActivityHelper.invokeOutOfUIThread(factoryComponent);
-				success = true;
-
-			} catch (MissingExtensionException e) {
-				StringBuilder message = new StringBuilder(prefix).append(e.getMessage());
-				logError(message.toString());
-				return false;
-
-			} catch (InvocationException e) {
-				StringBuilder message = new StringBuilder(prefix).append(e.getMessage());
-				logError(message.toString());
-				return false;
-
-			} catch (CoreException e) {
-				StringBuilder message = new StringBuilder(prefix).append(e.getMessage());
-				logError(message.toString());
-				return false;
-			}
+            try {
+                InvokeActivityHelper.invokeOutOfUIThread(factoryComponent);
+                success = true;
+            } catch (DocgenRuntimeException | MissingExtensionException | InvocationException | CoreException e) {
+                StringBuilder message = new StringBuilder(prefix).append(e.getMessage());
+                logError(message.toString());
+                success = false;
+            }
 
 		} else {
 			success = false;

--- a/docgenhtml/plugins/org.polarsys.capella.docgen.configuration.edit/.classpath
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen.configuration.edit/.classpath
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src-gen"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/docgenhtml/plugins/org.polarsys.capella.docgen.configuration.ui/.classpath
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen.configuration.ui/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src/"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/docgenhtml/plugins/org.polarsys.capella.docgen.configuration.ui/.settings/org.eclipse.jdt.core.prefs
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen.configuration.ui/.settings/org.eclipse.jdt.core.prefs
@@ -1,7 +1,8 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.6
-org.eclipse.jdt.core.compiler.compliance=1.6
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.6
+org.eclipse.jdt.core.compiler.release=disabled
+org.eclipse.jdt.core.compiler.source=1.8

--- a/docgenhtml/plugins/org.polarsys.capella.docgen.configuration.ui/META-INF/MANIFEST.MF
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen.configuration.ui/META-INF/MANIFEST.MF
@@ -26,5 +26,5 @@ Bundle-Name: %pluginName
 Bundle-Activator: org.polarsys.capella.docgen.configuration.ui.Activator
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.polarsys.capella.docgen.configuration.ui;singleton:=true
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 

--- a/docgenhtml/plugins/org.polarsys.capella.docgen.configuration/.classpath
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen.configuration/.classpath
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src-gen"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src-gen"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/docgenhtml/plugins/org.polarsys.capella.docgen.configuration/META-INF/MANIFEST.MF
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen.configuration/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 6.0.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.polarsys.capella.configuration,
  org.polarsys.capella.configuration.impl,
  org.polarsys.capella.configuration.util

--- a/docgenhtml/plugins/org.polarsys.capella.docgen.doc/.classpath
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen.doc/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/docgenhtml/plugins/org.polarsys.capella.docgen.doc/.settings/org.eclipse.jdt.core.prefs
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen.doc/.settings/org.eclipse.jdt.core.prefs
@@ -1,7 +1,8 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
-org.eclipse.jdt.core.compiler.compliance=1.7
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.7
+org.eclipse.jdt.core.compiler.release=disabled
+org.eclipse.jdt.core.compiler.source=1.8

--- a/docgenhtml/plugins/org.polarsys.capella.docgen.ui/.classpath
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen.ui/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/docgenhtml/plugins/org.polarsys.capella.docgen.ui/.settings/org.eclipse.jdt.core.prefs
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen.ui/.settings/org.eclipse.jdt.core.prefs
@@ -1,7 +1,8 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.6
-org.eclipse.jdt.core.compiler.compliance=1.6
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.6
+org.eclipse.jdt.core.compiler.release=disabled
+org.eclipse.jdt.core.compiler.source=1.8

--- a/docgenhtml/plugins/org.polarsys.capella.docgen.ui/META-INF/MANIFEST.MF
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen.ui/META-INF/MANIFEST.MF
@@ -12,7 +12,7 @@ Require-Bundle: org.polarsys.kitalpha.doc.gen.business.core.ui,
  org.eclipse.sirius,
  org.polarsys.capella.common.ef,
  org.polarsys.capella.core.platform.sirius.ui.navigator
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin
 Export-Package: org.polarsys.capella.docgen.ui,

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/.classpath
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="generated"/>
 	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="generated"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="bin"/>

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore
@@ -65,7 +65,7 @@
             <methods xmi:id="_TM8hYPbpEd-RH7MH9LLQsg" name="setFileNameService" patternFilePath="templates/pattern._ixj0MN0eEd-Vzvs7Wt1vzQ/method._TM8hYPbpEd-RH7MH9LLQsg.pt"/>
             <methods xmi:id="_5jqVAErlEeCvqtVx_IKrqA" name="endContent" patternFilePath="templates/pattern._ixj0MN0eEd-Vzvs7Wt1vzQ/method._5jqVAErlEeCvqtVx_IKrqA.pt"/>
             <methods xmi:id="_ALikYLklEemEHKw9GhkeOQ" name="docHeader" patternFilePath="templates/pattern._ixj0MN0eEd-Vzvs7Wt1vzQ/method._ALikYLklEemEHKw9GhkeOQ.pt"/>
-            <variables xmi:id="_8ZnqQN4gEd-Qav1YnqlO9A" name="element" type="http://www.polarsys.org/capella/core/core/5.0.0#//CapellaElement"/>
+            <variables xmi:id="_8ZnqQN4gEd-Qav1YnqlO9A" name="element" type="org.polarsys.capella.core.data.capellacore.CapellaElement"/>
             <variables xmi:id="_dqbzEHuzEeCAr9zliRjheA" name="documentTitle" type="java.lang.String"/>
             <variables xmi:id="_yKihsIwoEeCksqA-SB02WQ" name="elementPath" type="java.lang.String"/>
             <orchestration xmi:type="pattern:MethodCall" xmi:id="_Pru0IN4hEd-Qav1YnqlO9A"
@@ -102,7 +102,7 @@
             <methods xmi:id="_fiM9tOZdEd-YVt45ZEg4_w" name="preCondition" patternFilePath="templates/pattern._fiM9sOZdEd-YVt45ZEg4_w/method._fiM9tOZdEd-YVt45ZEg4_w.pt"/>
             <methods xmi:id="_fiM9teZdEd-YVt45ZEg4_w" name="body" patternFilePath="templates/pattern._fiM9sOZdEd-YVt45ZEg4_w/method._fiM9teZdEd-YVt45ZEg4_w.pt"/>
             <methods xmi:id="_fiM9tuZdEd-YVt45ZEg4_w" name="footer" patternFilePath="templates/pattern._fiM9sOZdEd-YVt45ZEg4_w/method._fiM9tuZdEd-YVt45ZEg4_w.pt"/>
-            <parameters xmi:id="_rvn80OZdEd-YVt45ZEg4_w" name="element" type="http://www.polarsys.org/capella/core/core/5.0.0#//CapellaElement"/>
+            <parameters xmi:id="_rvn80OZdEd-YVt45ZEg4_w" name="element" type="org.polarsys.capella.core.data.capellacore.CapellaElement"/>
             <orchestration xmi:type="pattern:SuperCall" xmi:id="_fiM9t-ZdEd-YVt45ZEg4_w"/>
             <orchestration xmi:type="pattern:MethodCall" xmi:id="_YChJ8OZmEd-YVt45ZEg4_w"
                 called="#_fiM9teZdEd-YVt45ZEg4_w"/>
@@ -118,7 +118,7 @@
             <methods xmi:id="_2sAHxXWMEemiHtSfRhpXIQ" name="genStatusAndReview" patternFilePath="templates/pattern._2sAHwHWMEemiHtSfRhpXIQ/method._2sAHxXWMEemiHtSfRhpXIQ.pt"/>
             <methods xmi:id="_2sAHxnWMEemiHtSfRhpXIQ" name="footer" patternFilePath="templates/pattern._2sAHwHWMEemiHtSfRhpXIQ/method._2sAHxnWMEemiHtSfRhpXIQ.pt"/>
             <methods xmi:id="__KGxkHeyEemiHtSfRhpXIQ" name="genProgressOverview" patternFilePath="templates/pattern._2sAHwHWMEemiHtSfRhpXIQ/method.__KGxkHeyEemiHtSfRhpXIQ.pt"/>
-            <parameters xmi:id="_6aa6QHWMEemiHtSfRhpXIQ" name="element" type="http://www.polarsys.org/capella/core/core/5.0.0#//CapellaElement"/>
+            <parameters xmi:id="_6aa6QHWMEemiHtSfRhpXIQ" name="element" type="org.polarsys.capella.core.data.capellacore.CapellaElement"/>
             <orchestration xmi:type="pattern:SuperCall" xmi:id="_2sAHx3WMEemiHtSfRhpXIQ"/>
             <orchestration xmi:type="pattern:MethodCall" xmi:id="_8656AHWMEemiHtSfRhpXIQ"
                 called="#_2sAHxXWMEemiHtSfRhpXIQ"/>
@@ -136,7 +136,7 @@
             <methods xmi:id="_C915BwahEeCbnKVq3TjTtg" name="footer" patternFilePath="templates/pattern._C915AQahEeCbnKVq3TjTtg/method._C915BwahEeCbnKVq3TjTtg.pt"/>
             <methods xmi:id="_dIGmcAahEeCbnKVq3TjTtg" name="openDescription" patternFilePath="templates/pattern._C915AQahEeCbnKVq3TjTtg/method._dIGmcAahEeCbnKVq3TjTtg.pt"/>
             <methods xmi:id="_dmkEEAahEeCbnKVq3TjTtg" name="closeDescription" patternFilePath="templates/pattern._C915AQahEeCbnKVq3TjTtg/method._dmkEEAahEeCbnKVq3TjTtg.pt"/>
-            <parameters xmi:id="_P5P_gAahEeCbnKVq3TjTtg" name="element" type="http://www.polarsys.org/capella/core/core/5.0.0#//CapellaElement"/>
+            <parameters xmi:id="_P5P_gAahEeCbnKVq3TjTtg" name="element" type="org.polarsys.capella.core.data.capellacore.CapellaElement"/>
             <orchestration xmi:type="pattern:SuperCall" xmi:id="_C915CAahEeCbnKVq3TjTtg"/>
           </elements>
           <elements xmi:id="_PVePETXrEeCNvtb1bUM2fQ" name="DiagramsGeneration" headerMethod="#_PVePEzXrEeCNvtb1bUM2fQ"
@@ -150,7 +150,7 @@
             <methods xmi:id="_8qnCsDX7EeCNvtb1bUM2fQ" name="setContext" patternFilePath="templates/pattern._PVePETXrEeCNvtb1bUM2fQ/method._8qnCsDX7EeCNvtb1bUM2fQ.pt"/>
             <methods xmi:id="_PVePFjXrEeCNvtb1bUM2fQ" name="body" patternFilePath="templates/pattern._PVePETXrEeCNvtb1bUM2fQ/method._PVePFjXrEeCNvtb1bUM2fQ.pt"/>
             <methods xmi:id="_PVePFzXrEeCNvtb1bUM2fQ" name="footer" patternFilePath="templates/pattern._PVePETXrEeCNvtb1bUM2fQ/method._PVePFzXrEeCNvtb1bUM2fQ.pt"/>
-            <parameters xmi:id="_mnIPUDX5EeCNvtb1bUM2fQ" name="element" type="http://www.polarsys.org/capella/core/core/5.0.0#//CapellaElement"/>
+            <parameters xmi:id="_mnIPUDX5EeCNvtb1bUM2fQ" name="element" type="org.polarsys.capella.core.data.capellacore.CapellaElement"/>
             <variables xmi:id="_bGTKEDXxEeCNvtb1bUM2fQ" name="fileNameService" type="org.polarsys.kitalpha.doc.gen.business.core.util.IFileNameService"/>
             <variables xmi:id="_tuyCkGQcEeCbC_q4r97G6A" name="helper" type="org.polarsys.kitalpha.doc.gen.business.core.util.IDiagramHelper"/>
             <orchestration xmi:type="pattern:SuperCall" xmi:id="_PVePGDXrEeCNvtb1bUM2fQ"/>
@@ -170,7 +170,7 @@
             <methods xmi:id="_wWwglUrlEeCvqtVx_IKrqA" name="setContext" patternFilePath="templates/pattern._wWwgkErlEeCvqtVx_IKrqA/method._wWwglUrlEeCvqtVx_IKrqA.pt"/>
             <methods xmi:id="_wWwglkrlEeCvqtVx_IKrqA" name="body" patternFilePath="templates/pattern._wWwgkErlEeCvqtVx_IKrqA/method._wWwglkrlEeCvqtVx_IKrqA.pt"/>
             <methods xmi:id="_wWwgl0rlEeCvqtVx_IKrqA" name="footer" patternFilePath="templates/pattern._wWwgkErlEeCvqtVx_IKrqA/method._wWwgl0rlEeCvqtVx_IKrqA.pt"/>
-            <parameters xmi:id="_wWwgmErlEeCvqtVx_IKrqA" name="element" type="http://www.polarsys.org/capella/core/core/5.0.0#//CapellaElement"/>
+            <parameters xmi:id="_wWwgmErlEeCvqtVx_IKrqA" name="element" type="org.polarsys.capella.core.data.capellacore.CapellaElement"/>
             <variables xmi:id="_wWwgmUrlEeCvqtVx_IKrqA" name="fileNameService" type="org.polarsys.kitalpha.doc.gen.business.core.util.IFileNameService"/>
             <variables xmi:id="_t3bZcWdXEeCnw5T_1So9cQ" name="helper" type="org.polarsys.kitalpha.doc.gen.business.core.util.IDiagramHelper"/>
             <orchestration xmi:type="pattern:SuperCall" xmi:id="_wWwgmkrlEeCvqtVx_IKrqA"/>
@@ -190,7 +190,7 @@
             <methods xmi:id="_2twVZau9EeCWrf9pgx3zjA" name="body" patternFilePath="templates/pattern._2twVYKu9EeCWrf9pgx3zjA/method._2twVZau9EeCWrf9pgx3zjA.pt"/>
             <methods xmi:id="_2twVZqu9EeCWrf9pgx3zjA" name="footer" patternFilePath="templates/pattern._2twVYKu9EeCWrf9pgx3zjA/method._2twVZqu9EeCWrf9pgx3zjA.pt"/>
             <methods xmi:id="_L0QUwLFLEeG5gNhMvEeYpg" name="postBody" patternFilePath="templates/pattern._2twVYKu9EeCWrf9pgx3zjA/method._L0QUwLFLEeG5gNhMvEeYpg.pt"/>
-            <parameters xmi:id="_NSfRIKu_EeCWrf9pgx3zjA" name="element" type="http://www.polarsys.org/capella/core/core/5.0.0#//CapellaElement"/>
+            <parameters xmi:id="_NSfRIKu_EeCWrf9pgx3zjA" name="element" type="org.polarsys.capella.core.data.capellacore.CapellaElement"/>
             <parameters xmi:id="_hcmjwL0HEeC7JNoAKQ1P0g" name="documentTitle" type="java.lang.String"/>
             <orchestration xmi:type="pattern:SuperCall" xmi:id="_2twVZ6u9EeCWrf9pgx3zjA"/>
             <orchestration xmi:type="pattern:MethodCall" xmi:id="_aLqYcKu-EeCWrf9pgx3zjA"
@@ -208,7 +208,7 @@
             <methods xmi:id="_H6ielavLEeCas-LHcur3rg" name="preCondition" patternFilePath="templates/pattern._H6iekavLEeCas-LHcur3rg/method._H6ielavLEeCas-LHcur3rg.pt"/>
             <methods xmi:id="_H6ielqvLEeCas-LHcur3rg" name="body" patternFilePath="templates/pattern._H6iekavLEeCas-LHcur3rg/method._H6ielqvLEeCas-LHcur3rg.pt"/>
             <methods xmi:id="_H6iel6vLEeCas-LHcur3rg" name="footer" patternFilePath="templates/pattern._H6iekavLEeCas-LHcur3rg/method._H6iel6vLEeCas-LHcur3rg.pt"/>
-            <parameters xmi:id="_ViPmMKvSEeCas-LHcur3rg" name="element" type="http://www.polarsys.org/capella/core/core/5.0.0#//CapellaElement"/>
+            <parameters xmi:id="_ViPmMKvSEeCas-LHcur3rg" name="element" type="org.polarsys.capella.core.data.capellacore.CapellaElement"/>
             <orchestration xmi:type="pattern:SuperCall" xmi:id="_H6iemKvLEeCas-LHcur3rg"/>
             <orchestration xmi:type="pattern:MethodCall" xmi:id="_vSiRQKvOEeCas-LHcur3rg"
                 called="#_H6ielqvLEeCas-LHcur3rg"/>
@@ -223,7 +223,7 @@
             <methods xmi:id="_UT85hDr2EeK9AZkoGpWdMw" name="preCondition" patternFilePath="templates/pattern._UT85gDr2EeK9AZkoGpWdMw/method._UT85hDr2EeK9AZkoGpWdMw.pt"/>
             <methods xmi:id="_UT85hTr2EeK9AZkoGpWdMw" name="body" patternFilePath="templates/pattern._UT85gDr2EeK9AZkoGpWdMw/method._UT85hTr2EeK9AZkoGpWdMw.pt"/>
             <methods xmi:id="_UT85hjr2EeK9AZkoGpWdMw" name="footer" patternFilePath="templates/pattern._UT85gDr2EeK9AZkoGpWdMw/method._UT85hjr2EeK9AZkoGpWdMw.pt"/>
-            <parameters xmi:id="_cFBpIDr2EeK9AZkoGpWdMw" name="element" type="http://www.polarsys.org/capella/core/core/5.0.0#//CapellaElement"/>
+            <parameters xmi:id="_cFBpIDr2EeK9AZkoGpWdMw" name="element" type="org.polarsys.capella.core.data.capellacore.CapellaElement"/>
             <parameters xmi:id="_W2690Dr8EeK9AZkoGpWdMw" name="outputFolder" type="java.lang.String"/>
             <parameters xmi:id="_ZAJ7MDr8EeK9AZkoGpWdMw" name="projectName" type="java.lang.String"/>
             <parameters xmi:id="_9HDB0LcnEeunS_LL9mf3jw" name="sectionLevelParameter"
@@ -278,7 +278,7 @@
             <methods xmi:id="_mGFhdQHoEemzNsJkc2kajg" name="setContext" patternFilePath="templates/pattern._mGFhcAHoEemzNsJkc2kajg/method._mGFhdQHoEemzNsJkc2kajg.pt"/>
             <methods xmi:id="_mGFhdgHoEemzNsJkc2kajg" name="footer" patternFilePath="templates/pattern._mGFhcAHoEemzNsJkc2kajg/method._mGFhdgHoEemzNsJkc2kajg.pt"/>
             <methods xmi:id="_7jkWsAHoEemzNsJkc2kajg" name="body" patternFilePath="templates/pattern._mGFhcAHoEemzNsJkc2kajg/method._7jkWsAHoEemzNsJkc2kajg.pt"/>
-            <parameters xmi:id="_rx_UUAHoEemzNsJkc2kajg" name="element" type="http://www.polarsys.org/capella/core/core/5.0.0#//CapellaElement"/>
+            <parameters xmi:id="_rx_UUAHoEemzNsJkc2kajg" name="element" type="org.polarsys.capella.core.data.capellacore.CapellaElement"/>
             <variables xmi:id="_QNgPIAHpEemzNsJkc2kajg" name="fileNameService" type="org.polarsys.kitalpha.doc.gen.business.core.util.IFileNameService"/>
             <variables xmi:id="_UB6U4AHpEemzNsJkc2kajg" name="helper" type="org.polarsys.kitalpha.doc.gen.business.core.util.IDiagramHelper"/>
             <orchestration xmi:type="pattern:SuperCall" xmi:id="_mGFhdwHoEemzNsJkc2kajg"/>
@@ -312,7 +312,7 @@
             <methods xmi:id="_mpoLJKGQEemXudi5U_Uo0A" name="preCondition" patternFilePath="templates/pattern._mpoLIKGQEemXudi5U_Uo0A/method._mpoLJKGQEemXudi5U_Uo0A.pt"/>
             <methods xmi:id="_mpoLJaGQEemXudi5U_Uo0A" name="body" patternFilePath="templates/pattern._mpoLIKGQEemXudi5U_Uo0A/method._mpoLJaGQEemXudi5U_Uo0A.pt"/>
             <methods xmi:id="_mpoLJqGQEemXudi5U_Uo0A" name="footer" patternFilePath="templates/pattern._mpoLIKGQEemXudi5U_Uo0A/method._mpoLJqGQEemXudi5U_Uo0A.pt"/>
-            <parameters xmi:id="_mpoLJ6GQEemXudi5U_Uo0A" name="element" type="http://www.polarsys.org/capella/core/core/5.0.0#//CapellaElement"/>
+            <parameters xmi:id="_mpoLJ6GQEemXudi5U_Uo0A" name="element" type="org.polarsys.capella.core.data.capellacore.CapellaElement"/>
             <parameters xmi:id="_mpoLKKGQEemXudi5U_Uo0A" name="outputFolder" type="java.lang.String"/>
             <parameters xmi:id="_mpoLKaGQEemXudi5U_Uo0A" name="projectName" type="java.lang.String"/>
             <orchestration xmi:type="pattern:SuperCall" xmi:id="_mpoLKqGQEemXudi5U_Uo0A"/>
@@ -332,7 +332,7 @@
             <methods xmi:id="_hW855N47Ed-Qav1YnqlO9A" name="preCondition" patternFilePath="templates/pattern._hW854N47Ed-Qav1YnqlO9A/method._hW855N47Ed-Qav1YnqlO9A.pt"/>
             <methods xmi:id="_hW855t47Ed-Qav1YnqlO9A" name="footer" patternFilePath="templates/pattern._hW854N47Ed-Qav1YnqlO9A/method._hW855t47Ed-Qav1YnqlO9A.pt"/>
             <methods xmi:id="_3HKd4N47Ed-Qav1YnqlO9A" name="setCapellaContext" patternFilePath="templates/pattern._hW854N47Ed-Qav1YnqlO9A/method._3HKd4N47Ed-Qav1YnqlO9A.pt"/>
-            <parameters xmi:id="_u1IWQN47Ed-Qav1YnqlO9A" name="parameter" type="http://www.polarsys.org/capella/core/core/5.0.0#//NamedElement"/>
+            <parameters xmi:id="_u1IWQN47Ed-Qav1YnqlO9A" name="parameter" type="org.polarsys.capella.core.data.capellacore.NamedElement"/>
             <orchestration xmi:type="pattern:SuperCall" xmi:id="_hW855947Ed-Qav1YnqlO9A"/>
           </elements>
           <elements xmi:id="_HyNjwN0cEd-Vzvs7Wt1vzQ" name="LogicalComponentDocGen"
@@ -347,7 +347,7 @@
             <methods xmi:id="_HyNjxt0cEd-Vzvs7Wt1vzQ" name="footer" patternFilePath="templates/pattern._HyNjwN0cEd-Vzvs7Wt1vzQ/method._HyNjxt0cEd-Vzvs7Wt1vzQ.pt"/>
             <methods xmi:id="_bjmvIN4jEd-Qav1YnqlO9A" name="setCapellaContext" patternFilePath="templates/pattern._HyNjwN0cEd-Vzvs7Wt1vzQ/method._bjmvIN4jEd-Qav1YnqlO9A.pt"/>
             <methods xmi:id="_TvoVwTgmEeCKVs4XEULBlA" name="content" patternFilePath="templates/pattern._HyNjwN0cEd-Vzvs7Wt1vzQ/method._TvoVwTgmEeCKVs4XEULBlA.pt"/>
-            <parameters xmi:id="_Nc7D0N0cEd-Vzvs7Wt1vzQ" name="parameter" type="http://www.polarsys.org/capella/core/cs/5.0.0#//Component"/>
+            <parameters xmi:id="_Nc7D0N0cEd-Vzvs7Wt1vzQ" name="parameter" type="org.polarsys.capella.core.data.cs.Component"/>
             <orchestration xmi:type="pattern:SuperCall" xmi:id="_HyNjx90cEd-Vzvs7Wt1vzQ"/>
           </elements>
           <elements xmi:id="_4rYdkTqcEeCgH6PBi_KPBw" description="" name="GeneralizableElementDocGen"
@@ -362,7 +362,7 @@
             <methods xmi:id="_6Dak0EWPEeCvqtVx_IKrqA" name="setCapellaContext" patternFilePath="templates/pattern._4rYdkTqcEeCgH6PBi_KPBw/method._6Dak0EWPEeCvqtVx_IKrqA.pt"/>
             <methods xmi:id="_4rYdljqcEeCgH6PBi_KPBw" name="content" patternFilePath="templates/pattern._4rYdkTqcEeCgH6PBi_KPBw/method._4rYdljqcEeCgH6PBi_KPBw.pt"/>
             <methods xmi:id="_4rYdlzqcEeCgH6PBi_KPBw" name="footer" patternFilePath="templates/pattern._4rYdkTqcEeCgH6PBi_KPBw/method._4rYdlzqcEeCgH6PBi_KPBw.pt"/>
-            <parameters xmi:id="_kPdJQEWPEeCvqtVx_IKrqA" name="parameter" type="http://www.polarsys.org/capella/core/core/5.0.0#//GeneralizableElement"/>
+            <parameters xmi:id="_kPdJQEWPEeCvqtVx_IKrqA" name="parameter" type="org.polarsys.capella.core.data.capellacore.GeneralizableElement"/>
             <orchestration xmi:type="pattern:SuperCall" xmi:id="_4rYdmDqcEeCgH6PBi_KPBw"/>
           </elements>
           <elements xmi:id="_JPU-gDtBEeCgH6PBi_KPBw" name="ClassifierDocGen" superPattern="#_4rYdkTqcEeCgH6PBi_KPBw"
@@ -428,7 +428,7 @@
             <methods xmi:id="_x_LwdWwiEeCUvpJOFjr3FQ" name="footer" patternFilePath="templates/pattern._x_LwcGwiEeCUvpJOFjr3FQ/method._x_LwdWwiEeCUvpJOFjr3FQ.pt"/>
             <methods xmi:id="_x_LwdmwiEeCUvpJOFjr3FQ" name="setCapellaContext" patternFilePath="templates/pattern._x_LwcGwiEeCUvpJOFjr3FQ/method._x_LwdmwiEeCUvpJOFjr3FQ.pt"/>
             <methods xmi:id="_x_Lwd2wiEeCUvpJOFjr3FQ" name="content" patternFilePath="templates/pattern._x_LwcGwiEeCUvpJOFjr3FQ/method._x_Lwd2wiEeCUvpJOFjr3FQ.pt"/>
-            <parameters xmi:id="_x_LweGwiEeCUvpJOFjr3FQ" name="parameter" type="http://www.polarsys.org/capella/core/fa/5.0.0#//AbstractFunction"/>
+            <parameters xmi:id="_x_LweGwiEeCUvpJOFjr3FQ" name="parameter" type="org.polarsys.capella.core.data.fa.AbstractFunction"/>
             <orchestration xmi:type="pattern:SuperCall" xmi:id="_x_LweWwiEeCUvpJOFjr3FQ"/>
           </elements>
           <elements xmi:id="_6RU6oXGlEeC8GrKepiiiTw" name="PartDocGen" superPattern="#_LUSfMN0jEd-Vzvs7Wt1vzQ"
@@ -443,7 +443,7 @@
             <methods xmi:id="_LYnywHGmEeC8GrKepiiiTw" name="setCapellaContext" patternFilePath="templates/pattern._6RU6oXGlEeC8GrKepiiiTw/method._LYnywHGmEeC8GrKepiiiTw.pt"/>
             <methods xmi:id="_MXRzYHGmEeC8GrKepiiiTw" name="content" patternFilePath="templates/pattern._6RU6oXGlEeC8GrKepiiiTw/method._MXRzYHGmEeC8GrKepiiiTw.pt"/>
             <methods xmi:id="_znK3QZwMEeCWeuBXIFCRXA" name="endContent" patternFilePath="templates/pattern._6RU6oXGlEeC8GrKepiiiTw/method._znK3QZwMEeCWeuBXIFCRXA.pt"/>
-            <parameters xmi:id="_BFHioHGmEeC8GrKepiiiTw" name="parameter" type="http://www.polarsys.org/capella/core/cs/5.0.0#//Part"/>
+            <parameters xmi:id="_BFHioHGmEeC8GrKepiiiTw" name="parameter" type="org.polarsys.capella.core.data.cs.Part"/>
             <orchestration xmi:type="pattern:SuperCall" xmi:id="_6RU6qHGlEeC8GrKepiiiTw"/>
           </elements>
           <elements xmi:id="_Axl3MH1uEeCIgcTVWxVnzQ" name="RequirementDocGen" superPattern="#_LUSfMN0jEd-Vzvs7Wt1vzQ"
@@ -457,7 +457,7 @@
             <methods xmi:id="_Axl3NX1uEeCIgcTVWxVnzQ" name="footer" patternFilePath="templates/pattern._Axl3MH1uEeCIgcTVWxVnzQ/method._Axl3NX1uEeCIgcTVWxVnzQ.pt"/>
             <methods xmi:id="_Axl3Nn1uEeCIgcTVWxVnzQ" name="setCapellaContext" patternFilePath="templates/pattern._Axl3MH1uEeCIgcTVWxVnzQ/method._Axl3Nn1uEeCIgcTVWxVnzQ.pt"/>
             <methods xmi:id="_Axl3N31uEeCIgcTVWxVnzQ" name="content" patternFilePath="templates/pattern._Axl3MH1uEeCIgcTVWxVnzQ/method._Axl3N31uEeCIgcTVWxVnzQ.pt"/>
-            <parameters xmi:id="_Axl3OH1uEeCIgcTVWxVnzQ" name="parameter" type="http://www.polarsys.org/capella/core/requirement/5.0.0#//Requirement"/>
+            <parameters xmi:id="_Axl3OH1uEeCIgcTVWxVnzQ" name="parameter" type="org.polarsys.capella.core.data.requirement.Requirement"/>
             <orchestration xmi:type="pattern:SuperCall" xmi:id="_Axl3OX1uEeCIgcTVWxVnzQ"/>
           </elements>
           <elements xmi:id="_WWJkYYBZEeCN8Jbz-bJe6w" name="InterfaceDocGen" superPattern="#_JPU-gDtBEeCgH6PBi_KPBw"
@@ -485,7 +485,7 @@
             <methods xmi:id="__fahYILCEeCjNOKMEA2WFg" name="setCapellaContext" patternFilePath="templates/pattern._MdyuQYLBEeCjNOKMEA2WFg/method.__fahYILCEeCjNOKMEA2WFg.pt"/>
             <methods xmi:id="_lt-ZEILBEeCjNOKMEA2WFg" name="content" patternFilePath="templates/pattern._MdyuQYLBEeCjNOKMEA2WFg/method._lt-ZEILBEeCjNOKMEA2WFg.pt"/>
             <methods xmi:id="_t1O6cILJEeCjNOKMEA2WFg" name="setTitle" patternFilePath="templates/pattern._MdyuQYLBEeCjNOKMEA2WFg/method._t1O6cILJEeCjNOKMEA2WFg.pt"/>
-            <parameters xmi:id="_Qrp10ILBEeCjNOKMEA2WFg" name="parameter" type="http://www.polarsys.org/capella/core/information/5.0.0#//ExchangeItem"/>
+            <parameters xmi:id="_Qrp10ILBEeCjNOKMEA2WFg" name="parameter" type="org.polarsys.capella.core.data.information.ExchangeItem"/>
             <orchestration xmi:type="pattern:SuperCall" xmi:id="_MdyuSILBEeCjNOKMEA2WFg"/>
           </elements>
           <elements xmi:id="_sGmFIZdTEeCvReB7msXe8Q" name="packageDocGen" superPattern="#_LUSfMN0jEd-Vzvs7Wt1vzQ"
@@ -499,7 +499,7 @@
             <methods xmi:id="_vGHikJdZEeCvReB7msXe8Q" name="setCapellaContext" patternFilePath="templates/pattern._sGmFIZdTEeCvReB7msXe8Q/method._vGHikJdZEeCvReB7msXe8Q.pt"/>
             <methods xmi:id="_sGmFJpdTEeCvReB7msXe8Q" name="content" patternFilePath="templates/pattern._sGmFIZdTEeCvReB7msXe8Q/method._sGmFJpdTEeCvReB7msXe8Q.pt"/>
             <methods xmi:id="_sGmFJ5dTEeCvReB7msXe8Q" name="footer" patternFilePath="templates/pattern._sGmFIZdTEeCvReB7msXe8Q/method._sGmFJ5dTEeCvReB7msXe8Q.pt"/>
-            <parameters xmi:id="_P2q2QJdUEeCvReB7msXe8Q" name="parameter" type="http://www.polarsys.org/capella/core/core/5.0.0#//Structure"/>
+            <parameters xmi:id="_P2q2QJdUEeCvReB7msXe8Q" name="parameter" type="org.polarsys.capella.core.data.capellacore.Structure"/>
             <orchestration xmi:type="pattern:SuperCall" xmi:id="_sGmFKJdTEeCvReB7msXe8Q"/>
           </elements>
           <elements xmi:id="_6uVm4JwPEeCWeuBXIFCRXA" name="EntityDocGen" superPattern="#_HyNjwN0cEd-Vzvs7Wt1vzQ"
@@ -524,7 +524,7 @@
             <methods xmi:id="_bbMz5auhEeCWrf9pgx3zjA" name="preCondition" patternFilePath="templates/pattern._bbMz4auhEeCWrf9pgx3zjA/method._bbMz5auhEeCWrf9pgx3zjA.pt"/>
             <methods xmi:id="_bbMz5quhEeCWrf9pgx3zjA" name="body" patternFilePath="templates/pattern._bbMz4auhEeCWrf9pgx3zjA/method._bbMz5quhEeCWrf9pgx3zjA.pt"/>
             <methods xmi:id="_bbMz56uhEeCWrf9pgx3zjA" name="footer" patternFilePath="templates/pattern._bbMz4auhEeCWrf9pgx3zjA/method._bbMz56uhEeCWrf9pgx3zjA.pt"/>
-            <parameters xmi:id="_1uoSIKumEeCWrf9pgx3zjA" name="element" type="http://www.polarsys.org/capella/core/core/5.0.0#//CapellaElement"/>
+            <parameters xmi:id="_1uoSIKumEeCWrf9pgx3zjA" name="element" type="org.polarsys.capella.core.data.capellacore.CapellaElement"/>
             <parameters xmi:id="_A8vJUKunEeCWrf9pgx3zjA" name="projectName" type="java.lang.String"/>
             <parameters xmi:id="_CaxNkKunEeCWrf9pgx3zjA" name="outputFolder" type="java.lang.String"/>
             <orchestration xmi:type="pattern:SuperCall" xmi:id="_bbMz6KuhEeCWrf9pgx3zjA"/>
@@ -541,7 +541,7 @@
             <methods xmi:id="_XX5iBaxbEeCYVYqpiRcXMA" name="preCondition" patternFilePath="templates/pattern._XX5iAaxbEeCYVYqpiRcXMA/method._XX5iBaxbEeCYVYqpiRcXMA.pt"/>
             <methods xmi:id="_XX5iBqxbEeCYVYqpiRcXMA" name="body" patternFilePath="templates/pattern._XX5iAaxbEeCYVYqpiRcXMA/method._XX5iBqxbEeCYVYqpiRcXMA.pt"/>
             <methods xmi:id="_XX5iB6xbEeCYVYqpiRcXMA" name="footer" patternFilePath="templates/pattern._XX5iAaxbEeCYVYqpiRcXMA/method._XX5iB6xbEeCYVYqpiRcXMA.pt"/>
-            <parameters xmi:id="_TiDVAKxfEeCYVYqpiRcXMA" name="element" type="http://www.polarsys.org/capella/core/oa/5.0.0#//Entity"/>
+            <parameters xmi:id="_TiDVAKxfEeCYVYqpiRcXMA" name="element" type="org.polarsys.capella.core.data.oa.Entity"/>
             <orchestration xmi:type="pattern:SuperCall" xmi:id="_XX5iCKxbEeCYVYqpiRcXMA"/>
             <orchestration xmi:type="pattern:MethodCall" xmi:id="_awUPUKxbEeCYVYqpiRcXMA"
                 called="#_XX5iBqxbEeCYVYqpiRcXMA"/>
@@ -582,7 +582,7 @@
             <methods xmi:id="_Pq5Fhb3fEeCFqqET0yrG_w" name="content" patternFilePath="templates/pattern._Pq5FgL3fEeCFqqET0yrG_w/method._Pq5Fhb3fEeCFqqET0yrG_w.pt"/>
             <methods xmi:id="_Pq5Fhr3fEeCFqqET0yrG_w" name="footer" patternFilePath="templates/pattern._Pq5FgL3fEeCFqqET0yrG_w/method._Pq5Fhr3fEeCFqqET0yrG_w.pt"/>
             <methods xmi:id="__I8gsL3fEeCFqqET0yrG_w" name="setCapellaContext" patternFilePath="templates/pattern._Pq5FgL3fEeCFqqET0yrG_w/method.__I8gsL3fEeCFqqET0yrG_w.pt"/>
-            <parameters xmi:id="_SZFxIL3fEeCFqqET0yrG_w" name="parameter" type="http://www.polarsys.org/capella/core/ctx/5.0.0#//Mission"/>
+            <parameters xmi:id="_SZFxIL3fEeCFqqET0yrG_w" name="parameter" type="org.polarsys.capella.core.data.ctx.Mission"/>
             <orchestration xmi:type="pattern:SuperCall" xmi:id="_Pq5Fh73fEeCFqqET0yrG_w"/>
           </elements>
           <elements xmi:id="_sRl5kb52EeCw5MDUpv1shw" name="FunctionalChainGenDoc"
@@ -597,7 +597,7 @@
             <methods xmi:id="_sRl5l752EeCw5MDUpv1shw" name="footer" patternFilePath="templates/pattern._sRl5kb52EeCw5MDUpv1shw/method._sRl5l752EeCw5MDUpv1shw.pt"/>
             <methods xmi:id="_PUNSUL54EeCw5MDUpv1shw" name="content" patternFilePath="templates/pattern._sRl5kb52EeCw5MDUpv1shw/method._PUNSUL54EeCw5MDUpv1shw.pt"/>
             <methods xmi:id="_QSITIL54EeCw5MDUpv1shw" name="setCapellaContext" patternFilePath="templates/pattern._sRl5kb52EeCw5MDUpv1shw/method._QSITIL54EeCw5MDUpv1shw.pt"/>
-            <parameters xmi:id="_Bc1IQL53EeCw5MDUpv1shw" name="parameter" type="http://www.polarsys.org/capella/core/fa/5.0.0#//FunctionalChain"/>
+            <parameters xmi:id="_Bc1IQL53EeCw5MDUpv1shw" name="parameter" type="org.polarsys.capella.core.data.fa.FunctionalChain"/>
             <orchestration xmi:type="pattern:SuperCall" xmi:id="_sRl5mL52EeCw5MDUpv1shw"/>
           </elements>
           <elements xmi:id="_a126IL6EEeCw5MDUpv1shw" name="StateDocGen" superPattern="#_LUSfMN0jEd-Vzvs7Wt1vzQ"
@@ -611,7 +611,7 @@
             <methods xmi:id="_a126Jr6EEeCw5MDUpv1shw" name="footer" patternFilePath="templates/pattern._a126IL6EEeCw5MDUpv1shw/method._a126Jr6EEeCw5MDUpv1shw.pt"/>
             <methods xmi:id="_lbm7YL6FEeCw5MDUpv1shw" name="content" patternFilePath="templates/pattern._a126IL6EEeCw5MDUpv1shw/method._lbm7YL6FEeCw5MDUpv1shw.pt"/>
             <methods xmi:id="_BkxeIL6JEeCw5MDUpv1shw" name="setCapellaContext" patternFilePath="templates/pattern._a126IL6EEeCw5MDUpv1shw/method._BkxeIL6JEeCw5MDUpv1shw.pt"/>
-            <parameters xmi:id="_e5WIQL6FEeCw5MDUpv1shw" name="parameter" type="http://www.polarsys.org/capella/core/common/5.0.0#//State"/>
+            <parameters xmi:id="_e5WIQL6FEeCw5MDUpv1shw" name="parameter" type="org.polarsys.capella.core.data.capellacommon.State"/>
             <orchestration xmi:type="pattern:SuperCall" xmi:id="_a126J76EEeCw5MDUpv1shw"/>
           </elements>
           <elements xmi:id="_ZXf8Ib88EeC3itjHQ6nPuA" name="StateMachineDocGen" superPattern="#_ixj0MN0eEd-Vzvs7Wt1vzQ"
@@ -625,7 +625,7 @@
             <methods xmi:id="_ZXf8Jr88EeC3itjHQ6nPuA" name="content" patternFilePath="templates/pattern._ZXf8Ib88EeC3itjHQ6nPuA/method._ZXf8Jr88EeC3itjHQ6nPuA.pt"/>
             <methods xmi:id="_ZXf8J788EeC3itjHQ6nPuA" name="footer" patternFilePath="templates/pattern._ZXf8Ib88EeC3itjHQ6nPuA/method._ZXf8J788EeC3itjHQ6nPuA.pt"/>
             <methods xmi:id="_sJ_f4L8-EeC3itjHQ6nPuA" name="setCapellaContext" patternFilePath="templates/pattern._ZXf8Ib88EeC3itjHQ6nPuA/method._sJ_f4L8-EeC3itjHQ6nPuA.pt"/>
-            <parameters xmi:id="_CQFpwL8-EeC3itjHQ6nPuA" name="parameter" type="http://www.polarsys.org/capella/core/common/5.0.0#//StateMachine"/>
+            <parameters xmi:id="_CQFpwL8-EeC3itjHQ6nPuA" name="parameter" type="org.polarsys.capella.core.data.capellacommon.StateMachine"/>
             <orchestration xmi:type="pattern:SuperCall" xmi:id="_ZXf8KL88EeC3itjHQ6nPuA"/>
           </elements>
           <elements xmi:id="_1fzXsL9JEeC3itjHQ6nPuA" name="RegionDocGen" superPattern="#_LUSfMN0jEd-Vzvs7Wt1vzQ"
@@ -640,7 +640,7 @@
             <methods xmi:id="_1fzXtr9JEeC3itjHQ6nPuA" name="footer" patternFilePath="templates/pattern._1fzXsL9JEeC3itjHQ6nPuA/method._1fzXtr9JEeC3itjHQ6nPuA.pt"/>
             <methods xmi:id="_MshV8L9KEeC3itjHQ6nPuA" name="setCapellaContext" patternFilePath="templates/pattern._1fzXsL9JEeC3itjHQ6nPuA/method._MshV8L9KEeC3itjHQ6nPuA.pt"/>
             <methods xmi:id="_A5FHED4pEeKDPO8mQtK38g" name="endContent" patternFilePath="templates/pattern._1fzXsL9JEeC3itjHQ6nPuA/method._A5FHED4pEeKDPO8mQtK38g.pt"/>
-            <parameters xmi:id="_IJU3kL9KEeC3itjHQ6nPuA" name="parameter" type="http://www.polarsys.org/capella/core/common/5.0.0#//Region"/>
+            <parameters xmi:id="_IJU3kL9KEeC3itjHQ6nPuA" name="parameter" type="org.polarsys.capella.core.data.capellacommon.Region"/>
             <orchestration xmi:type="pattern:SuperCall" xmi:id="_1fzXt79JEeC3itjHQ6nPuA"/>
           </elements>
           <elements xmi:id="_TIBLoDlmEeKfl43CFVnoFw" name="CapellaScenarioDocGen"
@@ -655,7 +655,7 @@
             <methods xmi:id="_TIBLpTlmEeKfl43CFVnoFw" name="setCapellaContext" patternFilePath="templates/pattern._TIBLoDlmEeKfl43CFVnoFw/method._TIBLpTlmEeKfl43CFVnoFw.pt"/>
             <methods xmi:id="_TIBLpjlmEeKfl43CFVnoFw" name="footer" patternFilePath="templates/pattern._TIBLoDlmEeKfl43CFVnoFw/method._TIBLpjlmEeKfl43CFVnoFw.pt"/>
             <methods xmi:id="_m0-ecDlmEeKfl43CFVnoFw" name="endContent" patternFilePath="templates/pattern._TIBLoDlmEeKfl43CFVnoFw/method._m0-ecDlmEeKfl43CFVnoFw.pt"/>
-            <parameters xmi:id="_W_zVgDlmEeKfl43CFVnoFw" name="parameter" type="http://www.polarsys.org/capella/core/interaction/5.0.0#//Scenario"/>
+            <parameters xmi:id="_W_zVgDlmEeKfl43CFVnoFw" name="parameter" type="org.polarsys.capella.core.data.interaction.Scenario"/>
             <orchestration xmi:type="pattern:SuperCall" xmi:id="_TIBLpzlmEeKfl43CFVnoFw"/>
           </elements>
           <elements xmi:id="_WnyP8OzGEeSAVbCPYCI8cQ" name="DataValueContainerPkg"
@@ -682,7 +682,7 @@
             <methods xmi:id="_u-tmFbXYEeiyaM1QyFX3Jg" name="content" patternFilePath="templates/pattern._u-tmELXYEeiyaM1QyFX3Jg/method._u-tmFbXYEeiyaM1QyFX3Jg.pt"/>
             <methods xmi:id="_u-tmFrXYEeiyaM1QyFX3Jg" name="footer" patternFilePath="templates/pattern._u-tmELXYEeiyaM1QyFX3Jg/method._u-tmFrXYEeiyaM1QyFX3Jg.pt"/>
             <methods xmi:id="_291YwLXYEeiyaM1QyFX3Jg" name="setCapellaContext" patternFilePath="templates/pattern._u-tmELXYEeiyaM1QyFX3Jg/method._291YwLXYEeiyaM1QyFX3Jg.pt"/>
-            <parameters xmi:id="_xcq2QLXYEeiyaM1QyFX3Jg" name="parameter" type="http://www.polarsys.org/capella/core/fa/5.0.0#//ComponentPort"/>
+            <parameters xmi:id="_xcq2QLXYEeiyaM1QyFX3Jg" name="parameter" type="org.polarsys.capella.core.data.fa.ComponentPort"/>
             <orchestration xmi:type="pattern:SuperCall" xmi:id="_u-tmF7XYEeiyaM1QyFX3Jg"/>
           </elements>
           <elements xmi:id="_a6_HILXaEeiyaM1QyFX3Jg" name="FunctionPortDocGen" superPattern="#_LUSfMN0jEd-Vzvs7Wt1vzQ"
@@ -696,7 +696,7 @@
             <methods xmi:id="_a6_HJbXaEeiyaM1QyFX3Jg" name="content" patternFilePath="templates/pattern._a6_HILXaEeiyaM1QyFX3Jg/method._a6_HJbXaEeiyaM1QyFX3Jg.pt"/>
             <methods xmi:id="_a6_HJrXaEeiyaM1QyFX3Jg" name="footer" patternFilePath="templates/pattern._a6_HILXaEeiyaM1QyFX3Jg/method._a6_HJrXaEeiyaM1QyFX3Jg.pt"/>
             <methods xmi:id="_h2T6gLXaEeiyaM1QyFX3Jg" name="setCapellaContext" patternFilePath="templates/pattern._a6_HILXaEeiyaM1QyFX3Jg/method._h2T6gLXaEeiyaM1QyFX3Jg.pt"/>
-            <parameters xmi:id="_l7zfELZwEeiyaM1QyFX3Jg" name="parameter" type="http://www.polarsys.org/capella/core/fa/5.0.0#//FunctionPort"/>
+            <parameters xmi:id="_l7zfELZwEeiyaM1QyFX3Jg" name="parameter" type="org.polarsys.capella.core.data.fa.FunctionPort"/>
             <orchestration xmi:type="pattern:SuperCall" xmi:id="_a6_HJ7XaEeiyaM1QyFX3Jg"/>
           </elements>
           <elements xmi:id="_EC31ALXcEeiyaM1QyFX3Jg" name="FunctionalExchangeDocGen"
@@ -711,7 +711,7 @@
             <methods xmi:id="_EC31BbXcEeiyaM1QyFX3Jg" name="content" patternFilePath="templates/pattern._EC31ALXcEeiyaM1QyFX3Jg/method._EC31BbXcEeiyaM1QyFX3Jg.pt"/>
             <methods xmi:id="_EC31BrXcEeiyaM1QyFX3Jg" name="footer" patternFilePath="templates/pattern._EC31ALXcEeiyaM1QyFX3Jg/method._EC31BrXcEeiyaM1QyFX3Jg.pt"/>
             <methods xmi:id="_fvV8ELXcEeiyaM1QyFX3Jg" name="setCapellaContext" patternFilePath="templates/pattern._EC31ALXcEeiyaM1QyFX3Jg/method._fvV8ELXcEeiyaM1QyFX3Jg.pt"/>
-            <parameters xmi:id="_aY5b0LXcEeiyaM1QyFX3Jg" name="parameter" type="http://www.polarsys.org/capella/core/fa/5.0.0#//FunctionalExchange"/>
+            <parameters xmi:id="_aY5b0LXcEeiyaM1QyFX3Jg" name="parameter" type="org.polarsys.capella.core.data.fa.FunctionalExchange"/>
             <orchestration xmi:type="pattern:SuperCall" xmi:id="_EC31B7XcEeiyaM1QyFX3Jg"/>
           </elements>
           <elements xmi:id="_B0Sp4FxqEemRLucKv8z86A" name="CategoriesDocGen" superPattern="#_LUSfMN0jEd-Vzvs7Wt1vzQ"
@@ -725,7 +725,7 @@
             <methods xmi:id="_5f3gIFxqEemRLucKv8z86A" name="setCapellaContext" patternFilePath="templates/pattern._B0Sp4FxqEemRLucKv8z86A/method._5f3gIFxqEemRLucKv8z86A.pt"/>
             <methods xmi:id="_B0Sp5VxqEemRLucKv8z86A" name="content" patternFilePath="templates/pattern._B0Sp4FxqEemRLucKv8z86A/method._B0Sp5VxqEemRLucKv8z86A.pt"/>
             <methods xmi:id="_B0Sp5lxqEemRLucKv8z86A" name="footer" patternFilePath="templates/pattern._B0Sp4FxqEemRLucKv8z86A/method._B0Sp5lxqEemRLucKv8z86A.pt"/>
-            <parameters xmi:id="_QHqo4FxqEemRLucKv8z86A" name="parameter" type="http://www.polarsys.org/capella/core/core/5.0.0#//NamedElement"/>
+            <parameters xmi:id="_QHqo4FxqEemRLucKv8z86A" name="parameter" type="org.polarsys.capella.core.data.capellacore.NamedElement"/>
             <orchestration xmi:type="pattern:SuperCall" xmi:id="_B0Sp51xqEemRLucKv8z86A"/>
           </elements>
           <elements xmi:id="_QKJzAIFHEemoWLDLVaBCIQ" description="Generation of HTML page for ComponentExchange."
@@ -739,7 +739,7 @@
             <methods xmi:id="_QKJzBIFHEemoWLDLVaBCIQ" name="preCondition" patternFilePath="templates/pattern._QKJzAIFHEemoWLDLVaBCIQ/method._QKJzBIFHEemoWLDLVaBCIQ.pt"/>
             <methods xmi:id="_QKJzBYFHEemoWLDLVaBCIQ" name="setCapellaContext" patternFilePath="templates/pattern._QKJzAIFHEemoWLDLVaBCIQ/method._QKJzBYFHEemoWLDLVaBCIQ.pt"/>
             <methods xmi:id="_QKJzBoFHEemoWLDLVaBCIQ" name="footer" patternFilePath="templates/pattern._QKJzAIFHEemoWLDLVaBCIQ/method._QKJzBoFHEemoWLDLVaBCIQ.pt"/>
-            <parameters xmi:id="_g1HUcIFHEemoWLDLVaBCIQ" name="parameter" type="http://www.polarsys.org/capella/core/fa/5.0.0#//ComponentExchange"/>
+            <parameters xmi:id="_g1HUcIFHEemoWLDLVaBCIQ" name="parameter" type="org.polarsys.capella.core.data.fa.ComponentExchange"/>
             <orchestration xmi:type="pattern:SuperCall" xmi:id="_QKJzB4FHEemoWLDLVaBCIQ"/>
           </elements>
           <elements xmi:id="_x6M3kIuDEemoWLDLVaBCIQ" description="Generation of HTML page for PhysicalLink."
@@ -753,7 +753,7 @@
             <methods xmi:id="_x6M3lIuDEemoWLDLVaBCIQ" name="preCondition" patternFilePath="templates/pattern._x6M3kIuDEemoWLDLVaBCIQ/method._x6M3lIuDEemoWLDLVaBCIQ.pt"/>
             <methods xmi:id="_x6M3lYuDEemoWLDLVaBCIQ" name="setCapellaContext" patternFilePath="templates/pattern._x6M3kIuDEemoWLDLVaBCIQ/method._x6M3lYuDEemoWLDLVaBCIQ.pt"/>
             <methods xmi:id="_x6M3louDEemoWLDLVaBCIQ" name="footer" patternFilePath="templates/pattern._x6M3kIuDEemoWLDLVaBCIQ/method._x6M3louDEemoWLDLVaBCIQ.pt"/>
-            <parameters xmi:id="_58mAsIuDEemoWLDLVaBCIQ" name="parameter" type="http://www.polarsys.org/capella/core/cs/5.0.0#//PhysicalLink"/>
+            <parameters xmi:id="_58mAsIuDEemoWLDLVaBCIQ" name="parameter" type="org.polarsys.capella.core.data.cs.PhysicalLink"/>
             <orchestration xmi:type="pattern:SuperCall" xmi:id="_x6M3l4uDEemoWLDLVaBCIQ"/>
           </elements>
         </libraries>
@@ -774,7 +774,7 @@
                 patternFilePath="templates/pattern._sJuJMN6ZEd-ZSZ6AN4Dlrg/method._DOFR8D2rEeCyXpZNg4b_aA.pt"/>
             <methods xmi:id="_yAqHMD2rEeCyXpZNg4b_aA" name="endSidebarSubElement"
                 patternFilePath="templates/pattern._sJuJMN6ZEd-ZSZ6AN4Dlrg/method._yAqHMD2rEeCyXpZNg4b_aA.pt"/>
-            <parameters xmi:id="_sJuJN96ZEd-ZSZ6AN4Dlrg" name="parameter" type="http://www.polarsys.org/capella/core/core/5.0.0#//CapellaElement"/>
+            <parameters xmi:id="_sJuJN96ZEd-ZSZ6AN4Dlrg" name="parameter" type="org.polarsys.capella.core.data.capellacore.CapellaElement"/>
             <orchestration xmi:type="pattern:SuperCall" xmi:id="_sJuJON6ZEd-ZSZ6AN4Dlrg"/>
           </elements>
         </libraries>

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore
@@ -809,6 +809,7 @@
       </viewpoints>
     </viewpointContainer>
     <orchestration xmi:type="fprod:ProductionPlan" xmi:id="_BcMYgNz-Ed-Vzvs7Wt1vzQ">
+      <invocations xmi:id="_9aMU0Fy-EeyWat65PgDwjg" name="Check Capella version" invokedActivity="#_uP6GgFy_EeyWat65PgDwjg"/>
       <invocations xmi:id="_3X7gIJ2NEemJ2K-s0Y7hRg" name="Initi runtime parameters (File name service)"
           invokedActivity="#_UQifoJ2NEemJ2K-s0Y7hRg"/>
       <invocations xmi:id="_3X87AJi7EemmGrHrkYlNKg" name="Load page extensions" invokedActivity="ftask:Task platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#_QF8EsJgtEemmGrHrkYlNKg">
@@ -950,6 +951,8 @@
       </invocations>
     </orchestration>
   </fcore:FactoryComponent>
+  <ftask:Task xmi:id="_uP6GgFy_EeyWat65PgDwjg" name="CheckCapellaVersion" kind="java"
+      implementation="org.polarsys.capella.docgen.task.CheckCapellaVersionTask"/>
   <ftask:Task xmi:id="_MtkCwUsFEeSfyeTEy5zUcw" name="Update.Documentation.Branding.Data"
       kind="java" implementation="org.polarsys.capella.docgen.task.UpdateCapellaDocGenBrandingData">
     <contractContainer xmi:id="_Q1dsQEsFEeSfyeTEy5zUcw">

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/AbstractFunctionDocGen.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/AbstractFunctionDocGen.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.2.202001031546
+//Generated with EGF 1.6.3.202110291409
 package org.polarsys.capella.docgen.content;
 
 import java.util.*;
@@ -18,325 +18,304 @@ import org.eclipse.emf.common.util.EList;
 import org.polarsys.capella.core.data.oa.OperationalActivity;
 
 public class AbstractFunctionDocGen extends org.polarsys.capella.docgen.foundations.NamedElementDocGen {
-	protected static String nl;
-
-	public static synchronized AbstractFunctionDocGen create(String lineSeparator) {
-		nl = lineSeparator;
-		AbstractFunctionDocGen result = new AbstractFunctionDocGen();
-		nl = null;
-		return result;
-	}
-
-	public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
-	protected final String TEXT_1 = "";
-	protected final String TEXT_2 = NL + "<h2>Involving Functional Chains</h2>";
-	protected final String TEXT_3 = NL + "<h2>Involving Operational Processes</h2>";
-	protected final String TEXT_4 = NL;
-	protected final String TEXT_5 = NL + "<h2>Allocating Component</h2>" + NL;
-	protected final String TEXT_6 = NL + "<h2>Incoming Functional Ports</h2>";
-	protected final String TEXT_7 = NL + "<h2>Outgoing Functional Ports</h2>";
-	protected final String TEXT_8 = NL + "    <h2>Incoming Internal Functional Exchanges</h2>" + NL + "    " + NL
-			+ "    " + NL + "   <table>" + NL + "\t<tr>" + NL + "\t\t<th>Exchange</th>" + NL
-			+ "\t\t<th>Involving functional chains</th>" + NL + "\t\t<th>Allocating component Exchanges</th>" + NL
-			+ "\t\t<th>Distant Port</th>" + NL + "\t\t<th>Source</th>" + NL + "\t\t<th>Target</th>" + NL
-			+ "\t\t<th>Description</th>" + NL + "\t\t<th>Allocated Exchange Items</th>" + NL
-			+ "\t\t<th>Realized Functional Exchange</th>" + NL + "\t\t<th>Realizing Functional Exchange</th>" + NL
-			+ "\t</tr>";
-	protected final String TEXT_9 = NL + "\t";
-	protected final String TEXT_10 = NL + "</table>";
-	protected final String TEXT_11 = NL + " <h2>Outgoing Internal Functional Exchanges</h2>" + NL + "" + NL
-			+ "    <table>" + NL + "\t<tr>" + NL + "\t\t<th>Exchange</th>" + NL
-			+ "\t\t<th>Involving functional chains</th>" + NL + "\t\t<th>Allocating component Exchanges</th>" + NL
-			+ "\t\t<th>Distant Port</th>" + NL + "\t\t<th>Source</th>" + NL + "\t\t<th>Target</th>" + NL
-			+ "\t\t<th>Description</th>" + NL + "\t\t<th>Allocated Exchange Items</th>" + NL
-			+ "\t\t<th>Realized Functional Exchange</th>" + NL + "\t\t<th>Realizing Functional Exchange</th>" + NL
-			+ "\t</tr>";
-	protected final String TEXT_12 = NL + "\t<h2>Incoming Functional Exchanges</h2>" + NL + "\t<table>" + NL + "\t<tr>"
-			+ NL + "\t\t<th>Exchange</th>" + NL + "\t\t<th>Involving functional chains</th>" + NL
-			+ "\t\t<th>Allocating component Exchanges</th>" + NL + "\t\t<th>Distant Port</th>" + NL
-			+ "\t\t<th>Source</th>" + NL + "\t\t<th>Description</th>" + NL + "\t\t<th>Allocated Exchange Items</th>"
-			+ NL + "\t\t<th>Realized Functional Exchange</th>" + NL + "\t\t<th>Realizing Functional Exchange</th>" + NL
-			+ "\t</tr>";
-	protected final String TEXT_13 = NL + "\t<h2>Outgoing Functional Exchanges</h2>" + NL + "\t<table>" + NL + "\t<tr>"
-			+ NL + "\t\t<th>Exchange</th>" + NL + "\t\t<th>Involving functional chains</th>" + NL
-			+ "\t\t<th>Allocating component Exchanges</th>" + NL + "\t\t<th>Distant Port</th>" + NL
-			+ "\t\t<th>Target</th>" + NL + "\t\t<th>Description</th>" + NL + "\t\t<th>Allocated Exchange Items</th>"
-			+ NL + "\t\t<th>Realized Functional Exchange</th>" + NL + "\t\t<th>Realizing Functional Exchange</th>" + NL
-			+ "\t</tr>";
-	protected final String TEXT_14 = NL + "    <h2>Incoming Internal Interactions</h2>" + NL + "        " + NL
-			+ "   <table>" + NL + "\t<tr>" + NL + "\t\t<th>Interaction</th>" + NL
-			+ "\t\t<th>Involving Operational Processes</th>" + NL + "\t\t<th>Source</th>" + NL + "\t\t<th>Target</th>"
-			+ NL + "\t\t<th>Description</th>" + NL + "\t\t<th>Allocated Exchange Items</th>" + NL
-			+ "\t\t<th>Realized Functional Exchange</th>" + NL + "\t\t<th>Realizing Functional Exchange</th>" + NL
-			+ "\t</tr>";
-	protected final String TEXT_15 = NL + " <h2>Outgoing Internal Interactions</h2>" + NL + "" + NL + "    <table>" + NL
-			+ "\t<tr>" + NL + "\t\t<th>Interaction</th>" + NL + "\t\t<th>Involving Operational Processes</th>" + NL
-			+ "\t\t<th>Source</th>" + NL + "\t\t<th>Target</th>" + NL + "\t\t<th>Description</th>" + NL
-			+ "\t\t<th>Allocated Exchange Items</th>" + NL + "\t\t<th>Realized Functional Exchange</th>" + NL
-			+ "\t\t<th>Realizing Functional Exchange</th>" + NL + "\t</tr>";
-	protected final String TEXT_16 = NL + "\t<h2>Incoming Interactions</h2>" + NL + "\t<table>" + NL + "\t<tr>" + NL
-			+ "\t\t<th>Interaction</th>" + NL + "\t\t<th>Source</th>" + NL + "\t\t<th>Description</th>" + NL
-			+ "\t\t<th>Allocated Exchange Items</th>" + NL + "\t</tr>";
-	protected final String TEXT_17 = NL + "\t<h2>Outgoing Interactions</h2>" + NL + "\t<table>" + NL + "\t<tr>" + NL
-			+ "\t\t<th>Interaction</th>" + NL + "\t\t<th>Target</th>" + NL + "\t\t<th>Description</th>" + NL
-			+ "\t\t<th>Allocated Exchange Items</th>" + NL + "\t</tr>";
-	protected final String TEXT_18 = NL + "<h2>Modes and States</h2>";
-
-	public AbstractFunctionDocGen() {
-		//Here is the constructor
-		StringBuffer stringBuffer = new StringBuffer();
-
-		// add initialisation of the pattern variables (declaration has been already done).
-
-	}
-
-	public String generate(Object argument) throws Exception {
-		final StringBuffer stringBuffer = new StringBuffer();
-		stringBuffer.append(TEXT_1);
-
-		InternalPatternContext ctx = (InternalPatternContext) argument;
-		Map<String, String> queryCtx = null;
-		IQuery.ParameterDescription paramDesc = null;
-		Node.Container currentNode = ctx.getNode();
-
-		List<Object> parameterList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
-
-		for (Object parameterParameter : parameterList) {
-
-			this.parameter = (org.polarsys.capella.core.data.fa.AbstractFunction) parameterParameter;
-
-			if (preCondition(ctx)) {
-				ctx.setNode(new Node.Container(currentNode, getClass()));
-				orchestration(ctx);
-			}
-
-		}
-		ctx.setNode(currentNode);
-		if (ctx.useReporter()) {
-			ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
-		}
-
-		stringBuffer.append(TEXT_4);
-		stringBuffer.append(TEXT_4);
-		return stringBuffer.toString();
-	}
+    protected static String nl;
 
-	public String orchestration(PatternContext ctx) throws Exception {
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
+    public static synchronized AbstractFunctionDocGen create(String lineSeparator) {
+        nl = lineSeparator;
+        AbstractFunctionDocGen result = new AbstractFunctionDocGen();
+        nl = null;
+        return result;
+    }
 
-		super.orchestration(new SuperOrchestrationContext(ictx));
+    public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
 
-		if (ictx.useReporter()) {
-			Map<String, Object> parameterValues = new HashMap<String, Object>();
-			parameterValues.put("parameter", this.parameter);
-			String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
-			String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
-			ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
-		}
-		return null;
-	}
+    protected final String TEXT_1 = "";
 
-	protected org.polarsys.capella.core.data.fa.AbstractFunction parameter = null;
+    protected final String TEXT_2 = NL + "<h2>Involving Functional Chains</h2>";
 
-	public void set_parameter(org.polarsys.capella.core.data.fa.AbstractFunction object) {
-		this.parameter = object;
-	}
+    protected final String TEXT_3 = NL + "<h2>Involving Operational Processes</h2>";
 
-	public Map<String, Object> getParameters() {
-		final Map<String, Object> parameters = new HashMap<String, Object>();
-		parameters.put("parameter", this.parameter);
-		return parameters;
-	}
+    protected final String TEXT_4 = NL;
 
-	protected void method_setCapellaContext(final StringBuffer stringBuffer, final PatternContext ctx)
-			throws Exception {
-
-		element = parameter;
+    protected final String TEXT_5 = NL + "<h2>Allocating Component</h2>" + NL;
 
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "setCapellaContext", stringBuffer.toString());
-	}
+    protected final String TEXT_6 = NL + "<h2>Incoming Functional Ports</h2>";
 
-	protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+    protected final String TEXT_7 = NL + "<h2>Outgoing Functional Ports</h2>";
 
-		super.method_content(new StringBuffer(), ctx);
-		String elementName = EscapeChars.forHTML(CapellaLabelProviderHelper.getText(element));
-		String elementType = EscapeChars.forHTML(element.eClass().getName());
-		String projectName = ctx.getValue("projectName").toString();
-		String outputFolder = ctx.getValue("outputFolder").toString();
-
-		Collection<String> involvingFunctionalChains = FunctionHelper.getInvolvingFunctionalChains(projectName,
-				outputFolder, (AbstractFunction) element);
-		if (involvingFunctionalChains.size() > 0) {
-			if (!(element instanceof OperationalActivity)) {
-
-				stringBuffer.append(TEXT_2);
-
-			} else {
-
-				stringBuffer.append(TEXT_3);
-
-			}
-
-			stringBuffer.append(TEXT_4);
-			stringBuffer.append(StringUtil.stringListToBulette(involvingFunctionalChains));
-
-		}
-
-		Collection<String> allocatingComponents = FunctionHelper.getAllocatingComponents(projectName, outputFolder,
-				(AbstractFunction) element);
-		if (allocatingComponents.size() > 0) {
-
-			stringBuffer.append(TEXT_5);
-			stringBuffer.append(TEXT_4);
-			stringBuffer.append(StringUtil.stringListToBulette(allocatingComponents));
-
-		}
-
-		EList<InputPin> incomingPorts = ((AbstractFunction) element).getInputs();
-		if (incomingPorts.size() > 0) {
-
-			stringBuffer.append(TEXT_6);
-			stringBuffer.append(TEXT_4);
-			stringBuffer.append(StringUtil.stringListToBulette(incomingPorts, projectName, outputFolder));
-			stringBuffer.append(TEXT_4);
-
-		}
-
-		EList<OutputPin> outgoingPorts = ((AbstractFunction) element).getOutputs();
-		if (outgoingPorts.size() > 0) {
-
-			stringBuffer.append(TEXT_7);
-			stringBuffer.append(TEXT_4);
-			stringBuffer.append(StringUtil.stringListToBulette(outgoingPorts, projectName, outputFolder));
-			stringBuffer.append(TEXT_4);
-
-		}
-
-		if (!(element instanceof OperationalActivity)) {
-			Collection<FunctionalExchange> incomingInternalFunctionalExchanges = CapellaFunctionServices
-					.getIncomingInternalFunctionalExchanges((AbstractFunction) element);
-			if (incomingInternalFunctionalExchanges.size() > 0) {
-
-				stringBuffer.append(TEXT_8);
-				for (FunctionalExchange functionalExchange : incomingInternalFunctionalExchanges) {
-					stringBuffer.append(TEXT_9);
-					stringBuffer.append(CapellaFunctionServices
-							.externalFunctionalExchangeToTableLine(functionalExchange, projectName, outputFolder));
-				}
-				stringBuffer.append(TEXT_10);
-
-			}
-			Collection<FunctionalExchange> outgoingInternalFunctionalExchanges = CapellaFunctionServices
-					.getOutgoingInternalFunctionalExchanges((AbstractFunction) element);
-			if (outgoingInternalFunctionalExchanges.size() > 0) {
-
-				stringBuffer.append(TEXT_11);
-				for (FunctionalExchange functionalExchange : outgoingInternalFunctionalExchanges) {
-					stringBuffer.append(TEXT_9);
-					stringBuffer.append(CapellaFunctionServices
-							.externalFunctionalExchangeToTableLine(functionalExchange, projectName, outputFolder));
-				}
-				stringBuffer.append(TEXT_10);
-
-			}
-			Collection<FunctionalExchange> incomingFunctionalExchanges = CapellaFunctionServices
-					.getIncomingFunctionalExchanges((AbstractFunction) element);
-			if (incomingFunctionalExchanges.size() > 0) {
-
-				stringBuffer.append(TEXT_12);
-				for (FunctionalExchange ae : incomingFunctionalExchanges) {
-					stringBuffer.append(TEXT_9);
-					stringBuffer.append(CapellaFunctionServices.incomingFunctionalExchangeToTableLine(ae, projectName,
-							outputFolder));
-				}
-				stringBuffer.append(TEXT_10);
-
-			}
-
-			Collection<FunctionalExchange> outgoingFunctionalExchanges = CapellaFunctionServices
-					.getOutgoingFunctionalExchanges((AbstractFunction) element);
-			if (outgoingFunctionalExchanges.size() > 0) {
-
-				stringBuffer.append(TEXT_13);
-				for (FunctionalExchange ae : outgoingFunctionalExchanges) {
-					stringBuffer.append(TEXT_9);
-					stringBuffer.append(CapellaFunctionServices.outgoingFunctionalExchangeToTableLine(ae, projectName,
-							outputFolder));
-				}
-				stringBuffer.append(TEXT_10);
-
-			}
-		} else {
-			Collection<FunctionalExchange> incomingInternalInteractions = CapellaFunctionServices
-					.getIncomingInternalFunctionalExchanges((AbstractFunction) element);
-			if (incomingInternalInteractions.size() > 0) {
-
-				stringBuffer.append(TEXT_14);
-				for (FunctionalExchange activityEdge : incomingInternalInteractions) {
-					stringBuffer.append(TEXT_9);
-					stringBuffer.append(CapellaFunctionServices.externalInteractionToTableLine(activityEdge,
-							projectName, outputFolder));
-				}
-				stringBuffer.append(TEXT_10);
-
-			}
-			Collection<FunctionalExchange> outgoingInternalInteractions = CapellaFunctionServices
-					.getOutgoingInternalFunctionalExchanges((AbstractFunction) element);
-			if (outgoingInternalInteractions.size() > 0) {
-
-				stringBuffer.append(TEXT_15);
-				for (FunctionalExchange activityEdge : outgoingInternalInteractions) {
-					stringBuffer.append(TEXT_9);
-					stringBuffer.append(CapellaFunctionServices.externalInteractionToTableLine(activityEdge,
-							projectName, outputFolder));
-				}
-				stringBuffer.append(TEXT_10);
-
-			}
-
-			Collection<FunctionalExchange> incomingInteractions = CapellaFunctionServices
-					.getIncomingFunctionalExchanges((AbstractFunction) element);
-			if (incomingInteractions.size() > 0) {
-
-				stringBuffer.append(TEXT_16);
-				for (FunctionalExchange ae : incomingInteractions) {
-					stringBuffer.append(TEXT_9);
-					stringBuffer.append(
-							CapellaFunctionServices.incomingInteractionToTableLine(ae, projectName, outputFolder));
-				}
-				stringBuffer.append(TEXT_10);
-
-			}
-
-			Collection<FunctionalExchange> outgoingInteractions = CapellaFunctionServices
-					.getOutgoingFunctionalExchanges((AbstractFunction) element);
-			if (outgoingInteractions.size() > 0) {
-
-				stringBuffer.append(TEXT_17);
-				for (FunctionalExchange ae : outgoingInteractions) {
-					stringBuffer.append(TEXT_9);
-					stringBuffer.append(
-							CapellaFunctionServices.outgoingInteractionToTableLine(ae, projectName, outputFolder));
-				}
-				stringBuffer.append(TEXT_10);
-
-			}
-		}
-
-		Collection<String> availableModeAndState = CapellaFunctionServices.getAvailableModeAndState(projectName,
-				outputFolder, (AbstractFunction) element);
-
-		if (availableModeAndState.size() > 0) {
-
-			stringBuffer.append(TEXT_18);
-			stringBuffer.append(TEXT_4);
-			stringBuffer.append(StringUtil.stringListToBulette(availableModeAndState));
-
-		}
-
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
-	}
+    protected final String TEXT_8 = NL + "    <h2>Incoming Internal Functional Exchanges</h2>" + NL + "    " + NL + "    " + NL + "   <table>" + NL + "\t<tr>" + NL + "\t\t<th>Exchange</th>" + NL
+            + "\t\t<th>Involving functional chains</th>" + NL + "\t\t<th>Allocating component Exchanges</th>" + NL + "\t\t<th>Distant Port</th>" + NL + "\t\t<th>Source</th>" + NL
+            + "\t\t<th>Target</th>" + NL + "\t\t<th>Description</th>" + NL + "\t\t<th>Allocated Exchange Items</th>" + NL + "\t\t<th>Realized Functional Exchange</th>" + NL
+            + "\t\t<th>Realizing Functional Exchange</th>" + NL + "\t</tr>";
+
+    protected final String TEXT_9 = NL + "\t";
+
+    protected final String TEXT_10 = NL + "</table>";
+
+    protected final String TEXT_11 = NL + " <h2>Outgoing Internal Functional Exchanges</h2>" + NL + "" + NL + "    <table>" + NL + "\t<tr>" + NL + "\t\t<th>Exchange</th>" + NL
+            + "\t\t<th>Involving functional chains</th>" + NL + "\t\t<th>Allocating component Exchanges</th>" + NL + "\t\t<th>Distant Port</th>" + NL + "\t\t<th>Source</th>" + NL
+            + "\t\t<th>Target</th>" + NL + "\t\t<th>Description</th>" + NL + "\t\t<th>Allocated Exchange Items</th>" + NL + "\t\t<th>Realized Functional Exchange</th>" + NL
+            + "\t\t<th>Realizing Functional Exchange</th>" + NL + "\t</tr>";
+
+    protected final String TEXT_12 = NL + "\t<h2>Incoming Functional Exchanges</h2>" + NL + "\t<table>" + NL + "\t<tr>" + NL + "\t\t<th>Exchange</th>" + NL + "\t\t<th>Involving functional chains</th>"
+            + NL + "\t\t<th>Allocating component Exchanges</th>" + NL + "\t\t<th>Distant Port</th>" + NL + "\t\t<th>Source</th>" + NL + "\t\t<th>Description</th>" + NL
+            + "\t\t<th>Allocated Exchange Items</th>" + NL + "\t\t<th>Realized Functional Exchange</th>" + NL + "\t\t<th>Realizing Functional Exchange</th>" + NL + "\t</tr>";
+
+    protected final String TEXT_13 = NL + "\t<h2>Outgoing Functional Exchanges</h2>" + NL + "\t<table>" + NL + "\t<tr>" + NL + "\t\t<th>Exchange</th>" + NL + "\t\t<th>Involving functional chains</th>"
+            + NL + "\t\t<th>Allocating component Exchanges</th>" + NL + "\t\t<th>Distant Port</th>" + NL + "\t\t<th>Target</th>" + NL + "\t\t<th>Description</th>" + NL
+            + "\t\t<th>Allocated Exchange Items</th>" + NL + "\t\t<th>Realized Functional Exchange</th>" + NL + "\t\t<th>Realizing Functional Exchange</th>" + NL + "\t</tr>";
+
+    protected final String TEXT_14 = NL + "    <h2>Incoming Internal Interactions</h2>" + NL + "        " + NL + "   <table>" + NL + "\t<tr>" + NL + "\t\t<th>Interaction</th>" + NL
+            + "\t\t<th>Involving Operational Processes</th>" + NL + "\t\t<th>Source</th>" + NL + "\t\t<th>Target</th>" + NL + "\t\t<th>Description</th>" + NL + "\t\t<th>Allocated Exchange Items</th>"
+            + NL + "\t\t<th>Realized Functional Exchange</th>" + NL + "\t\t<th>Realizing Functional Exchange</th>" + NL + "\t</tr>";
+
+    protected final String TEXT_15 = NL + " <h2>Outgoing Internal Interactions</h2>" + NL + "" + NL + "    <table>" + NL + "\t<tr>" + NL + "\t\t<th>Interaction</th>" + NL
+            + "\t\t<th>Involving Operational Processes</th>" + NL + "\t\t<th>Source</th>" + NL + "\t\t<th>Target</th>" + NL + "\t\t<th>Description</th>" + NL + "\t\t<th>Allocated Exchange Items</th>"
+            + NL + "\t\t<th>Realized Functional Exchange</th>" + NL + "\t\t<th>Realizing Functional Exchange</th>" + NL + "\t</tr>";
+
+    protected final String TEXT_16 = NL + "\t<h2>Incoming Interactions</h2>" + NL + "\t<table>" + NL + "\t<tr>" + NL + "\t\t<th>Interaction</th>" + NL + "\t\t<th>Source</th>" + NL
+            + "\t\t<th>Description</th>" + NL + "\t\t<th>Allocated Exchange Items</th>" + NL + "\t</tr>";
+
+    protected final String TEXT_17 = NL + "\t<h2>Outgoing Interactions</h2>" + NL + "\t<table>" + NL + "\t<tr>" + NL + "\t\t<th>Interaction</th>" + NL + "\t\t<th>Target</th>" + NL
+            + "\t\t<th>Description</th>" + NL + "\t\t<th>Allocated Exchange Items</th>" + NL + "\t</tr>";
+
+    protected final String TEXT_18 = NL + "<h2>Modes and States</h2>";
+
+    public AbstractFunctionDocGen() {
+        // Here is the constructor
+        StringBuffer stringBuffer = new StringBuffer();
+
+        // add initialisation of the pattern variables (declaration has been already done).
+
+    }
+
+    public String generate(Object argument) throws Exception {
+        final StringBuffer stringBuffer = new StringBuffer();
+        stringBuffer.append(TEXT_1);
+
+        InternalPatternContext ctx = (InternalPatternContext) argument;
+        Map<String, String> queryCtx = null;
+        IQuery.ParameterDescription paramDesc = null;
+        Node.Container currentNode = ctx.getNode();
+
+        List<Object> parameterList = null;
+        // this pattern can only be called by another (i.e. it's not an entry point in execution)
+
+        for (Object parameterParameter : parameterList) {
+
+            this.parameter = (org.polarsys.capella.core.data.fa.AbstractFunction) parameterParameter;
+
+            if (preCondition(ctx)) {
+                ctx.setNode(new Node.Container(currentNode, getClass()));
+                orchestration(ctx);
+            }
+
+        }
+        ctx.setNode(currentNode);
+        if (ctx.useReporter()) {
+            ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
+        }
+
+        stringBuffer.append(TEXT_4);
+        stringBuffer.append(TEXT_4);
+        return stringBuffer.toString();
+    }
+
+    public String orchestration(PatternContext ctx) throws Exception {
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+
+        super.orchestration(new SuperOrchestrationContext(ictx));
+
+        if (ictx.useReporter()) {
+            Map<String, Object> parameterValues = new HashMap<String, Object>();
+            parameterValues.put("parameter", this.parameter);
+            String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
+            String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
+            ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
+        }
+        return null;
+    }
+
+    protected org.polarsys.capella.core.data.fa.AbstractFunction parameter = null;
+
+    public void set_parameter(org.polarsys.capella.core.data.fa.AbstractFunction object) {
+        this.parameter = object;
+    }
+
+    public Map<String, Object> getParameters() {
+        final Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("parameter", this.parameter);
+        return parameters;
+    }
+
+    protected void method_setCapellaContext(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+
+        element = parameter;
+
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "setCapellaContext", stringBuffer.toString());
+    }
+
+    protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+
+        super.method_content(new StringBuffer(), ctx);
+        String elementName = EscapeChars.forHTML(CapellaLabelProviderHelper.getText(element));
+        String elementType = EscapeChars.forHTML(element.eClass().getName());
+        String projectName = ctx.getValue("projectName").toString();
+        String outputFolder = ctx.getValue("outputFolder").toString();
+
+        Collection<String> involvingFunctionalChains = FunctionHelper.getInvolvingFunctionalChains(projectName, outputFolder, (AbstractFunction) element);
+        if (involvingFunctionalChains.size() > 0) {
+            if (!(element instanceof OperationalActivity)) {
+
+                stringBuffer.append(TEXT_2);
+
+            } else {
+
+                stringBuffer.append(TEXT_3);
+
+            }
+
+            stringBuffer.append(TEXT_4);
+            stringBuffer.append(StringUtil.stringListToBulette(involvingFunctionalChains));
+
+        }
+
+        Collection<String> allocatingComponents = FunctionHelper.getAllocatingComponents(projectName, outputFolder, (AbstractFunction) element);
+        if (allocatingComponents.size() > 0) {
+
+            stringBuffer.append(TEXT_5);
+            stringBuffer.append(TEXT_4);
+            stringBuffer.append(StringUtil.stringListToBulette(allocatingComponents));
+
+        }
+
+        EList<InputPin> incomingPorts = ((AbstractFunction) element).getInputs();
+        if (incomingPorts.size() > 0) {
+
+            stringBuffer.append(TEXT_6);
+            stringBuffer.append(TEXT_4);
+            stringBuffer.append(StringUtil.stringListToBulette(incomingPorts, projectName, outputFolder));
+            stringBuffer.append(TEXT_4);
+
+        }
+
+        EList<OutputPin> outgoingPorts = ((AbstractFunction) element).getOutputs();
+        if (outgoingPorts.size() > 0) {
+
+            stringBuffer.append(TEXT_7);
+            stringBuffer.append(TEXT_4);
+            stringBuffer.append(StringUtil.stringListToBulette(outgoingPorts, projectName, outputFolder));
+            stringBuffer.append(TEXT_4);
+
+        }
+
+        if (!(element instanceof OperationalActivity)) {
+            Collection<FunctionalExchange> incomingInternalFunctionalExchanges = CapellaFunctionServices.getIncomingInternalFunctionalExchanges((AbstractFunction) element);
+            if (incomingInternalFunctionalExchanges.size() > 0) {
+
+                stringBuffer.append(TEXT_8);
+                for (FunctionalExchange functionalExchange : incomingInternalFunctionalExchanges) {
+                    stringBuffer.append(TEXT_9);
+                    stringBuffer.append(CapellaFunctionServices.externalFunctionalExchangeToTableLine(functionalExchange, projectName, outputFolder));
+                }
+                stringBuffer.append(TEXT_10);
+
+            }
+            Collection<FunctionalExchange> outgoingInternalFunctionalExchanges = CapellaFunctionServices.getOutgoingInternalFunctionalExchanges((AbstractFunction) element);
+            if (outgoingInternalFunctionalExchanges.size() > 0) {
+
+                stringBuffer.append(TEXT_11);
+                for (FunctionalExchange functionalExchange : outgoingInternalFunctionalExchanges) {
+                    stringBuffer.append(TEXT_9);
+                    stringBuffer.append(CapellaFunctionServices.externalFunctionalExchangeToTableLine(functionalExchange, projectName, outputFolder));
+                }
+                stringBuffer.append(TEXT_10);
+
+            }
+            Collection<FunctionalExchange> incomingFunctionalExchanges = CapellaFunctionServices.getIncomingFunctionalExchanges((AbstractFunction) element);
+            if (incomingFunctionalExchanges.size() > 0) {
+
+                stringBuffer.append(TEXT_12);
+                for (FunctionalExchange ae : incomingFunctionalExchanges) {
+                    stringBuffer.append(TEXT_9);
+                    stringBuffer.append(CapellaFunctionServices.incomingFunctionalExchangeToTableLine(ae, projectName, outputFolder));
+                }
+                stringBuffer.append(TEXT_10);
+
+            }
+
+            Collection<FunctionalExchange> outgoingFunctionalExchanges = CapellaFunctionServices.getOutgoingFunctionalExchanges((AbstractFunction) element);
+            if (outgoingFunctionalExchanges.size() > 0) {
+
+                stringBuffer.append(TEXT_13);
+                for (FunctionalExchange ae : outgoingFunctionalExchanges) {
+                    stringBuffer.append(TEXT_9);
+                    stringBuffer.append(CapellaFunctionServices.outgoingFunctionalExchangeToTableLine(ae, projectName, outputFolder));
+                }
+                stringBuffer.append(TEXT_10);
+
+            }
+        } else {
+            Collection<FunctionalExchange> incomingInternalInteractions = CapellaFunctionServices.getIncomingInternalFunctionalExchanges((AbstractFunction) element);
+            if (incomingInternalInteractions.size() > 0) {
+
+                stringBuffer.append(TEXT_14);
+                for (FunctionalExchange activityEdge : incomingInternalInteractions) {
+                    stringBuffer.append(TEXT_9);
+                    stringBuffer.append(CapellaFunctionServices.externalInteractionToTableLine(activityEdge, projectName, outputFolder));
+                }
+                stringBuffer.append(TEXT_10);
+
+            }
+            Collection<FunctionalExchange> outgoingInternalInteractions = CapellaFunctionServices.getOutgoingInternalFunctionalExchanges((AbstractFunction) element);
+            if (outgoingInternalInteractions.size() > 0) {
+
+                stringBuffer.append(TEXT_15);
+                for (FunctionalExchange activityEdge : outgoingInternalInteractions) {
+                    stringBuffer.append(TEXT_9);
+                    stringBuffer.append(CapellaFunctionServices.externalInteractionToTableLine(activityEdge, projectName, outputFolder));
+                }
+                stringBuffer.append(TEXT_10);
+
+            }
+
+            Collection<FunctionalExchange> incomingInteractions = CapellaFunctionServices.getIncomingFunctionalExchanges((AbstractFunction) element);
+            if (incomingInteractions.size() > 0) {
+
+                stringBuffer.append(TEXT_16);
+                for (FunctionalExchange ae : incomingInteractions) {
+                    stringBuffer.append(TEXT_9);
+                    stringBuffer.append(CapellaFunctionServices.incomingInteractionToTableLine(ae, projectName, outputFolder));
+                }
+                stringBuffer.append(TEXT_10);
+
+            }
+
+            Collection<FunctionalExchange> outgoingInteractions = CapellaFunctionServices.getOutgoingFunctionalExchanges((AbstractFunction) element);
+            if (outgoingInteractions.size() > 0) {
+
+                stringBuffer.append(TEXT_17);
+                for (FunctionalExchange ae : outgoingInteractions) {
+                    stringBuffer.append(TEXT_9);
+                    stringBuffer.append(CapellaFunctionServices.outgoingInteractionToTableLine(ae, projectName, outputFolder));
+                }
+                stringBuffer.append(TEXT_10);
+
+            }
+        }
+
+        Collection<String> availableModeAndState = CapellaFunctionServices.getAvailableModeAndState(projectName, outputFolder, (AbstractFunction) element);
+
+        if (availableModeAndState.size() > 0) {
+
+            stringBuffer.append(TEXT_18);
+            stringBuffer.append(TEXT_4);
+            stringBuffer.append(StringUtil.stringListToBulette(availableModeAndState));
+
+        }
+
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
+    }
 }

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/AbstractFunctionDocGen.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/AbstractFunctionDocGen.java
@@ -82,7 +82,7 @@ public class AbstractFunctionDocGen extends org.polarsys.capella.docgen.foundati
     protected final String TEXT_18 = NL + "<h2>Modes and States</h2>";
 
     public AbstractFunctionDocGen() {
-        // Here is the constructor
+        //Here is the constructor
         StringBuffer stringBuffer = new StringBuffer();
 
         // add initialisation of the pattern variables (declaration has been already done).
@@ -99,7 +99,7 @@ public class AbstractFunctionDocGen extends org.polarsys.capella.docgen.foundati
         Node.Container currentNode = ctx.getNode();
 
         List<Object> parameterList = null;
-        // this pattern can only be called by another (i.e. it's not an entry point in execution)
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
 
         for (Object parameterParameter : parameterList) {
 

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/AnyNamedElementDocGen.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/AnyNamedElementDocGen.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.1.201906060805
+//Generated with EGF 1.6.3.202110291409
 package org.polarsys.capella.docgen.content;
 
 import org.eclipse.egf.common.helper.*;
@@ -11,95 +11,96 @@ import org.polarsys.capella.core.data.capellacore.CapellaElement;
 import org.polarsys.capella.docgen.util.DocGenHtmlCapellaControl;
 
 public class AnyNamedElementDocGen extends org.polarsys.capella.docgen.foundations.NamedElementDocGen {
-	protected static String nl;
+    protected static String nl;
 
-	public static synchronized AnyNamedElementDocGen create(String lineSeparator) {
-		nl = lineSeparator;
-		AnyNamedElementDocGen result = new AnyNamedElementDocGen();
-		nl = null;
-		return result;
-	}
+    public static synchronized AnyNamedElementDocGen create(String lineSeparator) {
+        nl = lineSeparator;
+        AnyNamedElementDocGen result = new AnyNamedElementDocGen();
+        nl = null;
+        return result;
+    }
 
-	public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
-	protected final String TEXT_1 = "";
-	protected final String TEXT_2 = NL;
+    public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
 
-	public AnyNamedElementDocGen() {
-		//Here is the constructor
-		StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_1 = "";
 
-		// add initialisation of the pattern variables (declaration has been already done).
+    protected final String TEXT_2 = NL;
 
-	}
+    public AnyNamedElementDocGen() {
+        //Here is the constructor
+        StringBuffer stringBuffer = new StringBuffer();
 
-	public String generate(Object argument) throws Exception {
-		final StringBuffer stringBuffer = new StringBuffer();
+        // add initialisation of the pattern variables (declaration has been already done).
 
-		InternalPatternContext ctx = (InternalPatternContext) argument;
-		Map<String, String> queryCtx = null;
-		IQuery.ParameterDescription paramDesc = null;
-		Node.Container currentNode = ctx.getNode();
+    }
 
-		List<Object> parameterList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
+    public String generate(Object argument) throws Exception {
+        final StringBuffer stringBuffer = new StringBuffer();
 
-		for (Object parameterParameter : parameterList) {
+        InternalPatternContext ctx = (InternalPatternContext) argument;
+        Map<String, String> queryCtx = null;
+        IQuery.ParameterDescription paramDesc = null;
+        Node.Container currentNode = ctx.getNode();
 
-			this.parameter = (org.polarsys.capella.core.data.capellacore.NamedElement) parameterParameter;
+        List<Object> parameterList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
 
-			if (preCondition(ctx)) {
-				ctx.setNode(new Node.Container(currentNode, getClass()));
-				orchestration(ctx);
-			}
+        for (Object parameterParameter : parameterList) {
 
-		}
-		ctx.setNode(currentNode);
-		if (ctx.useReporter()) {
-			ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
-		}
+            this.parameter = (org.polarsys.capella.core.data.capellacore.NamedElement) parameterParameter;
 
-		stringBuffer.append(TEXT_1);
-		stringBuffer.append(TEXT_2);
-		return stringBuffer.toString();
-	}
+            if (preCondition(ctx)) {
+                ctx.setNode(new Node.Container(currentNode, getClass()));
+                orchestration(ctx);
+            }
 
-	public String orchestration(PatternContext ctx) throws Exception {
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
+        }
+        ctx.setNode(currentNode);
+        if (ctx.useReporter()) {
+            ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
+        }
 
-		super.orchestration(new SuperOrchestrationContext(ictx));
+        stringBuffer.append(TEXT_1);
+        stringBuffer.append(TEXT_2);
+        return stringBuffer.toString();
+    }
 
-		if (ictx.useReporter()) {
-			Map<String, Object> parameterValues = new HashMap<String, Object>();
-			parameterValues.put("parameter", this.parameter);
-			String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
-			String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
-			ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
-		}
-		return null;
-	}
+    public String orchestration(PatternContext ctx) throws Exception {
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
 
-	protected org.polarsys.capella.core.data.capellacore.NamedElement parameter = null;
+        super.orchestration(new SuperOrchestrationContext(ictx));
 
-	public void set_parameter(org.polarsys.capella.core.data.capellacore.NamedElement object) {
-		this.parameter = object;
-	}
+        if (ictx.useReporter()) {
+            Map<String, Object> parameterValues = new HashMap<String, Object>();
+            parameterValues.put("parameter", this.parameter);
+            String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
+            String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
+            ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
+        }
+        return null;
+    }
 
-	public Map<String, Object> getParameters() {
-		final Map<String, Object> parameters = new HashMap<String, Object>();
-		parameters.put("parameter", this.parameter);
-		return parameters;
-	}
+    protected org.polarsys.capella.core.data.capellacore.NamedElement parameter = null;
 
-	protected void method_setCapellaContext(final StringBuffer stringBuffer, final PatternContext ctx)
-			throws Exception {
+    public void set_parameter(org.polarsys.capella.core.data.capellacore.NamedElement object) {
+        this.parameter = object;
+    }
 
-		element = parameter;
+    public Map<String, Object> getParameters() {
+        final Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("parameter", this.parameter);
+        return parameters;
+    }
 
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "setCapellaContext", stringBuffer.toString());
-	}
+    protected void method_setCapellaContext(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-	public boolean preCondition(PatternContext ctx) throws Exception {
-		return DocGenHtmlCapellaControl.isPageCandidateForAnyElement((CapellaElement) parameter);
-	}
+        element = parameter;
+
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "setCapellaContext", stringBuffer.toString());
+    }
+
+    public boolean preCondition(PatternContext ctx) throws Exception {
+        return DocGenHtmlCapellaControl.isPageCandidateForAnyElement((CapellaElement) parameter);
+    }
 }

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/CapabilityDocGen.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/CapabilityDocGen.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.1.201906060805
+//Generated with EGF 1.6.3.202110291409
 package org.polarsys.capella.docgen.content;
 
 import org.eclipse.egf.common.helper.*;
@@ -12,178 +12,181 @@ import org.polarsys.capella.docgen.util.pattern.helper.CapellaCapabilityHelper;
 import org.polarsys.capella.core.data.ctx.Capability;
 
 public class CapabilityDocGen extends org.polarsys.capella.docgen.content.packageDocGen {
-	protected static String nl;
+    protected static String nl;
 
-	public static synchronized CapabilityDocGen create(String lineSeparator) {
-		nl = lineSeparator;
-		CapabilityDocGen result = new CapabilityDocGen();
-		nl = null;
-		return result;
-	}
+    public static synchronized CapabilityDocGen create(String lineSeparator) {
+        nl = lineSeparator;
+        CapabilityDocGen result = new CapabilityDocGen();
+        nl = null;
+        return result;
+    }
 
-	public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
-	protected final String TEXT_1 = NL + "<h2>Exploiting Missions</h2>";
-	protected final String TEXT_2 = NL;
-	protected final String TEXT_3 = NL + "<h2>Involved Actors</h2>";
-	protected final String TEXT_4 = NL + "<h2>Relationships with other Capabilities</h2>";
-	protected final String TEXT_5 = NL + "<h3>Extended Capabilities</h3>";
-	protected final String TEXT_6 = NL + "<h3>Included Capabilities</h3>";
-	protected final String TEXT_7 = NL + NL + "<h3>Super</h3>";
-	protected final String TEXT_8 = NL + "<h2>Related Functions</h2>";
-	protected final String TEXT_9 = NL + "<h2>Modes and States</h2>";
-	protected final String TEXT_10 = NL + NL + NL;
+    public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
 
-	public CapabilityDocGen() {
-		//Here is the constructor
-		StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_1 = NL + "<h2>Exploiting Missions</h2>";
 
-		// add initialisation of the pattern variables (declaration has been already done).
+    protected final String TEXT_2 = NL;
 
-	}
+    protected final String TEXT_3 = NL + "<h2>Involved Actors</h2>";
 
-	public String generate(Object argument) throws Exception {
-		final StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_4 = NL + "<h2>Relationships with other Capabilities</h2>";
 
-		InternalPatternContext ctx = (InternalPatternContext) argument;
-		Map<String, String> queryCtx = null;
-		IQuery.ParameterDescription paramDesc = null;
-		Node.Container currentNode = ctx.getNode();
+    protected final String TEXT_5 = NL + "<h3>Extended Capabilities</h3>";
 
-		List<Object> parameterList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
+    protected final String TEXT_6 = NL + "<h3>Included Capabilities</h3>";
 
-		for (Object parameterParameter : parameterList) {
+    protected final String TEXT_7 = NL + NL + "<h3>Super</h3>";
 
-			this.parameter = (org.polarsys.capella.core.data.capellacore.Structure) parameterParameter;
+    protected final String TEXT_8 = NL + "<h2>Related Functions</h2>";
 
-			if (preCondition(ctx)) {
-				ctx.setNode(new Node.Container(currentNode, getClass()));
-				orchestration(ctx);
-			}
+    protected final String TEXT_9 = NL + "<h2>Modes and States</h2>";
 
-		}
-		ctx.setNode(currentNode);
-		if (ctx.useReporter()) {
-			ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
-		}
+    protected final String TEXT_10 = NL + NL + NL;
 
-		stringBuffer.append(TEXT_2);
-		stringBuffer.append(TEXT_2);
-		return stringBuffer.toString();
-	}
+    public CapabilityDocGen() {
+        //Here is the constructor
+        StringBuffer stringBuffer = new StringBuffer();
 
-	public String orchestration(PatternContext ctx) throws Exception {
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
+        // add initialisation of the pattern variables (declaration has been already done).
 
-		super.orchestration(new SuperOrchestrationContext(ictx));
+    }
 
-		if (ictx.useReporter()) {
-			Map<String, Object> parameterValues = new HashMap<String, Object>();
-			parameterValues.put("parameter", this.parameter);
-			String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
-			String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
-			ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
-		}
-		return null;
-	}
+    public String generate(Object argument) throws Exception {
+        final StringBuffer stringBuffer = new StringBuffer();
 
-	public Map<String, Object> getParameters() {
-		final Map<String, Object> parameters = new HashMap<String, Object>();
-		parameters.put("parameter", this.parameter);
-		return parameters;
-	}
+        InternalPatternContext ctx = (InternalPatternContext) argument;
+        Map<String, String> queryCtx = null;
+        IQuery.ParameterDescription paramDesc = null;
+        Node.Container currentNode = ctx.getNode();
 
-	protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+        List<Object> parameterList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
 
-		super.method_content(new StringBuffer(), ctx);
-		String projectName = ctx.getValue("projectName").toString();
-		String outputFolder = ctx.getValue("outputFolder").toString();
+        for (Object parameterParameter : parameterList) {
 
-		Collection<String> exploitingMissions = CapellaCapabilityHelper.INSTANCE.getExploitingMissions(projectName,
-				outputFolder, (Capability) parameter);
+            this.parameter = (org.polarsys.capella.core.data.capellacore.Structure) parameterParameter;
 
-		if (exploitingMissions.size() > 0) {
+            if (preCondition(ctx)) {
+                ctx.setNode(new Node.Container(currentNode, getClass()));
+                orchestration(ctx);
+            }
 
-			stringBuffer.append(TEXT_1);
-			stringBuffer.append(TEXT_2);
-			stringBuffer.append(StringUtil.stringListToBulette(exploitingMissions));
-			stringBuffer.append(TEXT_2);
+        }
+        ctx.setNode(currentNode);
+        if (ctx.useReporter()) {
+            ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
+        }
 
-		}
-		Collection<String> actors = CapellaCapabilityHelper.INSTANCE.getInvolvedActors(projectName, outputFolder,
-				(Capability) parameter);
+        stringBuffer.append(TEXT_2);
+        stringBuffer.append(TEXT_2);
+        return stringBuffer.toString();
+    }
 
-		if (actors.size() > 0) {
+    public String orchestration(PatternContext ctx) throws Exception {
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
 
-			stringBuffer.append(TEXT_3);
-			stringBuffer.append(TEXT_2);
-			stringBuffer.append(StringUtil.stringListToBulette(actors));
+        super.orchestration(new SuperOrchestrationContext(ictx));
 
-		}
+        if (ictx.useReporter()) {
+            Map<String, Object> parameterValues = new HashMap<String, Object>();
+            parameterValues.put("parameter", this.parameter);
+            String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
+            String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
+            ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
+        }
+        return null;
+    }
 
-		Collection<String> extendedCapabilities = CapellaCapabilityHelper.INSTANCE.getExtendedCapabilities(projectName,
-				outputFolder, (Capability) parameter);
-		Collection<String> includedCapabilities = CapellaCapabilityHelper.INSTANCE.getIncludedCapabilities(projectName,
-				outputFolder, (Capability) parameter);
-		Collection<String> superCapabilities = CapellaCapabilityHelper.INSTANCE.getParentCapabilities(projectName,
-				outputFolder, (Capability) parameter);
-		if ((extendedCapabilities.size() > 0) || (includedCapabilities.size() > 0) || (superCapabilities.size() > 0)) {
+    public Map<String, Object> getParameters() {
+        final Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("parameter", this.parameter);
+        return parameters;
+    }
 
-			stringBuffer.append(TEXT_4);
+    protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-		}
-		if (extendedCapabilities.size() > 0) {
+        super.method_content(new StringBuffer(), ctx);
+        String projectName = ctx.getValue("projectName").toString();
+        String outputFolder = ctx.getValue("outputFolder").toString();
 
-			stringBuffer.append(TEXT_5);
-			stringBuffer.append(TEXT_2);
-			stringBuffer.append(StringUtil.stringListToBulette(extendedCapabilities));
+        Collection<String> exploitingMissions = CapellaCapabilityHelper.INSTANCE.getExploitingMissions(projectName, outputFolder, (Capability) parameter);
 
-		}
+        if (exploitingMissions.size() > 0) {
 
-		if (includedCapabilities.size() > 0) {
+            stringBuffer.append(TEXT_1);
+            stringBuffer.append(TEXT_2);
+            stringBuffer.append(StringUtil.stringListToBulette(exploitingMissions));
+            stringBuffer.append(TEXT_2);
 
-			stringBuffer.append(TEXT_6);
-			stringBuffer.append(TEXT_2);
-			stringBuffer.append(StringUtil.stringListToBulette(includedCapabilities));
+        }
+        Collection<String> actors = CapellaCapabilityHelper.INSTANCE.getInvolvedActors(projectName, outputFolder, (Capability) parameter);
 
-		}
+        if (actors.size() > 0) {
 
-		if (superCapabilities.size() > 0) {
+            stringBuffer.append(TEXT_3);
+            stringBuffer.append(TEXT_2);
+            stringBuffer.append(StringUtil.stringListToBulette(actors));
 
-			stringBuffer.append(TEXT_7);
-			stringBuffer.append(TEXT_2);
-			stringBuffer.append(StringUtil.stringListToBulette(superCapabilities));
-			stringBuffer.append(TEXT_2);
+        }
 
-		}
-		Collection<String> involvedFunctions = CapellaCapabilityHelper.INSTANCE.getInvolvedFunctions(projectName,
-				outputFolder, (Capability) parameter);
+        Collection<String> extendedCapabilities = CapellaCapabilityHelper.INSTANCE.getExtendedCapabilities(projectName, outputFolder, (Capability) parameter);
+        Collection<String> includedCapabilities = CapellaCapabilityHelper.INSTANCE.getIncludedCapabilities(projectName, outputFolder, (Capability) parameter);
+        Collection<String> superCapabilities = CapellaCapabilityHelper.INSTANCE.getParentCapabilities(projectName, outputFolder, (Capability) parameter);
+        if ((extendedCapabilities.size() > 0) || (includedCapabilities.size() > 0) || (superCapabilities.size() > 0)) {
 
-		if (involvedFunctions.size() > 0) {
+            stringBuffer.append(TEXT_4);
 
-			stringBuffer.append(TEXT_8);
-			stringBuffer.append(TEXT_2);
-			stringBuffer.append(StringUtil.stringListToBulette(involvedFunctions));
+        }
+        if (extendedCapabilities.size() > 0) {
 
-		}
+            stringBuffer.append(TEXT_5);
+            stringBuffer.append(TEXT_2);
+            stringBuffer.append(StringUtil.stringListToBulette(extendedCapabilities));
 
-		Collection<String> availableModeAndState = CapellaCapabilityHelper.INSTANCE
-				.getAvailableModeAndState(projectName, outputFolder, (Capability) parameter);
+        }
 
-		if (availableModeAndState.size() > 0) {
+        if (includedCapabilities.size() > 0) {
 
-			stringBuffer.append(TEXT_9);
-			stringBuffer.append(TEXT_2);
-			stringBuffer.append(StringUtil.stringListToBulette(availableModeAndState));
+            stringBuffer.append(TEXT_6);
+            stringBuffer.append(TEXT_2);
+            stringBuffer.append(StringUtil.stringListToBulette(includedCapabilities));
 
-		}
+        }
 
-		stringBuffer.append(TEXT_10);
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
-	}
+        if (superCapabilities.size() > 0) {
 
-	public boolean preCondition(PatternContext ctx) throws Exception {
-		return (this.parameter instanceof Capability);
-	}
+            stringBuffer.append(TEXT_7);
+            stringBuffer.append(TEXT_2);
+            stringBuffer.append(StringUtil.stringListToBulette(superCapabilities));
+            stringBuffer.append(TEXT_2);
+
+        }
+        Collection<String> involvedFunctions = CapellaCapabilityHelper.INSTANCE.getInvolvedFunctions(projectName, outputFolder, (Capability) parameter);
+
+        if (involvedFunctions.size() > 0) {
+
+            stringBuffer.append(TEXT_8);
+            stringBuffer.append(TEXT_2);
+            stringBuffer.append(StringUtil.stringListToBulette(involvedFunctions));
+
+        }
+
+        Collection<String> availableModeAndState = CapellaCapabilityHelper.INSTANCE.getAvailableModeAndState(projectName, outputFolder, (Capability) parameter);
+
+        if (availableModeAndState.size() > 0) {
+
+            stringBuffer.append(TEXT_9);
+            stringBuffer.append(TEXT_2);
+            stringBuffer.append(StringUtil.stringListToBulette(availableModeAndState));
+
+        }
+
+        stringBuffer.append(TEXT_10);
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
+    }
+
+    public boolean preCondition(PatternContext ctx) throws Exception {
+        return (this.parameter instanceof Capability);
+    }
 }

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/CapabilityRealizationDocGen.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/CapabilityRealizationDocGen.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.1.201906060805
+//Generated with EGF 1.6.3.202110291409
 package org.polarsys.capella.docgen.content;
 
 import org.eclipse.egf.common.helper.*;
@@ -12,112 +12,113 @@ import org.polarsys.capella.docgen.util.pattern.helper.CapellaCapabilityHelper;
 import org.polarsys.capella.core.data.la.CapabilityRealization;
 
 public class CapabilityRealizationDocGen extends org.polarsys.capella.docgen.content.packageDocGen {
-	protected static String nl;
+    protected static String nl;
 
-	public static synchronized CapabilityRealizationDocGen create(String lineSeparator) {
-		nl = lineSeparator;
-		CapabilityRealizationDocGen result = new CapabilityRealizationDocGen();
-		nl = null;
-		return result;
-	}
+    public static synchronized CapabilityRealizationDocGen create(String lineSeparator) {
+        nl = lineSeparator;
+        CapabilityRealizationDocGen result = new CapabilityRealizationDocGen();
+        nl = null;
+        return result;
+    }
 
-	public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
-	protected final String TEXT_1 = "<h2>Involved Components</h2>";
-	protected final String TEXT_2 = NL;
-	protected final String TEXT_3 = NL + "<h2>Related Functions</h2>";
+    public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
 
-	public CapabilityRealizationDocGen() {
-		//Here is the constructor
-		StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_1 = "<h2>Involved Components</h2>";
 
-		// add initialisation of the pattern variables (declaration has been already done).
+    protected final String TEXT_2 = NL;
 
-	}
+    protected final String TEXT_3 = NL + "<h2>Related Functions</h2>";
 
-	public String generate(Object argument) throws Exception {
-		final StringBuffer stringBuffer = new StringBuffer();
+    public CapabilityRealizationDocGen() {
+        //Here is the constructor
+        StringBuffer stringBuffer = new StringBuffer();
 
-		InternalPatternContext ctx = (InternalPatternContext) argument;
-		Map<String, String> queryCtx = null;
-		IQuery.ParameterDescription paramDesc = null;
-		Node.Container currentNode = ctx.getNode();
+        // add initialisation of the pattern variables (declaration has been already done).
 
-		List<Object> parameterList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
+    }
 
-		for (Object parameterParameter : parameterList) {
+    public String generate(Object argument) throws Exception {
+        final StringBuffer stringBuffer = new StringBuffer();
 
-			this.parameter = (org.polarsys.capella.core.data.capellacore.Structure) parameterParameter;
+        InternalPatternContext ctx = (InternalPatternContext) argument;
+        Map<String, String> queryCtx = null;
+        IQuery.ParameterDescription paramDesc = null;
+        Node.Container currentNode = ctx.getNode();
 
-			if (preCondition(ctx)) {
-				ctx.setNode(new Node.Container(currentNode, getClass()));
-				orchestration(ctx);
-			}
+        List<Object> parameterList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
 
-		}
-		ctx.setNode(currentNode);
-		if (ctx.useReporter()) {
-			ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
-		}
+        for (Object parameterParameter : parameterList) {
 
-		stringBuffer.append(TEXT_2);
-		stringBuffer.append(TEXT_2);
-		return stringBuffer.toString();
-	}
+            this.parameter = (org.polarsys.capella.core.data.capellacore.Structure) parameterParameter;
 
-	public String orchestration(PatternContext ctx) throws Exception {
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
+            if (preCondition(ctx)) {
+                ctx.setNode(new Node.Container(currentNode, getClass()));
+                orchestration(ctx);
+            }
 
-		super.orchestration(new SuperOrchestrationContext(ictx));
+        }
+        ctx.setNode(currentNode);
+        if (ctx.useReporter()) {
+            ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
+        }
 
-		if (ictx.useReporter()) {
-			Map<String, Object> parameterValues = new HashMap<String, Object>();
-			parameterValues.put("parameter", this.parameter);
-			String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
-			String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
-			ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
-		}
-		return null;
-	}
+        stringBuffer.append(TEXT_2);
+        stringBuffer.append(TEXT_2);
+        return stringBuffer.toString();
+    }
 
-	public Map<String, Object> getParameters() {
-		final Map<String, Object> parameters = new HashMap<String, Object>();
-		parameters.put("parameter", this.parameter);
-		return parameters;
-	}
+    public String orchestration(PatternContext ctx) throws Exception {
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
 
-	protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+        super.orchestration(new SuperOrchestrationContext(ictx));
 
-		super.method_content(new StringBuffer(), ctx);
-		String projectName = ctx.getValue("projectName").toString();
-		String outputFolder = ctx.getValue("outputFolder").toString();
-		Collection<String> involvedComponent = CapellaCapabilityHelper.INSTANCE.getInvolvedComponent(projectName,
-				outputFolder, (CapabilityRealization) parameter);
+        if (ictx.useReporter()) {
+            Map<String, Object> parameterValues = new HashMap<String, Object>();
+            parameterValues.put("parameter", this.parameter);
+            String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
+            String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
+            ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
+        }
+        return null;
+    }
 
-		if (involvedComponent.size() > 0) {
+    public Map<String, Object> getParameters() {
+        final Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("parameter", this.parameter);
+        return parameters;
+    }
 
-			stringBuffer.append(TEXT_1);
-			stringBuffer.append(TEXT_2);
-			stringBuffer.append(StringUtil.stringListToBulette(involvedComponent));
+    protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-		}
+        super.method_content(new StringBuffer(), ctx);
+        String projectName = ctx.getValue("projectName").toString();
+        String outputFolder = ctx.getValue("outputFolder").toString();
+        Collection<String> involvedComponent = CapellaCapabilityHelper.INSTANCE.getInvolvedComponent(projectName, outputFolder, (CapabilityRealization) parameter);
 
-		Collection<String> involvedFunctions = CapellaCapabilityHelper.INSTANCE.getInvolvedFunctions(projectName,
-				outputFolder, (CapabilityRealization) parameter);
+        if (involvedComponent.size() > 0) {
 
-		if (involvedFunctions.size() > 0) {
+            stringBuffer.append(TEXT_1);
+            stringBuffer.append(TEXT_2);
+            stringBuffer.append(StringUtil.stringListToBulette(involvedComponent));
 
-			stringBuffer.append(TEXT_3);
-			stringBuffer.append(TEXT_2);
-			stringBuffer.append(StringUtil.stringListToBulette(involvedFunctions));
+        }
 
-		}
+        Collection<String> involvedFunctions = CapellaCapabilityHelper.INSTANCE.getInvolvedFunctions(projectName, outputFolder, (CapabilityRealization) parameter);
 
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
-	}
+        if (involvedFunctions.size() > 0) {
 
-	public boolean preCondition(PatternContext ctx) throws Exception {
-		return (this.parameter instanceof CapabilityRealization);
-	}
+            stringBuffer.append(TEXT_3);
+            stringBuffer.append(TEXT_2);
+            stringBuffer.append(StringUtil.stringListToBulette(involvedFunctions));
+
+        }
+
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
+    }
+
+    public boolean preCondition(PatternContext ctx) throws Exception {
+        return (this.parameter instanceof CapabilityRealization);
+    }
 }

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/CapellaScenarioDocGen.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/CapellaScenarioDocGen.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.1.201906060805
+//Generated with EGF 1.6.3.202110291409
 package org.polarsys.capella.docgen.content;
 
 import org.eclipse.egf.common.helper.*;
@@ -13,189 +13,189 @@ import org.polarsys.capella.docgen.util.CapellaElementService;
 import org.polarsys.capella.docgen.util.StringUtil;
 
 public class CapellaScenarioDocGen extends org.polarsys.capella.docgen.foundations.NamedElementDocGen {
-	protected static String nl;
+    protected static String nl;
 
-	public static synchronized CapellaScenarioDocGen create(String lineSeparator) {
-		nl = lineSeparator;
-		CapellaScenarioDocGen result = new CapellaScenarioDocGen();
-		nl = null;
-		return result;
-	}
+    public static synchronized CapellaScenarioDocGen create(String lineSeparator) {
+        nl = lineSeparator;
+        CapellaScenarioDocGen result = new CapellaScenarioDocGen();
+        nl = null;
+        return result;
+    }
 
-	public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
-	protected final String TEXT_1 = "<h2>Realized Elements</h2>" + NL;
-	protected final String TEXT_2 = NL;
-	protected final String TEXT_3 = NL + "<h2>Realizing Elements </h2>" + NL;
-	protected final String TEXT_4 = NL + NL + "<h2>Sequence Messages</h2>" + NL + "" + NL
-			+ "<table max-width=\"screen.width\">" + NL + "   <thead> " + NL + "       <tr>" + NL
-			+ "           <th>Invoked Exchange</th>" + NL + "           <th>Source element of the Exchange</th>" + NL
-			+ "           <th>Target element of the Exchange</th>" + NL
-			+ "           <th>Description of the Sequence Message <br /> <i>(and not the one of the invoked exchange)</i></th>"
-			+ NL + "       </tr>" + NL + "   </thead>" + NL + "   <tbody>" + NL;
-	protected final String TEXT_5 = NL + "\t\t<tr>" + NL + "           <td>";
-	protected final String TEXT_6 = "</td>" + NL + "           <td>";
-	protected final String TEXT_7 = "</td>" + NL + "       </tr>";
-	protected final String TEXT_8 = NL + "   </tbody>" + NL + "</table>";
-	protected final String TEXT_9 = NL + "</div>";
+    public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
 
-	public CapellaScenarioDocGen() {
-		//Here is the constructor
-		StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_1 = "<h2>Realized Elements</h2>" + NL;
 
-		// add initialisation of the pattern variables (declaration has been already done).
+    protected final String TEXT_2 = NL;
 
-	}
+    protected final String TEXT_3 = NL + "<h2>Realizing Elements </h2>" + NL;
 
-	public String generate(Object argument) throws Exception {
-		final StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_4 = NL + NL + "<h2>Sequence Messages</h2>" + NL + "" + NL + "<table max-width=\"screen.width\">" + NL + "   <thead> " + NL + "       <tr>" + NL
+            + "           <th>Invoked Exchange</th>" + NL + "           <th>Source element of the Exchange</th>" + NL + "           <th>Target element of the Exchange</th>" + NL
+            + "           <th>Description of the Sequence Message <br /> <i>(and not the one of the invoked exchange)</i></th>" + NL + "       </tr>" + NL + "   </thead>" + NL + "   <tbody>" + NL;
 
-		InternalPatternContext ctx = (InternalPatternContext) argument;
-		Map<String, String> queryCtx = null;
-		IQuery.ParameterDescription paramDesc = null;
-		Node.Container currentNode = ctx.getNode();
+    protected final String TEXT_5 = NL + "\t\t<tr>" + NL + "           <td>";
 
-		List<Object> parameterList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
+    protected final String TEXT_6 = "</td>" + NL + "           <td>";
 
-		for (Object parameterParameter : parameterList) {
+    protected final String TEXT_7 = "</td>" + NL + "       </tr>";
 
-			this.parameter = (org.polarsys.capella.core.data.interaction.Scenario) parameterParameter;
+    protected final String TEXT_8 = NL + "   </tbody>" + NL + "</table>";
 
-			if (preCondition(ctx)) {
-				ctx.setNode(new Node.Container(currentNode, getClass()));
-				orchestration(ctx);
-			}
+    protected final String TEXT_9 = NL + "</div>";
 
-		}
-		ctx.setNode(currentNode);
-		if (ctx.useReporter()) {
-			ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
-		}
+    public CapellaScenarioDocGen() {
+        //Here is the constructor
+        StringBuffer stringBuffer = new StringBuffer();
 
-		stringBuffer.append(TEXT_2);
-		stringBuffer.append(TEXT_2);
-		return stringBuffer.toString();
-	}
+        // add initialisation of the pattern variables (declaration has been already done).
 
-	public String orchestration(PatternContext ctx) throws Exception {
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
+    }
 
-		super.orchestration(new SuperOrchestrationContext(ictx));
+    public String generate(Object argument) throws Exception {
+        final StringBuffer stringBuffer = new StringBuffer();
 
-		if (ictx.useReporter()) {
-			Map<String, Object> parameterValues = new HashMap<String, Object>();
-			parameterValues.put("parameter", this.parameter);
-			String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
-			String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
-			ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
-		}
-		return null;
-	}
+        InternalPatternContext ctx = (InternalPatternContext) argument;
+        Map<String, String> queryCtx = null;
+        IQuery.ParameterDescription paramDesc = null;
+        Node.Container currentNode = ctx.getNode();
 
-	protected org.polarsys.capella.core.data.interaction.Scenario parameter = null;
+        List<Object> parameterList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
 
-	public void set_parameter(org.polarsys.capella.core.data.interaction.Scenario object) {
-		this.parameter = object;
-	}
+        for (Object parameterParameter : parameterList) {
 
-	public Map<String, Object> getParameters() {
-		final Map<String, Object> parameters = new HashMap<String, Object>();
-		parameters.put("parameter", this.parameter);
-		return parameters;
-	}
+            this.parameter = (org.polarsys.capella.core.data.interaction.Scenario) parameterParameter;
 
-	protected void method_setCapellaContext(final StringBuffer stringBuffer, final PatternContext ctx)
-			throws Exception {
+            if (preCondition(ctx)) {
+                ctx.setNode(new Node.Container(currentNode, getClass()));
+                orchestration(ctx);
+            }
 
-		element = parameter;
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "setCapellaContext", stringBuffer.toString());
-	}
+        }
+        ctx.setNode(currentNode);
+        if (ctx.useReporter()) {
+            ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
+        }
 
-	protected void method_endContent(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+        stringBuffer.append(TEXT_2);
+        stringBuffer.append(TEXT_2);
+        return stringBuffer.toString();
+    }
 
-		// Realized Elements 
+    public String orchestration(PatternContext ctx) throws Exception {
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
 
-		String outputFolder = ctx.getValue("outputFolder").toString();
-		String projectName = ctx.getValue("projectName").toString();
-		Collection<String> allocations = CapellaElementService.getOutGoingAllocation(element, projectName,
-				outputFolder);
-		if (allocations.size() > 0) {
-			stringBuffer.append(TEXT_1);
-			stringBuffer.append(TEXT_2);
-			stringBuffer.append(StringUtil.stringListToBulette(allocations));
-			stringBuffer.append(TEXT_2);
-		}
-		stringBuffer.append(TEXT_2);
-		// Realizing Elements 
+        super.orchestration(new SuperOrchestrationContext(ictx));
 
-		//String outputFolder = ctx.getValue("outputFolder").toString();
-		//String projectName = ctx.getValue("projectName").toString();
-		Collection<String> allocations2 = CapellaElementService.getIncomingAllocation(element, projectName,
-				outputFolder);
-		if (allocations2.size() > 0) {
-			stringBuffer.append(TEXT_3);
-			stringBuffer.append(TEXT_2);
-			stringBuffer.append(StringUtil.stringListToBulette(allocations2));
-			stringBuffer.append(TEXT_2);
-		}
-		stringBuffer.append(TEXT_2);
-		// owned diagrams
-		stringBuffer.append(TEXT_2);
-		{
-			//<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#LogicalName=org.polarsys.capella.docgen.foundations.DiagramsGeneration" args="element:element"%>
+        if (ictx.useReporter()) {
+            Map<String, Object> parameterValues = new HashMap<String, Object>();
+            parameterValues.put("parameter", this.parameter);
+            String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
+            String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
+            ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
+        }
+        return null;
+    }
 
-			InternalPatternContext ictx = (InternalPatternContext) ctx;
-			new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
-			stringBuffer.setLength(0);
+    protected org.polarsys.capella.core.data.interaction.Scenario parameter = null;
 
-			final Map<String, Object> callParameters = new HashMap<String, Object>();
-			callParameters.put("element", element);
-			CallHelper.executeWithParameterInjection(
-					"platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#_PVePETXrEeCNvtb1bUM2fQ",
-					new ExecutionContext((InternalPatternContext) ctx), callParameters);
-			stringBuffer.setLength(0);
-		}
+    public void set_parameter(org.polarsys.capella.core.data.interaction.Scenario object) {
+        this.parameter = object;
+    }
 
-		stringBuffer.append(TEXT_2);
-		// Trier les messages
-		List<SequenceMessage> orderedMessagesList = ((Scenario) parameter).getOwnedMessages();
+    public Map<String, Object> getParameters() {
+        final Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("parameter", this.parameter);
+        return parameters;
+    }
 
-		stringBuffer.append(TEXT_2);
-		if (orderedMessagesList.size() > 0) {
-			stringBuffer.append(TEXT_4);
-			for (SequenceMessage sMessage : orderedMessagesList) {
+    protected void method_setCapellaContext(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-				String source = "";
-				String target = "";
+        element = parameter;
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "setCapellaContext", stringBuffer.toString());
+    }
 
-				if (sMessage.getSendingEnd() != null && sMessage.getSendingEnd().getCovered() != null
-						&& sMessage.getSendingEnd().getCovered().getRepresentedInstance() != null)
-					source = sMessage.getSendingEnd().getCovered().getRepresentedInstance().getName();
+    protected void method_endContent(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-				if (sMessage.getReceivingEnd() != null && sMessage.getReceivingEnd().getCovered() != null
-						&& sMessage.getReceivingEnd().getCovered().getRepresentedInstance() != null)
-					target = sMessage.getReceivingEnd().getCovered().getRepresentedInstance().getName();
+        // Realized Elements 
 
-				String name = sMessage.getName();
-				String description = sMessage.getDescription();
-				description = StringUtil.transformAREFString(sMessage, description, projectName, outputFolder);
-				if (description == null || description.trim().length() == 0)
-					description = "No description";
-				stringBuffer.append(TEXT_5);
-				stringBuffer.append(name);
-				stringBuffer.append(TEXT_6);
-				stringBuffer.append(source);
-				stringBuffer.append(TEXT_6);
-				stringBuffer.append(target);
-				stringBuffer.append(TEXT_6);
-				stringBuffer.append(description);
-				stringBuffer.append(TEXT_7);
-			}
-			stringBuffer.append(TEXT_8);
-		}
-		stringBuffer.append(TEXT_9);
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "endContent", stringBuffer.toString());
-	}
+        String outputFolder = ctx.getValue("outputFolder").toString();
+        String projectName = ctx.getValue("projectName").toString();
+        Collection<String> allocations = CapellaElementService.getOutGoingAllocation(element, projectName, outputFolder);
+        if (allocations.size() > 0) {
+            stringBuffer.append(TEXT_1);
+            stringBuffer.append(TEXT_2);
+            stringBuffer.append(StringUtil.stringListToBulette(allocations));
+            stringBuffer.append(TEXT_2);
+        }
+        stringBuffer.append(TEXT_2);
+        // Realizing Elements 
+
+        //String outputFolder = ctx.getValue("outputFolder").toString();
+        //String projectName = ctx.getValue("projectName").toString();
+        Collection<String> allocations2 = CapellaElementService.getIncomingAllocation(element, projectName, outputFolder);
+        if (allocations2.size() > 0) {
+            stringBuffer.append(TEXT_3);
+            stringBuffer.append(TEXT_2);
+            stringBuffer.append(StringUtil.stringListToBulette(allocations2));
+            stringBuffer.append(TEXT_2);
+        }
+        stringBuffer.append(TEXT_2);
+        // owned diagrams
+        stringBuffer.append(TEXT_2);
+        {
+            //<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#LogicalName=org.polarsys.capella.docgen.foundations.DiagramsGeneration" args="element:element"%>
+
+            InternalPatternContext ictx = (InternalPatternContext) ctx;
+            new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
+            stringBuffer.setLength(0);
+
+            final Map<String, Object> callParameters = new HashMap<String, Object>();
+            callParameters.put("element", element);
+            CallHelper.executeWithParameterInjection("platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#_PVePETXrEeCNvtb1bUM2fQ",
+                    new ExecutionContext((InternalPatternContext) ctx), callParameters);
+            stringBuffer.setLength(0);
+        }
+
+        stringBuffer.append(TEXT_2);
+        // Trier les messages
+        List<SequenceMessage> orderedMessagesList = ((Scenario) parameter).getOwnedMessages();
+
+        stringBuffer.append(TEXT_2);
+        if (orderedMessagesList.size() > 0) {
+            stringBuffer.append(TEXT_4);
+            for (SequenceMessage sMessage : orderedMessagesList) {
+
+                String source = "";
+                String target = "";
+
+                if (sMessage.getSendingEnd() != null && sMessage.getSendingEnd().getCovered() != null && sMessage.getSendingEnd().getCovered().getRepresentedInstance() != null)
+                    source = sMessage.getSendingEnd().getCovered().getRepresentedInstance().getName();
+
+                if (sMessage.getReceivingEnd() != null && sMessage.getReceivingEnd().getCovered() != null && sMessage.getReceivingEnd().getCovered().getRepresentedInstance() != null)
+                    target = sMessage.getReceivingEnd().getCovered().getRepresentedInstance().getName();
+
+                String name = sMessage.getName();
+                String description = sMessage.getDescription();
+                description = StringUtil.transformAREFString(sMessage, description, projectName, outputFolder);
+                if (description == null || description.trim().length() == 0)
+                    description = "No description";
+                stringBuffer.append(TEXT_5);
+                stringBuffer.append(name);
+                stringBuffer.append(TEXT_6);
+                stringBuffer.append(source);
+                stringBuffer.append(TEXT_6);
+                stringBuffer.append(target);
+                stringBuffer.append(TEXT_6);
+                stringBuffer.append(description);
+                stringBuffer.append(TEXT_7);
+            }
+            stringBuffer.append(TEXT_8);
+        }
+        stringBuffer.append(TEXT_9);
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "endContent", stringBuffer.toString());
+    }
 }

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/CategoriesDocGen.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/CategoriesDocGen.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.2.202001031546
+//Generated with EGF 1.6.3.202110291409
 package org.polarsys.capella.docgen.content;
 
 import org.polarsys.capella.docgen.util.CapellaCategoryServices;
@@ -16,200 +16,204 @@ import org.eclipse.egf.pattern.execution.*;
 import org.eclipse.egf.pattern.query.*;
 
 public class CategoriesDocGen extends org.polarsys.capella.docgen.foundations.NamedElementDocGen {
-	protected static String nl;
+    protected static String nl;
 
-	public static synchronized CategoriesDocGen create(String lineSeparator) {
-		nl = lineSeparator;
-		CategoriesDocGen result = new CategoriesDocGen();
-		nl = null;
-		return result;
-	}
+    public static synchronized CategoriesDocGen create(String lineSeparator) {
+        nl = lineSeparator;
+        CategoriesDocGen result = new CategoriesDocGen();
+        nl = null;
+        return result;
+    }
 
-	public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
-	protected final String TEXT_1 = "\t\t<h2>Involved Functional Exchanges</h2>" + NL + "\t\t";
-	protected final String TEXT_2 = NL + "\t\t<table>" + NL + "\t\t\t<tr>" + NL + "\t\t\t\t<th>Functional Exchange</th>"
-			+ NL + "\t\t\t\t<th>Source Function</th>" + NL + "\t\t\t\t<th>Target Function</th>" + NL
-			+ "\t\t\t\t<th>Description</th>" + NL + "\t\t\t</tr>" + NL + "\t\t";
-	protected final String TEXT_3 = NL + "\t\t\t";
-	protected final String TEXT_4 = NL + "\t\t</table>" + NL + "\t\t";
-	protected final String TEXT_5 = NL + "\t\t<h2>Involved Component Exchanges</h2>" + NL + "\t\t";
-	protected final String TEXT_6 = NL + "\t\t<table>" + NL + "\t\t\t<tr>" + NL + "\t\t\t\t<th>Component Exchange</th>"
-			+ NL + "\t\t\t\t<th>Source Component</th>" + NL + "\t\t\t\t<th>Target Component</th>" + NL
-			+ "\t\t\t\t<th>Description</th>" + NL + "\t\t\t</tr>" + NL + "\t\t";
-	protected final String TEXT_7 = NL + "\t\t<h2>Involved Physical Links</h2>" + NL + "\t\t";
-	protected final String TEXT_8 = NL + "\t\t<table>" + NL + "\t\t\t<tr>" + NL + "\t\t\t\t<th>Physical Link</th>" + NL
-			+ "\t\t\t\t<th>Source Component</th>" + NL + "\t\t\t\t<th>Target Component</th>" + NL
-			+ "\t\t\t\t<th>Description</th>" + NL + "\t\t\t</tr>" + NL + "\t\t";
-	protected final String TEXT_9 = NL;
+    public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
 
-	public CategoriesDocGen() {
-		//Here is the constructor
-		StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_1 = "\t\t<h2>Involved Functional Exchanges</h2>" + NL + "\t\t";
 
-		// add initialisation of the pattern variables (declaration has been already done).
+    protected final String TEXT_2 = NL + "\t\t<table>" + NL + "\t\t\t<tr>" + NL + "\t\t\t\t<th>Functional Exchange</th>" + NL + "\t\t\t\t<th>Source Function</th>" + NL
+            + "\t\t\t\t<th>Target Function</th>" + NL + "\t\t\t\t<th>Description</th>" + NL + "\t\t\t</tr>" + NL + "\t\t";
 
-	}
+    protected final String TEXT_3 = NL + "\t\t\t";
 
-	public String generate(Object argument) throws Exception {
-		final StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_4 = NL + "\t\t</table>" + NL + "\t\t";
 
-		InternalPatternContext ctx = (InternalPatternContext) argument;
-		Map<String, String> queryCtx = null;
-		IQuery.ParameterDescription paramDesc = null;
-		Node.Container currentNode = ctx.getNode();
+    protected final String TEXT_5 = NL + "\t\t<h2>Involved Component Exchanges</h2>" + NL + "\t\t";
 
-		List<Object> parameterList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
+    protected final String TEXT_6 = NL + "\t\t<table>" + NL + "\t\t\t<tr>" + NL + "\t\t\t\t<th>Component Exchange</th>" + NL + "\t\t\t\t<th>Source Component</th>" + NL
+            + "\t\t\t\t<th>Target Component</th>" + NL + "\t\t\t\t<th>Description</th>" + NL + "\t\t\t</tr>" + NL + "\t\t";
 
-		for (Object parameterParameter : parameterList) {
+    protected final String TEXT_7 = NL + "\t\t<h2>Involved Physical Links</h2>" + NL + "\t\t";
 
-			this.parameter = (org.polarsys.capella.core.data.capellacore.NamedElement) parameterParameter;
+    protected final String TEXT_8 = NL + "\t\t<table>" + NL + "\t\t\t<tr>" + NL + "\t\t\t\t<th>Physical Link</th>" + NL + "\t\t\t\t<th>Source Component</th>" + NL + "\t\t\t\t<th>Target Component</th>"
+            + NL + "\t\t\t\t<th>Description</th>" + NL + "\t\t\t</tr>" + NL + "\t\t";
 
-			if (preCondition(ctx)) {
-				ctx.setNode(new Node.Container(currentNode, getClass()));
-				orchestration(ctx);
-			}
+    protected final String TEXT_9 = NL;
 
-		}
-		ctx.setNode(currentNode);
-		if (ctx.useReporter()) {
-			ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
-		}
+    public CategoriesDocGen() {
+        //Here is the constructor
+        StringBuffer stringBuffer = new StringBuffer();
 
-		stringBuffer.append(TEXT_9);
-		stringBuffer.append(TEXT_9);
-		return stringBuffer.toString();
-	}
+        // add initialisation of the pattern variables (declaration has been already done).
 
-	public String orchestration(PatternContext ctx) throws Exception {
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
+    }
 
-		super.orchestration(new SuperOrchestrationContext(ictx));
+    public String generate(Object argument) throws Exception {
+        final StringBuffer stringBuffer = new StringBuffer();
 
-		if (ictx.useReporter()) {
-			Map<String, Object> parameterValues = new HashMap<String, Object>();
-			parameterValues.put("parameter", this.parameter);
-			String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
-			String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
-			ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
-		}
-		return null;
-	}
+        InternalPatternContext ctx = (InternalPatternContext) argument;
+        Map<String, String> queryCtx = null;
+        IQuery.ParameterDescription paramDesc = null;
+        Node.Container currentNode = ctx.getNode();
 
-	protected org.polarsys.capella.core.data.capellacore.NamedElement parameter = null;
+        List<Object> parameterList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
 
-	public void set_parameter(org.polarsys.capella.core.data.capellacore.NamedElement object) {
-		this.parameter = object;
-	}
+        for (Object parameterParameter : parameterList) {
 
-	public Map<String, Object> getParameters() {
-		final Map<String, Object> parameters = new HashMap<String, Object>();
-		parameters.put("parameter", this.parameter);
-		return parameters;
-	}
+            this.parameter = (org.polarsys.capella.core.data.capellacore.NamedElement) parameterParameter;
 
-	protected void method_setCapellaContext(final StringBuffer stringBuffer, final PatternContext ctx)
-			throws Exception {
+            if (preCondition(ctx)) {
+                ctx.setNode(new Node.Container(currentNode, getClass()));
+                orchestration(ctx);
+            }
 
-		element = parameter;
+        }
+        ctx.setNode(currentNode);
+        if (ctx.useReporter()) {
+            ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
+        }
 
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "setCapellaContext", stringBuffer.toString());
-	}
+        stringBuffer.append(TEXT_9);
+        stringBuffer.append(TEXT_9);
+        return stringBuffer.toString();
+    }
 
-	protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+    public String orchestration(PatternContext ctx) throws Exception {
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
 
-		super.method_content(new StringBuffer(), ctx);
-		String projectName = ctx.getValue("projectName").toString();
-		String outputFolder = ctx.getValue("outputFolder").toString();
+        super.orchestration(new SuperOrchestrationContext(ictx));
 
-		// Exchange Categories
-		if (element instanceof ExchangeCategory) {
-			ExchangeCategory category = (ExchangeCategory) element;
-			if (category.getExchanges().size() > 0) {
-				// Display Title
+        if (ictx.useReporter()) {
+            Map<String, Object> parameterValues = new HashMap<String, Object>();
+            parameterValues.put("parameter", this.parameter);
+            String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
+            String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
+            ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
+        }
+        return null;
+    }
 
-				stringBuffer.append(TEXT_1);
+    protected org.polarsys.capella.core.data.capellacore.NamedElement parameter = null;
 
-				// Create table header
+    public void set_parameter(org.polarsys.capella.core.data.capellacore.NamedElement object) {
+        this.parameter = object;
+    }
 
-				stringBuffer.append(TEXT_2);
+    public Map<String, Object> getParameters() {
+        final Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("parameter", this.parameter);
+        return parameters;
+    }
 
-				// Create each line
-				for (FunctionalExchange fe : category.getExchanges()) {
+    protected void method_setCapellaContext(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-					stringBuffer.append(TEXT_3);
-					stringBuffer.append(CapellaCategoryServices.edgeToTableLine(fe, projectName, outputFolder));
-					stringBuffer.append(TEXT_3);
+        element = parameter;
 
-				}
-				// Create table footer
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "setCapellaContext", stringBuffer.toString());
+    }
 
-				stringBuffer.append(TEXT_4);
+    protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-			}
-		}
+        super.method_content(new StringBuffer(), ctx);
+        String projectName = ctx.getValue("projectName").toString();
+        String outputFolder = ctx.getValue("outputFolder").toString();
 
-		// Component Exchange Categories
-		if (element instanceof ComponentExchangeCategory) {
-			ComponentExchangeCategory category = (ComponentExchangeCategory) element;
-			if (category.getExchanges().size() > 0) {
-				// Display Title
+        // Exchange Categories
+        if (element instanceof ExchangeCategory) {
+            ExchangeCategory category = (ExchangeCategory) element;
+            if (category.getExchanges().size() > 0) {
+                // Display Title
 
-				stringBuffer.append(TEXT_5);
+                stringBuffer.append(TEXT_1);
 
-				// Create table header
+                // Create table header
 
-				stringBuffer.append(TEXT_6);
+                stringBuffer.append(TEXT_2);
 
-				// Create each line
-				for (ComponentExchange ce : category.getExchanges()) {
+                // Create each line
+                for (FunctionalExchange fe : category.getExchanges()) {
 
-					stringBuffer.append(TEXT_3);
-					stringBuffer.append(CapellaCategoryServices.edgeToTableLine(ce, projectName, outputFolder));
-					stringBuffer.append(TEXT_3);
+                    stringBuffer.append(TEXT_3);
+                    stringBuffer.append(CapellaCategoryServices.edgeToTableLine(fe, projectName, outputFolder));
+                    stringBuffer.append(TEXT_3);
 
-				}
-				// Create table footer
+                }
+                // Create table footer
 
-				stringBuffer.append(TEXT_4);
+                stringBuffer.append(TEXT_4);
 
-			}
-		}
+            }
+        }
 
-		// Physical Link Categories
-		if (element instanceof PhysicalLinkCategory) {
-			PhysicalLinkCategory category = (PhysicalLinkCategory) element;
-			if (category.getLinks().size() > 0) {
-				// Display Title
+        // Component Exchange Categories
+        if (element instanceof ComponentExchangeCategory) {
+            ComponentExchangeCategory category = (ComponentExchangeCategory) element;
+            if (category.getExchanges().size() > 0) {
+                // Display Title
 
-				stringBuffer.append(TEXT_7);
+                stringBuffer.append(TEXT_5);
 
-				// Create table header
+                // Create table header
 
-				stringBuffer.append(TEXT_8);
+                stringBuffer.append(TEXT_6);
 
-				// Create each line
-				for (PhysicalLink pl : category.getLinks()) {
+                // Create each line
+                for (ComponentExchange ce : category.getExchanges()) {
 
-					stringBuffer.append(TEXT_3);
-					stringBuffer.append(CapellaCategoryServices.edgeToTableLine(pl, projectName, outputFolder));
-					stringBuffer.append(TEXT_3);
+                    stringBuffer.append(TEXT_3);
+                    stringBuffer.append(CapellaCategoryServices.edgeToTableLine(ce, projectName, outputFolder));
+                    stringBuffer.append(TEXT_3);
 
-				}
-				// Create table footer
+                }
+                // Create table footer
 
-				stringBuffer.append(TEXT_4);
+                stringBuffer.append(TEXT_4);
 
-			}
-		}
+            }
+        }
 
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
-	}
+        // Physical Link Categories
+        if (element instanceof PhysicalLinkCategory) {
+            PhysicalLinkCategory category = (PhysicalLinkCategory) element;
+            if (category.getLinks().size() > 0) {
+                // Display Title
 
-	public boolean preCondition(PatternContext ctx) throws Exception {
-		return parameter instanceof ExchangeCategory || parameter instanceof ComponentExchangeCategory
-				|| parameter instanceof PhysicalLinkCategory;
-	}
+                stringBuffer.append(TEXT_7);
+
+                // Create table header
+
+                stringBuffer.append(TEXT_8);
+
+                // Create each line
+                for (PhysicalLink pl : category.getLinks()) {
+
+                    stringBuffer.append(TEXT_3);
+                    stringBuffer.append(CapellaCategoryServices.edgeToTableLine(pl, projectName, outputFolder));
+                    stringBuffer.append(TEXT_3);
+
+                }
+                // Create table footer
+
+                stringBuffer.append(TEXT_4);
+
+            }
+        }
+
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
+    }
+
+    public boolean preCondition(PatternContext ctx) throws Exception {
+        return parameter instanceof ExchangeCategory || parameter instanceof ComponentExchangeCategory || parameter instanceof PhysicalLinkCategory;
+    }
 }

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/ClassDocGen.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/ClassDocGen.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.1.201906060805
+//Generated with EGF 1.6.3.202110291409
 package org.polarsys.capella.docgen.content;
 
 import org.eclipse.egf.common.helper.*;
@@ -15,269 +15,270 @@ import org.polarsys.capella.core.data.capellacore.VisibilityKind;
 import org.polarsys.capella.core.data.information.Class;
 
 public class ClassDocGen extends org.polarsys.capella.docgen.content.ClassifierDocGen {
-	protected static String nl;
+    protected static String nl;
 
-	public static synchronized ClassDocGen create(String lineSeparator) {
-		nl = lineSeparator;
-		ClassDocGen result = new ClassDocGen();
-		nl = null;
-		return result;
-	}
+    public static synchronized ClassDocGen create(String lineSeparator) {
+        nl = lineSeparator;
+        ClassDocGen result = new ClassDocGen();
+        nl = null;
+        return result;
+    }
 
-	public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
-	protected final String TEXT_1 = "";
-	protected final String TEXT_2 = NL + "<div title=\"Features\">";
-	protected final String TEXT_3 = NL;
-	protected final String TEXT_4 = NL + "</div>";
-	protected final String TEXT_5 = NL + "<div title=\"Realisation\">";
-	protected final String TEXT_6 = NL + "<div title=\"Properties\">";
-	protected final String TEXT_7 = NL + " ";
-	protected final String TEXT_8 = NL + " <div title=\"Operations\">";
-	protected final String TEXT_9 = NL + "<div title=\"Data Values\">";
-	protected final String TEXT_10 = NL + "<h2>Part Of</h2>";
-	protected final String TEXT_11 = NL + "<h2>Referenced By</h2>";
-	protected final String TEXT_12 = NL + "<h2>Parameter Of</h2>";
+    public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
 
-	public ClassDocGen() {
-		//Here is the constructor
-		StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_1 = "";
 
-		// add initialisation of the pattern variables (declaration has been already done).
+    protected final String TEXT_2 = NL + "<div title=\"Features\">";
 
-	}
+    protected final String TEXT_3 = NL;
 
-	public String generate(Object argument) throws Exception {
-		final StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_4 = NL + "</div>";
 
-		InternalPatternContext ctx = (InternalPatternContext) argument;
-		Map<String, String> queryCtx = null;
-		IQuery.ParameterDescription paramDesc = null;
-		Node.Container currentNode = ctx.getNode();
+    protected final String TEXT_5 = NL + "<div title=\"Realisation\">";
 
-		List<Object> parameterList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
+    protected final String TEXT_6 = NL + "<div title=\"Properties\">";
 
-		for (Object parameterParameter : parameterList) {
+    protected final String TEXT_7 = NL + " ";
 
-			this.parameter = (org.polarsys.capella.core.data.capellacore.GeneralizableElement) parameterParameter;
+    protected final String TEXT_8 = NL + " <div title=\"Operations\">";
 
-			if (preCondition(ctx)) {
-				ctx.setNode(new Node.Container(currentNode, getClass()));
-				orchestration(ctx);
-			}
+    protected final String TEXT_9 = NL + "<div title=\"Data Values\">";
 
-		}
-		ctx.setNode(currentNode);
-		if (ctx.useReporter()) {
-			ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
-		}
+    protected final String TEXT_10 = NL + "<h2>Part Of</h2>";
 
-		stringBuffer.append(TEXT_3);
-		stringBuffer.append(TEXT_3);
-		return stringBuffer.toString();
-	}
+    protected final String TEXT_11 = NL + "<h2>Referenced By</h2>";
 
-	public String orchestration(PatternContext ctx) throws Exception {
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
+    protected final String TEXT_12 = NL + "<h2>Parameter Of</h2>";
 
-		super.orchestration(new SuperOrchestrationContext(ictx));
+    public ClassDocGen() {
+        //Here is the constructor
+        StringBuffer stringBuffer = new StringBuffer();
 
-		if (ictx.useReporter()) {
-			Map<String, Object> parameterValues = new HashMap<String, Object>();
-			parameterValues.put("parameter", this.parameter);
-			String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
-			String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
-			ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
-		}
-		return null;
-	}
+        // add initialisation of the pattern variables (declaration has been already done).
 
-	public Map<String, Object> getParameters() {
-		final Map<String, Object> parameters = new HashMap<String, Object>();
-		parameters.put("parameter", this.parameter);
-		return parameters;
-	}
+    }
 
-	protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+    public String generate(Object argument) throws Exception {
+        final StringBuffer stringBuffer = new StringBuffer();
 
-		super.method_content(new StringBuffer(), ctx);
-		String projectName = ctx.getValue("projectName").toString();
-		String outputFolder = ctx.getValue("outputFolder").toString();
+        InternalPatternContext ctx = (InternalPatternContext) argument;
+        Map<String, String> queryCtx = null;
+        IQuery.ParameterDescription paramDesc = null;
+        Node.Container currentNode = ctx.getNode();
 
-		stringBuffer.append(TEXT_1);
-		if (CapellaClassServices.getClassFeatures(element).size() >= 1) {
-			stringBuffer.append(TEXT_2);
-			String features = "Features";
-			stringBuffer.append(TEXT_3);
-			{
-				//<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#LogicalName=org.polarsys.kitalpha.doc.gen.business.core.generic.ElementGenerateByPropterty" args="element:eObject,features:property"%>
+        List<Object> parameterList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
 
-				InternalPatternContext ictx = (InternalPatternContext) ctx;
-				new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
-				stringBuffer.setLength(0);
+        for (Object parameterParameter : parameterList) {
 
-				final Map<String, Object> callParameters = new HashMap<String, Object>();
-				callParameters.put("eObject", element);
-				callParameters.put("property", features);
-				CallHelper.executeWithParameterInjection(
-						"platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#_cWGxMONUEd-euK0PeLuaMA",
-						new ExecutionContext((InternalPatternContext) ctx), callParameters);
-				stringBuffer.setLength(0);
-			}
+            this.parameter = (org.polarsys.capella.core.data.capellacore.GeneralizableElement) parameterParameter;
 
-			stringBuffer.append(TEXT_3);
-			stringBuffer.append(StringUtil.stringListToBulette(CapellaClassServices.getClassFeatures(element)));
-			stringBuffer.append(TEXT_4);
-		}
-		stringBuffer.append(TEXT_3);
-		if (CapellaClassServices.getClassRealizeInformation(element).size() >= 1) {
-			stringBuffer.append(TEXT_5);
-			String realisation = "Realisation";
-			stringBuffer.append(TEXT_3);
-			{
-				//<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#LogicalName=org.polarsys.kitalpha.doc.gen.business.core.generic.ElementGenerateByPropterty" args="element:eObject,realisation:property"%>
+            if (preCondition(ctx)) {
+                ctx.setNode(new Node.Container(currentNode, getClass()));
+                orchestration(ctx);
+            }
 
-				InternalPatternContext ictx = (InternalPatternContext) ctx;
-				new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
-				stringBuffer.setLength(0);
+        }
+        ctx.setNode(currentNode);
+        if (ctx.useReporter()) {
+            ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
+        }
 
-				final Map<String, Object> callParameters = new HashMap<String, Object>();
-				callParameters.put("eObject", element);
-				callParameters.put("property", realisation);
-				CallHelper.executeWithParameterInjection(
-						"platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#_cWGxMONUEd-euK0PeLuaMA",
-						new ExecutionContext((InternalPatternContext) ctx), callParameters);
-				stringBuffer.setLength(0);
-			}
+        stringBuffer.append(TEXT_3);
+        stringBuffer.append(TEXT_3);
+        return stringBuffer.toString();
+    }
 
-			stringBuffer.append(TEXT_3);
-			stringBuffer
-					.append(StringUtil.stringListToBulette(CapellaClassServices.getClassRealizeInformation(element)));
-			stringBuffer.append(TEXT_4);
-		}
-		stringBuffer.append(TEXT_3);
+    public String orchestration(PatternContext ctx) throws Exception {
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
 
-		Collection<String> propertiesCollection = CapellaClassServices.getClassProperties(element, projectName,
-				outputFolder);
-		if (propertiesCollection.size() >= 1) {
-			stringBuffer.append(TEXT_6);
-			String properties = "Properties";
-			stringBuffer.append(TEXT_3);
-			{
-				//<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#LogicalName=org.polarsys.kitalpha.doc.gen.business.core.generic.ElementGenerateByPropterty" args="element:eObject,properties:property"%>
+        super.orchestration(new SuperOrchestrationContext(ictx));
 
-				InternalPatternContext ictx = (InternalPatternContext) ctx;
-				new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
-				stringBuffer.setLength(0);
+        if (ictx.useReporter()) {
+            Map<String, Object> parameterValues = new HashMap<String, Object>();
+            parameterValues.put("parameter", this.parameter);
+            String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
+            String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
+            ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
+        }
+        return null;
+    }
 
-				final Map<String, Object> callParameters = new HashMap<String, Object>();
-				callParameters.put("eObject", element);
-				callParameters.put("property", properties);
-				CallHelper.executeWithParameterInjection(
-						"platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#_cWGxMONUEd-euK0PeLuaMA",
-						new ExecutionContext((InternalPatternContext) ctx), callParameters);
-				stringBuffer.setLength(0);
-			}
+    public Map<String, Object> getParameters() {
+        final Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("parameter", this.parameter);
+        return parameters;
+    }
 
-			stringBuffer.append(TEXT_3);
-			stringBuffer.append(StringUtil.stringListToBulette(propertiesCollection));
-			stringBuffer.append(TEXT_4);
-		}
-		stringBuffer.append(TEXT_7);
-		if (CapellaClassServices.getClassOperation(element).size() > 0) {
-			stringBuffer.append(TEXT_8);
-			String operation = "Operations";
-			stringBuffer.append(TEXT_3);
-			{
-				//<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#LogicalName=org.polarsys.kitalpha.doc.gen.business.core.generic.ElementGenerateByPropterty" args="element:eObject,operation:property"%>
+    protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-				InternalPatternContext ictx = (InternalPatternContext) ctx;
-				new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
-				stringBuffer.setLength(0);
+        super.method_content(new StringBuffer(), ctx);
+        String projectName = ctx.getValue("projectName").toString();
+        String outputFolder = ctx.getValue("outputFolder").toString();
 
-				final Map<String, Object> callParameters = new HashMap<String, Object>();
-				callParameters.put("eObject", element);
-				callParameters.put("property", operation);
-				CallHelper.executeWithParameterInjection(
-						"platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#_cWGxMONUEd-euK0PeLuaMA",
-						new ExecutionContext((InternalPatternContext) ctx), callParameters);
-				stringBuffer.setLength(0);
-			}
+        stringBuffer.append(TEXT_1);
+        if (CapellaClassServices.getClassFeatures(element).size() >= 1) {
+            stringBuffer.append(TEXT_2);
+            String features = "Features";
+            stringBuffer.append(TEXT_3);
+            {
+                //<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#LogicalName=org.polarsys.kitalpha.doc.gen.business.core.generic.ElementGenerateByPropterty" args="element:eObject,features:property"%>
 
-			stringBuffer.append(TEXT_3);
-			stringBuffer.append(StringUtil.stringListToBulette(CapellaClassServices.getClassOperation(element)));
-			stringBuffer.append(TEXT_4);
-		}
-		stringBuffer.append(TEXT_3);
+                InternalPatternContext ictx = (InternalPatternContext) ctx;
+                new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
+                stringBuffer.setLength(0);
 
-		Collection<String> dataValuesCollection = CapellaClassServices.getClassDataValues(element, projectName,
-				outputFolder);
-		if (dataValuesCollection.size() >= 1) {
-			stringBuffer.append(TEXT_9);
-			String dataValue = "Data Values";
-			stringBuffer.append(TEXT_3);
-			{
-				//<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#LogicalName=org.polarsys.kitalpha.doc.gen.business.core.generic.ElementGenerateByPropterty" args="element:eObject,dataValue:property"%>
+                final Map<String, Object> callParameters = new HashMap<String, Object>();
+                callParameters.put("eObject", element);
+                callParameters.put("property", features);
+                CallHelper.executeWithParameterInjection("platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#_cWGxMONUEd-euK0PeLuaMA",
+                        new ExecutionContext((InternalPatternContext) ctx), callParameters);
+                stringBuffer.setLength(0);
+            }
 
-				InternalPatternContext ictx = (InternalPatternContext) ctx;
-				new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
-				stringBuffer.setLength(0);
+            stringBuffer.append(TEXT_3);
+            stringBuffer.append(StringUtil.stringListToBulette(CapellaClassServices.getClassFeatures(element)));
+            stringBuffer.append(TEXT_4);
+        }
+        stringBuffer.append(TEXT_3);
+        if (CapellaClassServices.getClassRealizeInformation(element).size() >= 1) {
+            stringBuffer.append(TEXT_5);
+            String realisation = "Realisation";
+            stringBuffer.append(TEXT_3);
+            {
+                //<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#LogicalName=org.polarsys.kitalpha.doc.gen.business.core.generic.ElementGenerateByPropterty" args="element:eObject,realisation:property"%>
 
-				final Map<String, Object> callParameters = new HashMap<String, Object>();
-				callParameters.put("eObject", element);
-				callParameters.put("property", dataValue);
-				CallHelper.executeWithParameterInjection(
-						"platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#_cWGxMONUEd-euK0PeLuaMA",
-						new ExecutionContext((InternalPatternContext) ctx), callParameters);
-				stringBuffer.setLength(0);
-			}
+                InternalPatternContext ictx = (InternalPatternContext) ctx;
+                new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
+                stringBuffer.setLength(0);
 
-			stringBuffer.append(TEXT_3);
-			stringBuffer.append(StringUtil.stringListToBulette(dataValuesCollection));
-			stringBuffer.append(TEXT_4);
-		}
-		stringBuffer.append(TEXT_3);
-		Collection<String> partofCollection = CapellaClassServices.getPartOf((Class) element, projectName,
-				outputFolder);
-		if (partofCollection.size() > 0) {
-			stringBuffer.append(TEXT_10);
-			stringBuffer.append(TEXT_3);
-			stringBuffer.append(StringUtil.stringListToBulette(partofCollection));
-		}
+                final Map<String, Object> callParameters = new HashMap<String, Object>();
+                callParameters.put("eObject", element);
+                callParameters.put("property", realisation);
+                CallHelper.executeWithParameterInjection("platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#_cWGxMONUEd-euK0PeLuaMA",
+                        new ExecutionContext((InternalPatternContext) ctx), callParameters);
+                stringBuffer.setLength(0);
+            }
 
-		Collection<String> referencedByCollection = CapellaClassServices.getReferencedBy((Class) element, projectName,
-				outputFolder);
-		if (referencedByCollection.size() > 0) {
-			stringBuffer.append(TEXT_11);
-			stringBuffer.append(TEXT_3);
-			stringBuffer.append(StringUtil.stringListToBulette(referencedByCollection));
-		}
+            stringBuffer.append(TEXT_3);
+            stringBuffer.append(StringUtil.stringListToBulette(CapellaClassServices.getClassRealizeInformation(element)));
+            stringBuffer.append(TEXT_4);
+        }
+        stringBuffer.append(TEXT_3);
 
-		Collection<String> parameterOfCollection = CapellaClassServices.getParameterOf((Class) element, projectName,
-				outputFolder);
-		if (parameterOfCollection.size() > 0) {
-			stringBuffer.append(TEXT_12);
-			stringBuffer.append(TEXT_3);
-			stringBuffer.append(StringUtil.stringListToBulette(parameterOfCollection));
-		}
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
-	}
+        Collection<String> propertiesCollection = CapellaClassServices.getClassProperties(element, projectName, outputFolder);
+        if (propertiesCollection.size() >= 1) {
+            stringBuffer.append(TEXT_6);
+            String properties = "Properties";
+            stringBuffer.append(TEXT_3);
+            {
+                //<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#LogicalName=org.polarsys.kitalpha.doc.gen.business.core.generic.ElementGenerateByPropterty" args="element:eObject,properties:property"%>
 
-	protected void method_setTitle(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+                InternalPatternContext ictx = (InternalPatternContext) ctx;
+                new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
+                stringBuffer.setLength(0);
 
-		String visibility = "";
-		if (((Class) element).getVisibility().getValue() != VisibilityKind.UNSET_VALUE)
-			visibility = "{" + ((Class) element).getVisibility().getLiteral().toLowerCase() + "} ";
-		String type = element.eClass().getName();
-		String elementFullName = CapellaServices.getHyperlinkFromElement(element);
-		documentTitle = "<span class=\"elementMetaClass\">" + visibility + "</span> " + elementFullName;
+                final Map<String, Object> callParameters = new HashMap<String, Object>();
+                callParameters.put("eObject", element);
+                callParameters.put("property", properties);
+                CallHelper.executeWithParameterInjection("platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#_cWGxMONUEd-euK0PeLuaMA",
+                        new ExecutionContext((InternalPatternContext) ctx), callParameters);
+                stringBuffer.setLength(0);
+            }
 
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "setTitle", stringBuffer.toString());
-	}
+            stringBuffer.append(TEXT_3);
+            stringBuffer.append(StringUtil.stringListToBulette(propertiesCollection));
+            stringBuffer.append(TEXT_4);
+        }
+        stringBuffer.append(TEXT_7);
+        if (CapellaClassServices.getClassOperation(element).size() > 0) {
+            stringBuffer.append(TEXT_8);
+            String operation = "Operations";
+            stringBuffer.append(TEXT_3);
+            {
+                //<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#LogicalName=org.polarsys.kitalpha.doc.gen.business.core.generic.ElementGenerateByPropterty" args="element:eObject,operation:property"%>
 
-	public boolean preCondition(PatternContext ctx) throws Exception {
-		return (this.parameter instanceof Class);
-	}
+                InternalPatternContext ictx = (InternalPatternContext) ctx;
+                new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
+                stringBuffer.setLength(0);
+
+                final Map<String, Object> callParameters = new HashMap<String, Object>();
+                callParameters.put("eObject", element);
+                callParameters.put("property", operation);
+                CallHelper.executeWithParameterInjection("platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#_cWGxMONUEd-euK0PeLuaMA",
+                        new ExecutionContext((InternalPatternContext) ctx), callParameters);
+                stringBuffer.setLength(0);
+            }
+
+            stringBuffer.append(TEXT_3);
+            stringBuffer.append(StringUtil.stringListToBulette(CapellaClassServices.getClassOperation(element)));
+            stringBuffer.append(TEXT_4);
+        }
+        stringBuffer.append(TEXT_3);
+
+        Collection<String> dataValuesCollection = CapellaClassServices.getClassDataValues(element, projectName, outputFolder);
+        if (dataValuesCollection.size() >= 1) {
+            stringBuffer.append(TEXT_9);
+            String dataValue = "Data Values";
+            stringBuffer.append(TEXT_3);
+            {
+                //<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#LogicalName=org.polarsys.kitalpha.doc.gen.business.core.generic.ElementGenerateByPropterty" args="element:eObject,dataValue:property"%>
+
+                InternalPatternContext ictx = (InternalPatternContext) ctx;
+                new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
+                stringBuffer.setLength(0);
+
+                final Map<String, Object> callParameters = new HashMap<String, Object>();
+                callParameters.put("eObject", element);
+                callParameters.put("property", dataValue);
+                CallHelper.executeWithParameterInjection("platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#_cWGxMONUEd-euK0PeLuaMA",
+                        new ExecutionContext((InternalPatternContext) ctx), callParameters);
+                stringBuffer.setLength(0);
+            }
+
+            stringBuffer.append(TEXT_3);
+            stringBuffer.append(StringUtil.stringListToBulette(dataValuesCollection));
+            stringBuffer.append(TEXT_4);
+        }
+        stringBuffer.append(TEXT_3);
+        Collection<String> partofCollection = CapellaClassServices.getPartOf((Class) element, projectName, outputFolder);
+        if (partofCollection.size() > 0) {
+            stringBuffer.append(TEXT_10);
+            stringBuffer.append(TEXT_3);
+            stringBuffer.append(StringUtil.stringListToBulette(partofCollection));
+        }
+
+        Collection<String> referencedByCollection = CapellaClassServices.getReferencedBy((Class) element, projectName, outputFolder);
+        if (referencedByCollection.size() > 0) {
+            stringBuffer.append(TEXT_11);
+            stringBuffer.append(TEXT_3);
+            stringBuffer.append(StringUtil.stringListToBulette(referencedByCollection));
+        }
+
+        Collection<String> parameterOfCollection = CapellaClassServices.getParameterOf((Class) element, projectName, outputFolder);
+        if (parameterOfCollection.size() > 0) {
+            stringBuffer.append(TEXT_12);
+            stringBuffer.append(TEXT_3);
+            stringBuffer.append(StringUtil.stringListToBulette(parameterOfCollection));
+        }
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
+    }
+
+    protected void method_setTitle(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+
+        String visibility = "";
+        if (((Class) element).getVisibility().getValue() != VisibilityKind.UNSET_VALUE)
+            visibility = "{" + ((Class) element).getVisibility().getLiteral().toLowerCase() + "} ";
+        String type = element.eClass().getName();
+        String elementFullName = CapellaServices.getHyperlinkFromElement(element);
+        documentTitle = "<span class=\"elementMetaClass\">" + visibility + "</span> " + elementFullName;
+
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "setTitle", stringBuffer.toString());
+    }
+
+    public boolean preCondition(PatternContext ctx) throws Exception {
+        return (this.parameter instanceof Class);
+    }
 }

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/ClassifierDocGen.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/ClassifierDocGen.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.1.201906060805
+//Generated with EGF 1.6.3.202110291409
 package org.polarsys.capella.docgen.content;
 
 import org.eclipse.egf.common.helper.*;
@@ -10,87 +10,88 @@ import org.eclipse.egf.pattern.query.*;
 import org.polarsys.capella.core.data.capellacore.Classifier;
 
 public class ClassifierDocGen extends org.polarsys.capella.docgen.content.GeneralizableElementDocGen {
-	protected static String nl;
+    protected static String nl;
 
-	public static synchronized ClassifierDocGen create(String lineSeparator) {
-		nl = lineSeparator;
-		ClassifierDocGen result = new ClassifierDocGen();
-		nl = null;
-		return result;
-	}
+    public static synchronized ClassifierDocGen create(String lineSeparator) {
+        nl = lineSeparator;
+        ClassifierDocGen result = new ClassifierDocGen();
+        nl = null;
+        return result;
+    }
 
-	public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
-	protected final String TEXT_1 = NL;
+    public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
 
-	public ClassifierDocGen() {
-		//Here is the constructor
-		StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_1 = NL;
 
-		// add initialisation of the pattern variables (declaration has been already done).
+    public ClassifierDocGen() {
+        //Here is the constructor
+        StringBuffer stringBuffer = new StringBuffer();
 
-	}
+        // add initialisation of the pattern variables (declaration has been already done).
 
-	public String generate(Object argument) throws Exception {
-		final StringBuffer stringBuffer = new StringBuffer();
+    }
 
-		InternalPatternContext ctx = (InternalPatternContext) argument;
-		Map<String, String> queryCtx = null;
-		IQuery.ParameterDescription paramDesc = null;
-		Node.Container currentNode = ctx.getNode();
+    public String generate(Object argument) throws Exception {
+        final StringBuffer stringBuffer = new StringBuffer();
 
-		List<Object> parameterList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
+        InternalPatternContext ctx = (InternalPatternContext) argument;
+        Map<String, String> queryCtx = null;
+        IQuery.ParameterDescription paramDesc = null;
+        Node.Container currentNode = ctx.getNode();
 
-		for (Object parameterParameter : parameterList) {
+        List<Object> parameterList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
 
-			this.parameter = (org.polarsys.capella.core.data.capellacore.GeneralizableElement) parameterParameter;
+        for (Object parameterParameter : parameterList) {
 
-			if (preCondition(ctx)) {
-				ctx.setNode(new Node.Container(currentNode, getClass()));
-				orchestration(ctx);
-			}
+            this.parameter = (org.polarsys.capella.core.data.capellacore.GeneralizableElement) parameterParameter;
 
-		}
-		ctx.setNode(currentNode);
-		if (ctx.useReporter()) {
-			ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
-		}
+            if (preCondition(ctx)) {
+                ctx.setNode(new Node.Container(currentNode, getClass()));
+                orchestration(ctx);
+            }
 
-		stringBuffer.append(TEXT_1);
-		stringBuffer.append(TEXT_1);
-		return stringBuffer.toString();
-	}
+        }
+        ctx.setNode(currentNode);
+        if (ctx.useReporter()) {
+            ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
+        }
 
-	public String orchestration(PatternContext ctx) throws Exception {
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
+        stringBuffer.append(TEXT_1);
+        stringBuffer.append(TEXT_1);
+        return stringBuffer.toString();
+    }
 
-		super.orchestration(new SuperOrchestrationContext(ictx));
+    public String orchestration(PatternContext ctx) throws Exception {
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
 
-		if (ictx.useReporter()) {
-			Map<String, Object> parameterValues = new HashMap<String, Object>();
-			parameterValues.put("parameter", this.parameter);
-			String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
-			String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
-			ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
-		}
-		return null;
-	}
+        super.orchestration(new SuperOrchestrationContext(ictx));
 
-	public Map<String, Object> getParameters() {
-		final Map<String, Object> parameters = new HashMap<String, Object>();
-		parameters.put("parameter", this.parameter);
-		return parameters;
-	}
+        if (ictx.useReporter()) {
+            Map<String, Object> parameterValues = new HashMap<String, Object>();
+            parameterValues.put("parameter", this.parameter);
+            String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
+            String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
+            ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
+        }
+        return null;
+    }
 
-	protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+    public Map<String, Object> getParameters() {
+        final Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("parameter", this.parameter);
+        return parameters;
+    }
 
-		super.method_content(new StringBuffer(), ctx);
-		stringBuffer.append(TEXT_1);
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
-	}
+    protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-	public boolean preCondition(PatternContext ctx) throws Exception {
-		return (this.parameter instanceof Classifier);
-	}
+        super.method_content(new StringBuffer(), ctx);
+        stringBuffer.append(TEXT_1);
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
+    }
+
+    public boolean preCondition(PatternContext ctx) throws Exception {
+        return (this.parameter instanceof Classifier);
+    }
 }

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/CollectionDocGen.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/CollectionDocGen.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.1.201906060805
+//Generated with EGF 1.6.3.202110291409
 package org.polarsys.capella.docgen.content;
 
 import org.eclipse.egf.common.helper.*;
@@ -16,233 +16,226 @@ import org.polarsys.capella.docgen.util.StringUtil;
 import org.polarsys.capella.core.data.capellacore.Type;
 
 public class CollectionDocGen extends org.polarsys.capella.docgen.content.ClassifierDocGen {
-	protected static String nl;
+    protected static String nl;
 
-	public static synchronized CollectionDocGen create(String lineSeparator) {
-		nl = lineSeparator;
-		CollectionDocGen result = new CollectionDocGen();
-		nl = null;
-		return result;
-	}
+    public static synchronized CollectionDocGen create(String lineSeparator) {
+        nl = lineSeparator;
+        CollectionDocGen result = new CollectionDocGen();
+        nl = null;
+        return result;
+    }
 
-	public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
-	protected final String TEXT_1 = "";
-	protected final String TEXT_2 = NL + "<div title=\"Element\">";
-	protected final String TEXT_3 = NL;
-	protected final String TEXT_4 = NL + "</div>";
-	protected final String TEXT_5 = NL + "<div title=\"Indexed By\">";
-	protected final String TEXT_6 = NL + "<div title=\"Features\">";
-	protected final String TEXT_7 = NL + "<div title=\"Data Values\">";
+    public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
 
-	public CollectionDocGen() {
-		//Here is the constructor
-		StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_1 = "";
 
-		// add initialisation of the pattern variables (declaration has been already done).
+    protected final String TEXT_2 = NL + "<div title=\"Element\">";
 
-	}
+    protected final String TEXT_3 = NL;
 
-	public String generate(Object argument) throws Exception {
-		final StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_4 = NL + "</div>";
 
-		InternalPatternContext ctx = (InternalPatternContext) argument;
-		Map<String, String> queryCtx = null;
-		IQuery.ParameterDescription paramDesc = null;
-		Node.Container currentNode = ctx.getNode();
+    protected final String TEXT_5 = NL + "<div title=\"Indexed By\">";
 
-		List<Object> parameterList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
+    protected final String TEXT_6 = NL + "<div title=\"Features\">";
 
-		for (Object parameterParameter : parameterList) {
+    protected final String TEXT_7 = NL + "<div title=\"Data Values\">";
 
-			this.parameter = (org.polarsys.capella.core.data.capellacore.GeneralizableElement) parameterParameter;
+    public CollectionDocGen() {
+        //Here is the constructor
+        StringBuffer stringBuffer = new StringBuffer();
 
-			if (preCondition(ctx)) {
-				ctx.setNode(new Node.Container(currentNode, getClass()));
-				orchestration(ctx);
-			}
+        // add initialisation of the pattern variables (declaration has been already done).
 
-		}
-		ctx.setNode(currentNode);
-		if (ctx.useReporter()) {
-			ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
-		}
+    }
 
-		stringBuffer.append(TEXT_3);
-		stringBuffer.append(TEXT_3);
-		return stringBuffer.toString();
-	}
+    public String generate(Object argument) throws Exception {
+        final StringBuffer stringBuffer = new StringBuffer();
 
-	public String orchestration(PatternContext ctx) throws Exception {
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
+        InternalPatternContext ctx = (InternalPatternContext) argument;
+        Map<String, String> queryCtx = null;
+        IQuery.ParameterDescription paramDesc = null;
+        Node.Container currentNode = ctx.getNode();
 
-		super.orchestration(new SuperOrchestrationContext(ictx));
+        List<Object> parameterList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
 
-		if (ictx.useReporter()) {
-			Map<String, Object> parameterValues = new HashMap<String, Object>();
-			parameterValues.put("parameter", this.parameter);
-			String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
-			String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
-			ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
-		}
-		return null;
-	}
+        for (Object parameterParameter : parameterList) {
 
-	public Map<String, Object> getParameters() {
-		final Map<String, Object> parameters = new HashMap<String, Object>();
-		parameters.put("parameter", this.parameter);
-		return parameters;
-	}
+            this.parameter = (org.polarsys.capella.core.data.capellacore.GeneralizableElement) parameterParameter;
 
-	protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+            if (preCondition(ctx)) {
+                ctx.setNode(new Node.Container(currentNode, getClass()));
+                orchestration(ctx);
+            }
 
-		super.method_content(new StringBuffer(), ctx);
-		String projectName = ctx.getValue("projectName").toString();
-		String outputFolder = ctx.getValue("outputFolder").toString();
+        }
+        ctx.setNode(currentNode);
+        if (ctx.useReporter()) {
+            ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
+        }
 
-		stringBuffer.append(TEXT_1);
-		if (CapellaCollectionService.getCollectionElements(element).size() >= 1) {
-			stringBuffer.append(TEXT_2);
-			String elem = "Element";
-			stringBuffer.append(TEXT_3);
-			{
-				//<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#LogicalName=org.polarsys.kitalpha.doc.gen.business.core.generic.ElementGenerateByPropterty" args="element:eObject,elem:property"%>
+        stringBuffer.append(TEXT_3);
+        stringBuffer.append(TEXT_3);
+        return stringBuffer.toString();
+    }
 
-				InternalPatternContext ictx = (InternalPatternContext) ctx;
-				new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
-				stringBuffer.setLength(0);
+    public String orchestration(PatternContext ctx) throws Exception {
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
 
-				final Map<String, Object> callParameters = new HashMap<String, Object>();
-				callParameters.put("eObject", element);
-				callParameters.put("property", elem);
-				CallHelper.executeWithParameterInjection(
-						"platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#_cWGxMONUEd-euK0PeLuaMA",
-						new ExecutionContext((InternalPatternContext) ctx), callParameters);
-				stringBuffer.setLength(0);
-			}
+        super.orchestration(new SuperOrchestrationContext(ictx));
 
-			stringBuffer.append(TEXT_3);
-			stringBuffer
-					.append(StringUtil.stringListToBulette(CapellaCollectionService.getCollectionElements(element)));
-			stringBuffer.append(TEXT_4);
-		}
+        if (ictx.useReporter()) {
+            Map<String, Object> parameterValues = new HashMap<String, Object>();
+            parameterValues.put("parameter", this.parameter);
+            String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
+            String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
+            ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
+        }
+        return null;
+    }
 
-		Collection<String> indexedByCollection = CapellaCollectionService.getIndexedBy(
-				(org.polarsys.capella.core.data.information.Collection) element, projectName, outputFolder);
-		if (indexedByCollection.size() >= 1) {
-			stringBuffer.append(TEXT_5);
-			String propertyValue = "Index";
-			stringBuffer.append(TEXT_3);
-			{
-				//<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#LogicalName=org.polarsys.kitalpha.doc.gen.business.core.generic.ElementGenerateByPropterty" args="element:eObject,propertyValue:property"%>
+    public Map<String, Object> getParameters() {
+        final Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("parameter", this.parameter);
+        return parameters;
+    }
 
-				InternalPatternContext ictx = (InternalPatternContext) ctx;
-				new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
-				stringBuffer.setLength(0);
+    protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-				final Map<String, Object> callParameters = new HashMap<String, Object>();
-				callParameters.put("eObject", element);
-				callParameters.put("property", propertyValue);
-				CallHelper.executeWithParameterInjection(
-						"platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#_cWGxMONUEd-euK0PeLuaMA",
-						new ExecutionContext((InternalPatternContext) ctx), callParameters);
-				stringBuffer.setLength(0);
-			}
+        super.method_content(new StringBuffer(), ctx);
+        String projectName = ctx.getValue("projectName").toString();
+        String outputFolder = ctx.getValue("outputFolder").toString();
 
-			stringBuffer.append(TEXT_3);
-			stringBuffer.append(StringUtil.stringListToBulette(indexedByCollection));
-			stringBuffer.append(TEXT_4);
-		}
+        stringBuffer.append(TEXT_1);
+        if (CapellaCollectionService.getCollectionElements(element).size() >= 1) {
+            stringBuffer.append(TEXT_2);
+            String elem = "Element";
+            stringBuffer.append(TEXT_3);
+            {
+                //<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#LogicalName=org.polarsys.kitalpha.doc.gen.business.core.generic.ElementGenerateByPropterty" args="element:eObject,elem:property"%>
 
-		if (CapellaCollectionService.getCollectionFeatures(element).size() >= 1) {
-			stringBuffer.append(TEXT_6);
-			String features = "Features";
-			stringBuffer.append(TEXT_3);
-			{
-				//<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#LogicalName=org.polarsys.kitalpha.doc.gen.business.core.generic.ElementGenerateByPropterty" args="element:eObject,features:property"%>
+                InternalPatternContext ictx = (InternalPatternContext) ctx;
+                new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
+                stringBuffer.setLength(0);
 
-				InternalPatternContext ictx = (InternalPatternContext) ctx;
-				new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
-				stringBuffer.setLength(0);
+                final Map<String, Object> callParameters = new HashMap<String, Object>();
+                callParameters.put("eObject", element);
+                callParameters.put("property", elem);
+                CallHelper.executeWithParameterInjection("platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#_cWGxMONUEd-euK0PeLuaMA",
+                        new ExecutionContext((InternalPatternContext) ctx), callParameters);
+                stringBuffer.setLength(0);
+            }
 
-				final Map<String, Object> callParameters = new HashMap<String, Object>();
-				callParameters.put("eObject", element);
-				callParameters.put("property", features);
-				CallHelper.executeWithParameterInjection(
-						"platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#_cWGxMONUEd-euK0PeLuaMA",
-						new ExecutionContext((InternalPatternContext) ctx), callParameters);
-				stringBuffer.setLength(0);
-			}
+            stringBuffer.append(TEXT_3);
+            stringBuffer.append(StringUtil.stringListToBulette(CapellaCollectionService.getCollectionElements(element)));
+            stringBuffer.append(TEXT_4);
+        }
 
-			stringBuffer.append(TEXT_3);
-			stringBuffer
-					.append(StringUtil.stringListToBulette(CapellaCollectionService.getCollectionFeatures(element)));
-			stringBuffer.append(TEXT_4);
-		}
+        Collection<String> indexedByCollection = CapellaCollectionService.getIndexedBy((org.polarsys.capella.core.data.information.Collection) element, projectName, outputFolder);
+        if (indexedByCollection.size() >= 1) {
+            stringBuffer.append(TEXT_5);
+            String propertyValue = "Index";
+            stringBuffer.append(TEXT_3);
+            {
+                //<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#LogicalName=org.polarsys.kitalpha.doc.gen.business.core.generic.ElementGenerateByPropterty" args="element:eObject,propertyValue:property"%>
 
-		if (DataValuePkgService.getDataValues(element, projectName, outputFolder).size() >= 1) {
-			stringBuffer.append(TEXT_7);
-			String dataValue = "Data Values";
-			stringBuffer.append(TEXT_3);
-			{
-				//<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#LogicalName=org.polarsys.kitalpha.doc.gen.business.core.generic.ElementGenerateByPropterty" args="element:eObject,dataValue:property"%>
+                InternalPatternContext ictx = (InternalPatternContext) ctx;
+                new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
+                stringBuffer.setLength(0);
 
-				InternalPatternContext ictx = (InternalPatternContext) ctx;
-				new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
-				stringBuffer.setLength(0);
+                final Map<String, Object> callParameters = new HashMap<String, Object>();
+                callParameters.put("eObject", element);
+                callParameters.put("property", propertyValue);
+                CallHelper.executeWithParameterInjection("platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#_cWGxMONUEd-euK0PeLuaMA",
+                        new ExecutionContext((InternalPatternContext) ctx), callParameters);
+                stringBuffer.setLength(0);
+            }
 
-				final Map<String, Object> callParameters = new HashMap<String, Object>();
-				callParameters.put("eObject", element);
-				callParameters.put("property", dataValue);
-				CallHelper.executeWithParameterInjection(
-						"platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#_cWGxMONUEd-euK0PeLuaMA",
-						new ExecutionContext((InternalPatternContext) ctx), callParameters);
-				stringBuffer.setLength(0);
-			}
+            stringBuffer.append(TEXT_3);
+            stringBuffer.append(StringUtil.stringListToBulette(indexedByCollection));
+            stringBuffer.append(TEXT_4);
+        }
 
-			stringBuffer.append(TEXT_3);
-			stringBuffer.append(StringUtil
-					.stringListToBulette(DataValuePkgService.getDataValues(element, projectName, outputFolder)));
-			stringBuffer.append(TEXT_4);
-		}
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
-	}
+        if (CapellaCollectionService.getCollectionFeatures(element).size() >= 1) {
+            stringBuffer.append(TEXT_6);
+            String features = "Features";
+            stringBuffer.append(TEXT_3);
+            {
+                //<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#LogicalName=org.polarsys.kitalpha.doc.gen.business.core.generic.ElementGenerateByPropterty" args="element:eObject,features:property"%>
 
-	protected void method_setTitle(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+                InternalPatternContext ictx = (InternalPatternContext) ctx;
+                new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
+                stringBuffer.setLength(0);
 
-		String visibility = "";
-		String aggregation = "";
-		String kind = "";
-		String collectionTypeString = "";
+                final Map<String, Object> callParameters = new HashMap<String, Object>();
+                callParameters.put("eObject", element);
+                callParameters.put("property", features);
+                CallHelper.executeWithParameterInjection("platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#_cWGxMONUEd-euK0PeLuaMA",
+                        new ExecutionContext((InternalPatternContext) ctx), callParameters);
+                stringBuffer.setLength(0);
+            }
 
-		if (((org.polarsys.capella.core.data.information.Collection) element).getVisibility()
-				.getValue() != VisibilityKind.UNSET_VALUE)
-			visibility = "{" + ((org.polarsys.capella.core.data.information.Collection) element).getVisibility()
-					.getLiteral().toLowerCase() + "} ";
+            stringBuffer.append(TEXT_3);
+            stringBuffer.append(StringUtil.stringListToBulette(CapellaCollectionService.getCollectionFeatures(element)));
+            stringBuffer.append(TEXT_4);
+        }
 
-		if (((org.polarsys.capella.core.data.information.Collection) element).getAggregationKind()
-				.getValue() != AggregationKind.UNSET_VALUE)
-			aggregation = "{" + ((org.polarsys.capella.core.data.information.Collection) element).getAggregationKind()
-					.getLiteral().toLowerCase() + "} ";
+        if (DataValuePkgService.getDataValues(element, projectName, outputFolder).size() >= 1) {
+            stringBuffer.append(TEXT_7);
+            String dataValue = "Data Values";
+            stringBuffer.append(TEXT_3);
+            {
+                //<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#LogicalName=org.polarsys.kitalpha.doc.gen.business.core.generic.ElementGenerateByPropterty" args="element:eObject,dataValue:property"%>
 
-		kind = "{"
-				+ ((org.polarsys.capella.core.data.information.Collection) element).getKind().getLiteral().toLowerCase()
-				+ "} ";
+                InternalPatternContext ictx = (InternalPatternContext) ctx;
+                new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
+                stringBuffer.setLength(0);
 
-		Type collectionType = ((org.polarsys.capella.core.data.information.Collection) element).getType();
-		if (collectionType != null)
-			collectionTypeString = " of " + CapellaServices.getFullDataPkgHierarchyLink(collectionType);
+                final Map<String, Object> callParameters = new HashMap<String, Object>();
+                callParameters.put("eObject", element);
+                callParameters.put("property", dataValue);
+                CallHelper.executeWithParameterInjection("platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#_cWGxMONUEd-euK0PeLuaMA",
+                        new ExecutionContext((InternalPatternContext) ctx), callParameters);
+                stringBuffer.setLength(0);
+            }
 
-		String type = element.eClass().getName();
-		String elementFullName = CapellaServices.getHyperlinkFromElement(element);
-		documentTitle = visibility + aggregation + kind + " " + elementFullName + collectionTypeString;
+            stringBuffer.append(TEXT_3);
+            stringBuffer.append(StringUtil.stringListToBulette(DataValuePkgService.getDataValues(element, projectName, outputFolder)));
+            stringBuffer.append(TEXT_4);
+        }
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
+    }
 
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "setTitle", stringBuffer.toString());
-	}
+    protected void method_setTitle(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-	public boolean preCondition(PatternContext ctx) throws Exception {
-		return (this.parameter instanceof org.polarsys.capella.core.data.information.Collection);
-	}
+        String visibility = "";
+        String aggregation = "";
+        String kind = "";
+        String collectionTypeString = "";
+
+        if (((org.polarsys.capella.core.data.information.Collection) element).getVisibility().getValue() != VisibilityKind.UNSET_VALUE)
+            visibility = "{" + ((org.polarsys.capella.core.data.information.Collection) element).getVisibility().getLiteral().toLowerCase() + "} ";
+
+        if (((org.polarsys.capella.core.data.information.Collection) element).getAggregationKind().getValue() != AggregationKind.UNSET_VALUE)
+            aggregation = "{" + ((org.polarsys.capella.core.data.information.Collection) element).getAggregationKind().getLiteral().toLowerCase() + "} ";
+
+        kind = "{" + ((org.polarsys.capella.core.data.information.Collection) element).getKind().getLiteral().toLowerCase() + "} ";
+
+        Type collectionType = ((org.polarsys.capella.core.data.information.Collection) element).getType();
+        if (collectionType != null)
+            collectionTypeString = " of " + CapellaServices.getFullDataPkgHierarchyLink(collectionType);
+
+        String type = element.eClass().getName();
+        String elementFullName = CapellaServices.getHyperlinkFromElement(element);
+        documentTitle = visibility + aggregation + kind + " " + elementFullName + collectionTypeString;
+
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "setTitle", stringBuffer.toString());
+    }
+
+    public boolean preCondition(PatternContext ctx) throws Exception {
+        return (this.parameter instanceof org.polarsys.capella.core.data.information.Collection);
+    }
 }

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/ComponentContentDocGen.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/ComponentContentDocGen.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.2.202001031546
+//Generated with EGF 1.6.3.202110291409
 package org.polarsys.capella.docgen.content;
 
 import org.eclipse.egf.common.helper.*;
@@ -17,272 +17,270 @@ import org.polarsys.capella.docgen.util.CapellaLabelProviderHelper;
 import org.polarsys.capella.core.data.oa.Entity;
 
 public class ComponentContentDocGen {
-	protected static String nl;
+    protected static String nl;
 
-	public static synchronized ComponentContentDocGen create(String lineSeparator) {
-		nl = lineSeparator;
-		ComponentContentDocGen result = new ComponentContentDocGen();
-		nl = null;
-		return result;
-	}
+    public static synchronized ComponentContentDocGen create(String lineSeparator) {
+        nl = lineSeparator;
+        ComponentContentDocGen result = new ComponentContentDocGen();
+        nl = null;
+        return result;
+    }
 
-	public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
-	protected final String TEXT_1 = "<h2>Features</h2>";
-	protected final String TEXT_2 = NL;
-	protected final String TEXT_3 = NL + "\t<h2>Allocated Activites</h2>" + NL + "\t";
-	protected final String TEXT_4 = NL + "<h2>Allocated Functions</h2>";
-	protected final String TEXT_5 = NL + "<h2>Implemented Interfaces</h2>";
-	protected final String TEXT_6 = NL + "<h2>Provided Interfaces</h2>";
-	protected final String TEXT_7 = NL + "<h2>Used Interfaces</h2>";
-	protected final String TEXT_8 = NL + "<h2>Required Interfaces</h2>";
-	protected final String TEXT_9 = NL + "<h2>Incoming Component Exchanges</h2>" + NL + "<table>" + NL + "\t<tr>" + NL
-			+ "\t\t<th>Exchange</th>" + NL + "\t\t<th>Source</th>" + NL + "\t\t<th>Description</th>" + NL
-			+ "\t\t<th>Allocated Functional Exchanges</th>" + NL + "\t\t<th>Allocated Exchange Items</th>" + NL
-			+ "\t\t<th>Realized Component Exchanges</th>" + NL + "\t\t<th>Realizing Component Exchanges</th>" + NL
-			+ "\t</tr>" + NL + "\t";
-	protected final String TEXT_10 = NL + "\t";
-	protected final String TEXT_11 = NL + "</table>";
-	protected final String TEXT_12 = NL + "<h2>Outgoing Component Exchanges</h2>" + NL + "<table>" + NL + "\t<tr>" + NL
-			+ "\t\t<th>Exchange</th>" + NL + "\t\t<th>Target</th>" + NL + "\t\t<th>Description</th>" + NL
-			+ "\t\t<th>Allocated Functional Exchanges</th>" + NL + "\t\t<th>Allocated Exchange Items</th>" + NL
-			+ "\t\t<th>Realized Component Exchanges</th>" + NL + "\t\t<th>Realizing Component Exchanges</th>" + NL
-			+ "\t</tr>" + NL + "\t";
-	protected final String TEXT_13 = NL + "<h2>In/Out Component Exchanges</h2>" + NL + "<table>" + NL + "\t<tr>" + NL
-			+ "\t\t<th>Exchange</th>" + NL + "\t\t<th>Target</th>" + NL + "\t\t<th>Description</th>" + NL
-			+ "\t\t<th>Allocated Functional Exchanges</th>" + NL + "\t\t<th>Allocated Exchange Items</th>" + NL
-			+ "\t\t<th>Realized Component Exchanges</th>" + NL + "\t\t<th>Realizing Component Exchanges</th>" + NL
-			+ "\t</tr>" + NL + "\t";
-	protected final String TEXT_14 = NL + "<h2>Ports</h2>";
-	protected final String TEXT_15 = NL + "<h2>State Machines</h2>";
+    public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
 
-	public ComponentContentDocGen() {
-		//Here is the constructor
-		StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_1 = "<h2>Features</h2>";
 
-		// add initialisation of the pattern variables (declaration has been already done).
+    protected final String TEXT_2 = NL;
 
-	}
+    protected final String TEXT_3 = NL + "\t<h2>Allocated Activites</h2>" + NL + "\t";
 
-	public String generate(Object argument) throws Exception {
-		final StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_4 = NL + "<h2>Allocated Functions</h2>";
 
-		InternalPatternContext ctx = (InternalPatternContext) argument;
-		Map<String, String> queryCtx = null;
-		IQuery.ParameterDescription paramDesc = null;
-		Node.Container currentNode = ctx.getNode();
+    protected final String TEXT_5 = NL + "<h2>Implemented Interfaces</h2>";
 
-		List<Object> elementList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
-		List<Object> projectNameList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
-		List<Object> outputFolderList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
+    protected final String TEXT_6 = NL + "<h2>Provided Interfaces</h2>";
 
-		for (Object elementParameter : elementList) {
-			for (Object projectNameParameter : projectNameList) {
-				for (Object outputFolderParameter : outputFolderList) {
+    protected final String TEXT_7 = NL + "<h2>Used Interfaces</h2>";
 
-					this.element = (org.polarsys.capella.core.data.capellacore.CapellaElement) elementParameter;
-					this.projectName = (java.lang.String) projectNameParameter;
-					this.outputFolder = (java.lang.String) outputFolderParameter;
+    protected final String TEXT_8 = NL + "<h2>Required Interfaces</h2>";
 
-					if (preCondition(ctx)) {
-						ctx.setNode(new Node.Container(currentNode, getClass()));
-						orchestration(ctx);
-					}
+    protected final String TEXT_9 = NL + "<h2>Incoming Component Exchanges</h2>" + NL + "<table>" + NL + "\t<tr>" + NL + "\t\t<th>Exchange</th>" + NL + "\t\t<th>Source</th>" + NL
+            + "\t\t<th>Description</th>" + NL + "\t\t<th>Allocated Functional Exchanges</th>" + NL + "\t\t<th>Allocated Exchange Items</th>" + NL + "\t\t<th>Realized Component Exchanges</th>" + NL
+            + "\t\t<th>Realizing Component Exchanges</th>" + NL + "\t</tr>" + NL + "\t";
 
-				}
-			}
-		}
-		ctx.setNode(currentNode);
-		if (ctx.useReporter()) {
-			ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
-		}
+    protected final String TEXT_10 = NL + "\t";
 
-		stringBuffer.append(TEXT_2);
-		stringBuffer.append(TEXT_2);
-		return stringBuffer.toString();
-	}
+    protected final String TEXT_11 = NL + "</table>";
 
-	public String orchestration(PatternContext ctx) throws Exception {
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
+    protected final String TEXT_12 = NL + "<h2>Outgoing Component Exchanges</h2>" + NL + "<table>" + NL + "\t<tr>" + NL + "\t\t<th>Exchange</th>" + NL + "\t\t<th>Target</th>" + NL
+            + "\t\t<th>Description</th>" + NL + "\t\t<th>Allocated Functional Exchanges</th>" + NL + "\t\t<th>Allocated Exchange Items</th>" + NL + "\t\t<th>Realized Component Exchanges</th>" + NL
+            + "\t\t<th>Realizing Component Exchanges</th>" + NL + "\t</tr>" + NL + "\t";
 
-		method_body(new StringBuffer(), ictx);
+    protected final String TEXT_13 = NL + "<h2>In/Out Component Exchanges</h2>" + NL + "<table>" + NL + "\t<tr>" + NL + "\t\t<th>Exchange</th>" + NL + "\t\t<th>Target</th>" + NL
+            + "\t\t<th>Description</th>" + NL + "\t\t<th>Allocated Functional Exchanges</th>" + NL + "\t\t<th>Allocated Exchange Items</th>" + NL + "\t\t<th>Realized Component Exchanges</th>" + NL
+            + "\t\t<th>Realizing Component Exchanges</th>" + NL + "\t</tr>" + NL + "\t";
 
-		if (ictx.useReporter()) {
-			Map<String, Object> parameterValues = new HashMap<String, Object>();
-			parameterValues.put("element", this.element);
-			parameterValues.put("projectName", this.projectName);
-			parameterValues.put("outputFolder", this.outputFolder);
-			String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
-			String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
-			ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
-		}
-		return null;
-	}
+    protected final String TEXT_14 = NL + "<h2>Ports</h2>";
 
-	protected org.polarsys.capella.core.data.capellacore.CapellaElement element = null;
+    protected final String TEXT_15 = NL + "<h2>State Machines</h2>";
 
-	public void set_element(org.polarsys.capella.core.data.capellacore.CapellaElement object) {
-		this.element = object;
-	}
+    public ComponentContentDocGen() {
+        //Here is the constructor
+        StringBuffer stringBuffer = new StringBuffer();
 
-	protected java.lang.String projectName = null;
+        // add initialisation of the pattern variables (declaration has been already done).
 
-	public void set_projectName(java.lang.String object) {
-		this.projectName = object;
-	}
+    }
 
-	protected java.lang.String outputFolder = null;
+    public String generate(Object argument) throws Exception {
+        final StringBuffer stringBuffer = new StringBuffer();
 
-	public void set_outputFolder(java.lang.String object) {
-		this.outputFolder = object;
-	}
+        InternalPatternContext ctx = (InternalPatternContext) argument;
+        Map<String, String> queryCtx = null;
+        IQuery.ParameterDescription paramDesc = null;
+        Node.Container currentNode = ctx.getNode();
 
-	public Map<String, Object> getParameters() {
-		final Map<String, Object> parameters = new HashMap<String, Object>();
-		parameters.put("element", this.element);
-		parameters.put("projectName", this.projectName);
-		parameters.put("outputFolder", this.outputFolder);
-		return parameters;
-	}
+        List<Object> elementList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
+        List<Object> projectNameList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
+        List<Object> outputFolderList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
 
-	protected void method_body(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+        for (Object elementParameter : elementList) {
+            for (Object projectNameParameter : projectNameList) {
+                for (Object outputFolderParameter : outputFolderList) {
 
-		String elementName = EscapeChars.forHTML(CapellaLabelProviderHelper.getText(element));
-		String elementType = EscapeChars.forHTML(element.eClass().getName());
-		Collection<String> componentFeatures = CapellaComponentServices.getFeatures((Component) element);
-		if (componentFeatures.size() > 0) {
+                    this.element = (org.polarsys.capella.core.data.capellacore.CapellaElement) elementParameter;
+                    this.projectName = (java.lang.String) projectNameParameter;
+                    this.outputFolder = (java.lang.String) outputFolderParameter;
 
-			stringBuffer.append(TEXT_1);
-			stringBuffer.append(TEXT_2);
-			stringBuffer.append(StringUtil.stringListToBulette(componentFeatures));
+                    if (preCondition(ctx)) {
+                        ctx.setNode(new Node.Container(currentNode, getClass()));
+                        orchestration(ctx);
+                    }
 
-		}
+                }
+            }
+        }
+        ctx.setNode(currentNode);
+        if (ctx.useReporter()) {
+            ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
+        }
 
-		Collection<String> allocatedFunctionsInformations = CapellaComponentServices
-				.getAllocatedFunctionsInformation((Component) element, projectName, outputFolder);
-		if (allocatedFunctionsInformations.size() > 0) {
-			if (element instanceof Entity) {
+        stringBuffer.append(TEXT_2);
+        stringBuffer.append(TEXT_2);
+        return stringBuffer.toString();
+    }
 
-				stringBuffer.append(TEXT_3);
+    public String orchestration(PatternContext ctx) throws Exception {
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
 
-			} else {
+        method_body(new StringBuffer(), ictx);
 
-				stringBuffer.append(TEXT_4);
+        if (ictx.useReporter()) {
+            Map<String, Object> parameterValues = new HashMap<String, Object>();
+            parameterValues.put("element", this.element);
+            parameterValues.put("projectName", this.projectName);
+            parameterValues.put("outputFolder", this.outputFolder);
+            String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
+            String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
+            ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
+        }
+        return null;
+    }
 
-			}
+    protected org.polarsys.capella.core.data.capellacore.CapellaElement element = null;
 
-			stringBuffer.append(TEXT_2);
-			stringBuffer.append(StringUtil.stringListToBulette(allocatedFunctionsInformations));
+    public void set_element(org.polarsys.capella.core.data.capellacore.CapellaElement object) {
+        this.element = object;
+    }
 
-		}
-		Collection<String> implementedInterfaces = CapellaComponentServices
-				.getImplementedInterfaces((Component) element, projectName, outputFolder);
-		if (implementedInterfaces.size() > 0) {
-			stringBuffer.append(TEXT_5);
-			stringBuffer.append(TEXT_2);
-			stringBuffer.append(StringUtil.stringListToBulette(implementedInterfaces));
+    protected java.lang.String projectName = null;
 
-		}
+    public void set_projectName(java.lang.String object) {
+        this.projectName = object;
+    }
 
-		Collection<String> providedInterfaces = CapellaComponentServices.getProvidedInterfaces((Component) element,
-				projectName, outputFolder);
-		if (providedInterfaces.size() > 0) {
-			stringBuffer.append(TEXT_6);
-			stringBuffer.append(TEXT_2);
-			stringBuffer.append(StringUtil.stringListToBulette(providedInterfaces));
+    protected java.lang.String outputFolder = null;
 
-		}
+    public void set_outputFolder(java.lang.String object) {
+        this.outputFolder = object;
+    }
 
-		Collection<String> usedInterfaces = CapellaComponentServices.getUsedInterfaces((Component) element, projectName,
-				outputFolder);
-		if (usedInterfaces.size() > 0) {
-			stringBuffer.append(TEXT_7);
-			stringBuffer.append(TEXT_2);
-			stringBuffer.append(StringUtil.stringListToBulette(usedInterfaces));
+    public Map<String, Object> getParameters() {
+        final Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("element", this.element);
+        parameters.put("projectName", this.projectName);
+        parameters.put("outputFolder", this.outputFolder);
+        return parameters;
+    }
 
-		}
+    protected void method_body(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-		Collection<String> requiredInterfaces = CapellaComponentServices.getRequiredInterfaces((Component) element,
-				projectName, outputFolder);
-		if (requiredInterfaces.size() > 0) {
-			stringBuffer.append(TEXT_8);
-			stringBuffer.append(TEXT_2);
-			stringBuffer.append(StringUtil.stringListToBulette(requiredInterfaces));
+        String elementName = EscapeChars.forHTML(CapellaLabelProviderHelper.getText(element));
+        String elementType = EscapeChars.forHTML(element.eClass().getName());
+        Collection<String> componentFeatures = CapellaComponentServices.getFeatures((Component) element);
+        if (componentFeatures.size() > 0) {
 
-		}
+            stringBuffer.append(TEXT_1);
+            stringBuffer.append(TEXT_2);
+            stringBuffer.append(StringUtil.stringListToBulette(componentFeatures));
 
-		Collection<ComponentExchange> incomingComponentExchanges = CapellaComponentServices
-				.getIncomingComponentExchanges((Component) element);
-		if (incomingComponentExchanges.size() > 0) {
+        }
 
-			stringBuffer.append(TEXT_9);
-			for (ComponentExchange componentExchange : incomingComponentExchanges) {
+        Collection<String> allocatedFunctionsInformations = CapellaComponentServices.getAllocatedFunctionsInformation((Component) element, projectName, outputFolder);
+        if (allocatedFunctionsInformations.size() > 0) {
+            if (element instanceof Entity) {
 
-				stringBuffer.append(TEXT_10);
-				stringBuffer.append(CapellaComponentServices.componentExchangeToTableLine((Component) element,
-						componentExchange, projectName, outputFolder));
-				stringBuffer.append(TEXT_10);
+                stringBuffer.append(TEXT_3);
 
-			}
-			stringBuffer.append(TEXT_11);
+            } else {
 
-		}
-		Collection<ComponentExchange> outgoingComponentExchanges = CapellaComponentServices
-				.getOutgoingComponentExchanges((Component) element);
-		if (outgoingComponentExchanges.size() > 0) {
+                stringBuffer.append(TEXT_4);
 
-			stringBuffer.append(TEXT_12);
-			for (ComponentExchange componentExchange : outgoingComponentExchanges) {
+            }
 
-				stringBuffer.append(TEXT_10);
-				stringBuffer.append(CapellaComponentServices.componentExchangeToTableLine((Component) element,
-						componentExchange, projectName, outputFolder));
-				stringBuffer.append(TEXT_10);
+            stringBuffer.append(TEXT_2);
+            stringBuffer.append(StringUtil.stringListToBulette(allocatedFunctionsInformations));
 
-			}
-			stringBuffer.append(TEXT_11);
+        }
+        Collection<String> implementedInterfaces = CapellaComponentServices.getImplementedInterfaces((Component) element, projectName, outputFolder);
+        if (implementedInterfaces.size() > 0) {
+            stringBuffer.append(TEXT_5);
+            stringBuffer.append(TEXT_2);
+            stringBuffer.append(StringUtil.stringListToBulette(implementedInterfaces));
 
-		}
+        }
 
-		Collection<ComponentExchange> inoutComponentExchanges = CapellaComponentServices
-				.getInOutComponentExchanges((Component) element);
-		if (inoutComponentExchanges.size() > 0) {
+        Collection<String> providedInterfaces = CapellaComponentServices.getProvidedInterfaces((Component) element, projectName, outputFolder);
+        if (providedInterfaces.size() > 0) {
+            stringBuffer.append(TEXT_6);
+            stringBuffer.append(TEXT_2);
+            stringBuffer.append(StringUtil.stringListToBulette(providedInterfaces));
 
-			stringBuffer.append(TEXT_13);
-			for (ComponentExchange componentExchange : inoutComponentExchanges) {
+        }
 
-				stringBuffer.append(TEXT_10);
-				stringBuffer.append(CapellaComponentServices.componentExchangeToTableLine((Component) element,
-						componentExchange, projectName, outputFolder));
-				stringBuffer.append(TEXT_10);
+        Collection<String> usedInterfaces = CapellaComponentServices.getUsedInterfaces((Component) element, projectName, outputFolder);
+        if (usedInterfaces.size() > 0) {
+            stringBuffer.append(TEXT_7);
+            stringBuffer.append(TEXT_2);
+            stringBuffer.append(StringUtil.stringListToBulette(usedInterfaces));
 
-			}
-			stringBuffer.append(TEXT_11);
+        }
 
-		}
+        Collection<String> requiredInterfaces = CapellaComponentServices.getRequiredInterfaces((Component) element, projectName, outputFolder);
+        if (requiredInterfaces.size() > 0) {
+            stringBuffer.append(TEXT_8);
+            stringBuffer.append(TEXT_2);
+            stringBuffer.append(StringUtil.stringListToBulette(requiredInterfaces));
 
-		Collection<String> ports = CapellaComponentServices.getPorts((Component) element, projectName, outputFolder);
-		if (ports.size() > 0) {
-			stringBuffer.append(TEXT_14);
-			stringBuffer.append(TEXT_2);
-			stringBuffer.append(StringUtil.stringListToBulette(ports));
-		}
+        }
 
-		Collection<String> stateMachines = BlockHelper.getStateMachine(projectName, outputFolder, (Component) element);
-		if (stateMachines.size() > 0) {
-			stringBuffer.append(TEXT_15);
-			stringBuffer.append(TEXT_2);
-			stringBuffer.append(StringUtil.stringListToBulette(stateMachines));
-		}
+        Collection<ComponentExchange> incomingComponentExchanges = CapellaComponentServices.getIncomingComponentExchanges((Component) element);
+        if (incomingComponentExchanges.size() > 0) {
 
-		stringBuffer.append(TEXT_2);
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "body", stringBuffer.toString());
-	}
+            stringBuffer.append(TEXT_9);
+            for (ComponentExchange componentExchange : incomingComponentExchanges) {
 
-	public boolean preCondition(PatternContext ctx) throws Exception {
-		return true;
-	}
+                stringBuffer.append(TEXT_10);
+                stringBuffer.append(CapellaComponentServices.componentExchangeToTableLine((Component) element, componentExchange, projectName, outputFolder));
+                stringBuffer.append(TEXT_10);
+
+            }
+            stringBuffer.append(TEXT_11);
+
+        }
+        Collection<ComponentExchange> outgoingComponentExchanges = CapellaComponentServices.getOutgoingComponentExchanges((Component) element);
+        if (outgoingComponentExchanges.size() > 0) {
+
+            stringBuffer.append(TEXT_12);
+            for (ComponentExchange componentExchange : outgoingComponentExchanges) {
+
+                stringBuffer.append(TEXT_10);
+                stringBuffer.append(CapellaComponentServices.componentExchangeToTableLine((Component) element, componentExchange, projectName, outputFolder));
+                stringBuffer.append(TEXT_10);
+
+            }
+            stringBuffer.append(TEXT_11);
+
+        }
+
+        Collection<ComponentExchange> inoutComponentExchanges = CapellaComponentServices.getInOutComponentExchanges((Component) element);
+        if (inoutComponentExchanges.size() > 0) {
+
+            stringBuffer.append(TEXT_13);
+            for (ComponentExchange componentExchange : inoutComponentExchanges) {
+
+                stringBuffer.append(TEXT_10);
+                stringBuffer.append(CapellaComponentServices.componentExchangeToTableLine((Component) element, componentExchange, projectName, outputFolder));
+                stringBuffer.append(TEXT_10);
+
+            }
+            stringBuffer.append(TEXT_11);
+
+        }
+
+        Collection<String> ports = CapellaComponentServices.getPorts((Component) element, projectName, outputFolder);
+        if (ports.size() > 0) {
+            stringBuffer.append(TEXT_14);
+            stringBuffer.append(TEXT_2);
+            stringBuffer.append(StringUtil.stringListToBulette(ports));
+        }
+
+        Collection<String> stateMachines = BlockHelper.getStateMachine(projectName, outputFolder, (Component) element);
+        if (stateMachines.size() > 0) {
+            stringBuffer.append(TEXT_15);
+            stringBuffer.append(TEXT_2);
+            stringBuffer.append(StringUtil.stringListToBulette(stateMachines));
+        }
+
+        stringBuffer.append(TEXT_2);
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "body", stringBuffer.toString());
+    }
+
+    public boolean preCondition(PatternContext ctx) throws Exception {
+        return true;
+    }
 }

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/ComponentExchangeDocGen.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/ComponentExchangeDocGen.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.1.201906060805
+//Generated with EGF 1.6.3.202110291409
 package org.polarsys.capella.docgen.content;
 
 import org.eclipse.egf.common.helper.*;
@@ -11,96 +11,97 @@ import org.polarsys.capella.core.data.fa.ComponentExchange;
 import org.polarsys.capella.docgen.preference.CapellaDocgenPreferenceHelper;
 
 public class ComponentExchangeDocGen extends org.polarsys.capella.docgen.foundations.AbstractExchangeDocGen {
-	protected static String nl;
+    protected static String nl;
 
-	public static synchronized ComponentExchangeDocGen create(String lineSeparator) {
-		nl = lineSeparator;
-		ComponentExchangeDocGen result = new ComponentExchangeDocGen();
-		nl = null;
-		return result;
-	}
+    public static synchronized ComponentExchangeDocGen create(String lineSeparator) {
+        nl = lineSeparator;
+        ComponentExchangeDocGen result = new ComponentExchangeDocGen();
+        nl = null;
+        return result;
+    }
 
-	public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
-	protected final String TEXT_1 = " ";
-	protected final String TEXT_2 = NL;
+    public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
 
-	public ComponentExchangeDocGen() {
-		//Here is the constructor
-		StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_1 = " ";
 
-		// add initialisation of the pattern variables (declaration has been already done).
+    protected final String TEXT_2 = NL;
 
-	}
+    public ComponentExchangeDocGen() {
+        //Here is the constructor
+        StringBuffer stringBuffer = new StringBuffer();
 
-	public String generate(Object argument) throws Exception {
-		final StringBuffer stringBuffer = new StringBuffer();
-		stringBuffer.append(TEXT_1);
+        // add initialisation of the pattern variables (declaration has been already done).
 
-		InternalPatternContext ctx = (InternalPatternContext) argument;
-		Map<String, String> queryCtx = null;
-		IQuery.ParameterDescription paramDesc = null;
-		Node.Container currentNode = ctx.getNode();
+    }
 
-		List<Object> parameterList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
+    public String generate(Object argument) throws Exception {
+        final StringBuffer stringBuffer = new StringBuffer();
+        stringBuffer.append(TEXT_1);
 
-		for (Object parameterParameter : parameterList) {
+        InternalPatternContext ctx = (InternalPatternContext) argument;
+        Map<String, String> queryCtx = null;
+        IQuery.ParameterDescription paramDesc = null;
+        Node.Container currentNode = ctx.getNode();
 
-			this.parameter = (org.polarsys.capella.core.data.fa.ComponentExchange) parameterParameter;
+        List<Object> parameterList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
 
-			if (preCondition(ctx)) {
-				ctx.setNode(new Node.Container(currentNode, getClass()));
-				orchestration(ctx);
-			}
+        for (Object parameterParameter : parameterList) {
 
-		}
-		ctx.setNode(currentNode);
-		if (ctx.useReporter()) {
-			ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
-		}
+            this.parameter = (org.polarsys.capella.core.data.fa.ComponentExchange) parameterParameter;
 
-		stringBuffer.append(TEXT_2);
-		stringBuffer.append(TEXT_2);
-		return stringBuffer.toString();
-	}
+            if (preCondition(ctx)) {
+                ctx.setNode(new Node.Container(currentNode, getClass()));
+                orchestration(ctx);
+            }
 
-	public String orchestration(PatternContext ctx) throws Exception {
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
+        }
+        ctx.setNode(currentNode);
+        if (ctx.useReporter()) {
+            ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
+        }
 
-		super.orchestration(new SuperOrchestrationContext(ictx));
+        stringBuffer.append(TEXT_2);
+        stringBuffer.append(TEXT_2);
+        return stringBuffer.toString();
+    }
 
-		if (ictx.useReporter()) {
-			Map<String, Object> parameterValues = new HashMap<String, Object>();
-			parameterValues.put("parameter", this.parameter);
-			String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
-			String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
-			ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
-		}
-		return null;
-	}
+    public String orchestration(PatternContext ctx) throws Exception {
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
 
-	protected org.polarsys.capella.core.data.fa.ComponentExchange parameter = null;
+        super.orchestration(new SuperOrchestrationContext(ictx));
 
-	public void set_parameter(org.polarsys.capella.core.data.fa.ComponentExchange object) {
-		this.parameter = object;
-	}
+        if (ictx.useReporter()) {
+            Map<String, Object> parameterValues = new HashMap<String, Object>();
+            parameterValues.put("parameter", this.parameter);
+            String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
+            String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
+            ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
+        }
+        return null;
+    }
 
-	public Map<String, Object> getParameters() {
-		final Map<String, Object> parameters = new HashMap<String, Object>();
-		parameters.put("parameter", this.parameter);
-		return parameters;
-	}
+    protected org.polarsys.capella.core.data.fa.ComponentExchange parameter = null;
 
-	protected void method_setCapellaContext(final StringBuffer stringBuffer, final PatternContext ctx)
-			throws Exception {
+    public void set_parameter(org.polarsys.capella.core.data.fa.ComponentExchange object) {
+        this.parameter = object;
+    }
 
-		element = parameter;
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "setCapellaContext", stringBuffer.toString());
-	}
+    public Map<String, Object> getParameters() {
+        final Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("parameter", this.parameter);
+        return parameters;
+    }
 
-	public boolean preCondition(PatternContext ctx) throws Exception {
-		return CapellaDocgenPreferenceHelper.isExportComponentExchange();
+    protected void method_setCapellaContext(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-	}
+        element = parameter;
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "setCapellaContext", stringBuffer.toString());
+    }
+
+    public boolean preCondition(PatternContext ctx) throws Exception {
+        return CapellaDocgenPreferenceHelper.isExportComponentExchange();
+
+    }
 }

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/ComponentPortDocGen.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/ComponentPortDocGen.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.2.202001031546
+//Generated with EGF 1.6.3.202110291409
 package org.polarsys.capella.docgen.content;
 
 import org.eclipse.egf.common.helper.*;
@@ -18,161 +18,160 @@ import org.polarsys.capella.docgen.util.pattern.helper.CapellaComponentPortHelpe
 import org.polarsys.capella.core.data.fa.ComponentPort;
 
 public class ComponentPortDocGen extends org.polarsys.capella.docgen.foundations.NamedElementDocGen {
-	protected static String nl;
+    protected static String nl;
 
-	public static synchronized ComponentPortDocGen create(String lineSeparator) {
-		nl = lineSeparator;
-		ComponentPortDocGen result = new ComponentPortDocGen();
-		nl = null;
-		return result;
-	}
+    public static synchronized ComponentPortDocGen create(String lineSeparator) {
+        nl = lineSeparator;
+        ComponentPortDocGen result = new ComponentPortDocGen();
+        nl = null;
+        return result;
+    }
 
-	public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
-	protected final String TEXT_1 = "";
-	protected final String TEXT_2 = NL + "<h2>Provided Interfaces</h2>";
-	protected final String TEXT_3 = NL;
-	protected final String TEXT_4 = NL + "<h2>Required Interfaces</h2>";
-	protected final String TEXT_5 = NL + "<h2>Component Exchanges</h2>" + NL + "" + NL + "<table>" + NL + "\t<tr>" + NL
-			+ "\t\t<th>Exchange</th>" + NL + "\t\t<th>Opposite Port</th>" + NL + "\t\t<th>Opposite Component</th>" + NL
-			+ "\t\t<th>Description</th>" + NL + "\t</tr>" + NL + "\t";
-	protected final String TEXT_6 = NL + "\t";
-	protected final String TEXT_7 = NL + "</table>";
-	protected final String TEXT_8 = NL + "<h2>Component Delegations</h2>" + NL + "" + NL + "<table>" + NL + "\t<tr>"
-			+ NL + "\t\t<th>Delegation</th>" + NL + "\t\t<th>Opposite Port</th>" + NL
-			+ "\t\t<th>Opposite Component</th>" + NL + "\t\t<th>Description</th>" + NL + "\t</tr>" + NL + "\t";
+    public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
 
-	public ComponentPortDocGen() {
-		//Here is the constructor
-		StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_1 = "";
 
-		// add initialisation of the pattern variables (declaration has been already done).
+    protected final String TEXT_2 = NL + "<h2>Provided Interfaces</h2>";
 
-	}
+    protected final String TEXT_3 = NL;
 
-	public String generate(Object argument) throws Exception {
-		final StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_4 = NL + "<h2>Required Interfaces</h2>";
 
-		InternalPatternContext ctx = (InternalPatternContext) argument;
-		Map<String, String> queryCtx = null;
-		IQuery.ParameterDescription paramDesc = null;
-		Node.Container currentNode = ctx.getNode();
+    protected final String TEXT_5 = NL + "<h2>Component Exchanges</h2>" + NL + "" + NL + "<table>" + NL + "\t<tr>" + NL + "\t\t<th>Exchange</th>" + NL + "\t\t<th>Opposite Port</th>" + NL
+            + "\t\t<th>Opposite Component</th>" + NL + "\t\t<th>Description</th>" + NL + "\t</tr>" + NL + "\t";
 
-		List<Object> parameterList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
+    protected final String TEXT_6 = NL + "\t";
 
-		for (Object parameterParameter : parameterList) {
+    protected final String TEXT_7 = NL + "</table>";
 
-			this.parameter = (org.polarsys.capella.core.data.fa.ComponentPort) parameterParameter;
+    protected final String TEXT_8 = NL + "<h2>Component Delegations</h2>" + NL + "" + NL + "<table>" + NL + "\t<tr>" + NL + "\t\t<th>Delegation</th>" + NL + "\t\t<th>Opposite Port</th>" + NL
+            + "\t\t<th>Opposite Component</th>" + NL + "\t\t<th>Description</th>" + NL + "\t</tr>" + NL + "\t";
 
-			if (preCondition(ctx)) {
-				ctx.setNode(new Node.Container(currentNode, getClass()));
-				orchestration(ctx);
-			}
+    public ComponentPortDocGen() {
+        //Here is the constructor
+        StringBuffer stringBuffer = new StringBuffer();
 
-		}
-		ctx.setNode(currentNode);
-		if (ctx.useReporter()) {
-			ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
-		}
+        // add initialisation of the pattern variables (declaration has been already done).
 
-		stringBuffer.append(TEXT_3);
-		stringBuffer.append(TEXT_3);
-		return stringBuffer.toString();
-	}
+    }
 
-	public String orchestration(PatternContext ctx) throws Exception {
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
+    public String generate(Object argument) throws Exception {
+        final StringBuffer stringBuffer = new StringBuffer();
 
-		super.orchestration(new SuperOrchestrationContext(ictx));
+        InternalPatternContext ctx = (InternalPatternContext) argument;
+        Map<String, String> queryCtx = null;
+        IQuery.ParameterDescription paramDesc = null;
+        Node.Container currentNode = ctx.getNode();
 
-		if (ictx.useReporter()) {
-			Map<String, Object> parameterValues = new HashMap<String, Object>();
-			parameterValues.put("parameter", this.parameter);
-			String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
-			String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
-			ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
-		}
-		return null;
-	}
+        List<Object> parameterList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
 
-	protected org.polarsys.capella.core.data.fa.ComponentPort parameter = null;
+        for (Object parameterParameter : parameterList) {
 
-	public void set_parameter(org.polarsys.capella.core.data.fa.ComponentPort object) {
-		this.parameter = object;
-	}
+            this.parameter = (org.polarsys.capella.core.data.fa.ComponentPort) parameterParameter;
 
-	public Map<String, Object> getParameters() {
-		final Map<String, Object> parameters = new HashMap<String, Object>();
-		parameters.put("parameter", this.parameter);
-		return parameters;
-	}
+            if (preCondition(ctx)) {
+                ctx.setNode(new Node.Container(currentNode, getClass()));
+                orchestration(ctx);
+            }
 
-	protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+        }
+        ctx.setNode(currentNode);
+        if (ctx.useReporter()) {
+            ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
+        }
 
-		super.method_content(new StringBuffer(), ctx);
-		String projectName = ctx.getValue("projectName").toString();
-		String outputFolder = ctx.getValue("outputFolder").toString();
+        stringBuffer.append(TEXT_3);
+        stringBuffer.append(TEXT_3);
+        return stringBuffer.toString();
+    }
 
-		stringBuffer.append(TEXT_1);
+    public String orchestration(PatternContext ctx) throws Exception {
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
 
-		Map<String, String> providedInterfaces = CapellaComponentPortHelper.getProvidedInterfaces(parameter,
-				projectName, outputFolder);
-		if (providedInterfaces.size() > 0) {
+        super.orchestration(new SuperOrchestrationContext(ictx));
 
-			stringBuffer.append(TEXT_2);
-			stringBuffer.append(TEXT_3);
-			stringBuffer.append(StringUtil.mapToHTMLTable(providedInterfaces, "Interface", "Exchange Items"));
+        if (ictx.useReporter()) {
+            Map<String, Object> parameterValues = new HashMap<String, Object>();
+            parameterValues.put("parameter", this.parameter);
+            String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
+            String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
+            ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
+        }
+        return null;
+    }
 
-		}
-		Map<String, String> requiredInterfaces = CapellaComponentPortHelper.getRequiredInterfaces(parameter,
-				projectName, outputFolder);
-		if (requiredInterfaces.size() > 0) {
-			stringBuffer.append(TEXT_4);
-			stringBuffer.append(TEXT_3);
-			stringBuffer.append(StringUtil.mapToHTMLTable(requiredInterfaces, "Interface", "Exchange Items"));
+    protected org.polarsys.capella.core.data.fa.ComponentPort parameter = null;
 
-		}
-		Collection<ComponentExchange> componentExchanges = CapellaComponentPortHelper
-				.getComponentPortExchanges(parameter, projectName, outputFolder);
-		if (componentExchanges.size() > 0) {
+    public void set_parameter(org.polarsys.capella.core.data.fa.ComponentPort object) {
+        this.parameter = object;
+    }
 
-			stringBuffer.append(TEXT_5);
-			for (ComponentExchange componentExchange : componentExchanges) {
-				stringBuffer.append(TEXT_6);
-				stringBuffer.append(CapellaComponentPortHelper.componentExchangeToTableLine(parameter,
-						componentExchange, projectName, outputFolder));
-				stringBuffer.append(TEXT_6);
+    public Map<String, Object> getParameters() {
+        final Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("parameter", this.parameter);
+        return parameters;
+    }
 
-			}
-			stringBuffer.append(TEXT_7);
+    protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-		}
-		Collection<ComponentExchange> componentDelegations = CapellaComponentPortHelper
-				.getComponentPortDelegations(parameter, projectName, outputFolder);
-		if (componentDelegations.size() > 0) {
+        super.method_content(new StringBuffer(), ctx);
+        String projectName = ctx.getValue("projectName").toString();
+        String outputFolder = ctx.getValue("outputFolder").toString();
 
-			stringBuffer.append(TEXT_8);
-			for (ComponentExchange componentDelegation : componentDelegations) {
-				stringBuffer.append(TEXT_6);
-				stringBuffer.append(CapellaComponentPortHelper.componentExchangeToTableLine(parameter,
-						componentDelegation, projectName, outputFolder));
-				stringBuffer.append(TEXT_6);
+        stringBuffer.append(TEXT_1);
 
-			}
-			stringBuffer.append(TEXT_7);
+        Map<String, String> providedInterfaces = CapellaComponentPortHelper.getProvidedInterfaces(parameter, projectName, outputFolder);
+        if (providedInterfaces.size() > 0) {
 
-		}
+            stringBuffer.append(TEXT_2);
+            stringBuffer.append(TEXT_3);
+            stringBuffer.append(StringUtil.mapToHTMLTable(providedInterfaces, "Interface", "Exchange Items"));
 
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
-	}
+        }
+        Map<String, String> requiredInterfaces = CapellaComponentPortHelper.getRequiredInterfaces(parameter, projectName, outputFolder);
+        if (requiredInterfaces.size() > 0) {
+            stringBuffer.append(TEXT_4);
+            stringBuffer.append(TEXT_3);
+            stringBuffer.append(StringUtil.mapToHTMLTable(requiredInterfaces, "Interface", "Exchange Items"));
 
-	protected void method_setCapellaContext(final StringBuffer stringBuffer, final PatternContext ctx)
-			throws Exception {
+        }
+        Collection<ComponentExchange> componentExchanges = CapellaComponentPortHelper.getComponentPortExchanges(parameter, projectName, outputFolder);
+        if (componentExchanges.size() > 0) {
 
-		element = parameter;
+            stringBuffer.append(TEXT_5);
+            for (ComponentExchange componentExchange : componentExchanges) {
+                stringBuffer.append(TEXT_6);
+                stringBuffer.append(CapellaComponentPortHelper.componentExchangeToTableLine(parameter, componentExchange, projectName, outputFolder));
+                stringBuffer.append(TEXT_6);
 
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "setCapellaContext", stringBuffer.toString());
-	}
+            }
+            stringBuffer.append(TEXT_7);
+
+        }
+        Collection<ComponentExchange> componentDelegations = CapellaComponentPortHelper.getComponentPortDelegations(parameter, projectName, outputFolder);
+        if (componentDelegations.size() > 0) {
+
+            stringBuffer.append(TEXT_8);
+            for (ComponentExchange componentDelegation : componentDelegations) {
+                stringBuffer.append(TEXT_6);
+                stringBuffer.append(CapellaComponentPortHelper.componentExchangeToTableLine(parameter, componentDelegation, projectName, outputFolder));
+                stringBuffer.append(TEXT_6);
+
+            }
+            stringBuffer.append(TEXT_7);
+
+        }
+
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
+    }
+
+    protected void method_setCapellaContext(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+
+        element = parameter;
+
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "setCapellaContext", stringBuffer.toString());
+    }
 }

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/DataTypeDocGen.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/DataTypeDocGen.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.1.201906060805
+//Generated with EGF 1.6.3.202110291409
 package org.polarsys.capella.docgen.content;
 
 import org.eclipse.egf.common.helper.*;
@@ -15,194 +15,195 @@ import org.polarsys.capella.docgen.util.CapellaServices;
 import org.polarsys.capella.docgen.util.StringUtil;
 
 public class DataTypeDocGen extends org.polarsys.capella.docgen.content.GeneralizableElementDocGen {
-	protected static String nl;
+    protected static String nl;
 
-	public static synchronized DataTypeDocGen create(String lineSeparator) {
-		nl = lineSeparator;
-		DataTypeDocGen result = new DataTypeDocGen();
-		nl = null;
-		return result;
-	}
+    public static synchronized DataTypeDocGen create(String lineSeparator) {
+        nl = lineSeparator;
+        DataTypeDocGen result = new DataTypeDocGen();
+        nl = null;
+        return result;
+    }
 
-	public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
-	protected final String TEXT_1 = "<div title=\"Features\">";
-	protected final String TEXT_2 = NL;
-	protected final String TEXT_3 = NL + "</div>";
-	protected final String TEXT_4 = NL + "<div title=\"Literals\">";
-	protected final String TEXT_5 = NL + "<div title=\"Data Values\">";
-	protected final String TEXT_6 = NL + "<h2>Type Of</h2>";
+    public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
 
-	public DataTypeDocGen() {
-		//Here is the constructor
-		StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_1 = "<div title=\"Features\">";
 
-		// add initialisation of the pattern variables (declaration has been already done).
+    protected final String TEXT_2 = NL;
 
-	}
+    protected final String TEXT_3 = NL + "</div>";
 
-	public String generate(Object argument) throws Exception {
-		final StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_4 = NL + "<div title=\"Literals\">";
 
-		InternalPatternContext ctx = (InternalPatternContext) argument;
-		Map<String, String> queryCtx = null;
-		IQuery.ParameterDescription paramDesc = null;
-		Node.Container currentNode = ctx.getNode();
+    protected final String TEXT_5 = NL + "<div title=\"Data Values\">";
 
-		List<Object> parameterList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
+    protected final String TEXT_6 = NL + "<h2>Type Of</h2>";
 
-		for (Object parameterParameter : parameterList) {
+    public DataTypeDocGen() {
+        //Here is the constructor
+        StringBuffer stringBuffer = new StringBuffer();
 
-			this.parameter = (org.polarsys.capella.core.data.capellacore.GeneralizableElement) parameterParameter;
+        // add initialisation of the pattern variables (declaration has been already done).
 
-			if (preCondition(ctx)) {
-				ctx.setNode(new Node.Container(currentNode, getClass()));
-				orchestration(ctx);
-			}
+    }
 
-		}
-		ctx.setNode(currentNode);
-		if (ctx.useReporter()) {
-			ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
-		}
+    public String generate(Object argument) throws Exception {
+        final StringBuffer stringBuffer = new StringBuffer();
 
-		stringBuffer.append(TEXT_2);
-		stringBuffer.append(TEXT_2);
-		return stringBuffer.toString();
-	}
+        InternalPatternContext ctx = (InternalPatternContext) argument;
+        Map<String, String> queryCtx = null;
+        IQuery.ParameterDescription paramDesc = null;
+        Node.Container currentNode = ctx.getNode();
 
-	public String orchestration(PatternContext ctx) throws Exception {
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
+        List<Object> parameterList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
 
-		super.orchestration(new SuperOrchestrationContext(ictx));
+        for (Object parameterParameter : parameterList) {
 
-		if (ictx.useReporter()) {
-			Map<String, Object> parameterValues = new HashMap<String, Object>();
-			parameterValues.put("parameter", this.parameter);
-			String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
-			String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
-			ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
-		}
-		return null;
-	}
+            this.parameter = (org.polarsys.capella.core.data.capellacore.GeneralizableElement) parameterParameter;
 
-	public Map<String, Object> getParameters() {
-		final Map<String, Object> parameters = new HashMap<String, Object>();
-		parameters.put("parameter", this.parameter);
-		return parameters;
-	}
+            if (preCondition(ctx)) {
+                ctx.setNode(new Node.Container(currentNode, getClass()));
+                orchestration(ctx);
+            }
 
-	protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+        }
+        ctx.setNode(currentNode);
+        if (ctx.useReporter()) {
+            ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
+        }
 
-		super.method_content(new StringBuffer(), ctx);
-		String projectName = ctx.getValue("projectName").toString();
-		String outputFolder = ctx.getValue("outputFolder").toString();
+        stringBuffer.append(TEXT_2);
+        stringBuffer.append(TEXT_2);
+        return stringBuffer.toString();
+    }
 
-		Collection<String> featuresCollection = CapellaDataTypeService.getFeatures(element);
-		if (featuresCollection.size() >= 1) {
-			stringBuffer.append(TEXT_1);
-			String features = "Features";
-			stringBuffer.append(TEXT_2);
-			{
-				//<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#LogicalName=org.polarsys.kitalpha.doc.gen.business.core.generic.ElementGenerateByPropterty" args="element:eObject,features:property"%>
+    public String orchestration(PatternContext ctx) throws Exception {
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
 
-				InternalPatternContext ictx = (InternalPatternContext) ctx;
-				new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
-				stringBuffer.setLength(0);
+        super.orchestration(new SuperOrchestrationContext(ictx));
 
-				final Map<String, Object> callParameters = new HashMap<String, Object>();
-				callParameters.put("eObject", element);
-				callParameters.put("property", features);
-				CallHelper.executeWithParameterInjection(
-						"platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#_cWGxMONUEd-euK0PeLuaMA",
-						new ExecutionContext((InternalPatternContext) ctx), callParameters);
-				stringBuffer.setLength(0);
-			}
+        if (ictx.useReporter()) {
+            Map<String, Object> parameterValues = new HashMap<String, Object>();
+            parameterValues.put("parameter", this.parameter);
+            String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
+            String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
+            ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
+        }
+        return null;
+    }
 
-			stringBuffer.append(TEXT_2);
-			stringBuffer.append(StringUtil.stringListToBulette(featuresCollection));
-			stringBuffer.append(TEXT_3);
-		}
+    public Map<String, Object> getParameters() {
+        final Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("parameter", this.parameter);
+        return parameters;
+    }
 
-		Collection<String> literalsCollection = CapellaDataTypeService.getLiterals(element, projectName, outputFolder);
-		if (literalsCollection.size() >= 1) {
-			stringBuffer.append(TEXT_4);
-			String propertyValue = "Literals";
-			stringBuffer.append(TEXT_2);
-			{
-				//<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#LogicalName=org.polarsys.kitalpha.doc.gen.business.core.generic.ElementGenerateByPropterty" args="element:eObject,propertyValue:property"%>
+    protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-				InternalPatternContext ictx = (InternalPatternContext) ctx;
-				new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
-				stringBuffer.setLength(0);
+        super.method_content(new StringBuffer(), ctx);
+        String projectName = ctx.getValue("projectName").toString();
+        String outputFolder = ctx.getValue("outputFolder").toString();
 
-				final Map<String, Object> callParameters = new HashMap<String, Object>();
-				callParameters.put("eObject", element);
-				callParameters.put("property", propertyValue);
-				CallHelper.executeWithParameterInjection(
-						"platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#_cWGxMONUEd-euK0PeLuaMA",
-						new ExecutionContext((InternalPatternContext) ctx), callParameters);
-				stringBuffer.setLength(0);
-			}
+        Collection<String> featuresCollection = CapellaDataTypeService.getFeatures(element);
+        if (featuresCollection.size() >= 1) {
+            stringBuffer.append(TEXT_1);
+            String features = "Features";
+            stringBuffer.append(TEXT_2);
+            {
+                //<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#LogicalName=org.polarsys.kitalpha.doc.gen.business.core.generic.ElementGenerateByPropterty" args="element:eObject,features:property"%>
 
-			stringBuffer.append(TEXT_2);
-			stringBuffer.append(StringUtil.stringListToBulette(literalsCollection));
-			stringBuffer.append(TEXT_3);
-		}
+                InternalPatternContext ictx = (InternalPatternContext) ctx;
+                new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
+                stringBuffer.setLength(0);
 
-		Collection<String> dataValuesCollection = CapellaDataValuePkgService.getDataValues(element, projectName,
-				outputFolder);
-		if (dataValuesCollection.size() >= 1) {
-			stringBuffer.append(TEXT_5);
-			String dataValue = "Data Values";
-			stringBuffer.append(TEXT_2);
-			{
-				//<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#LogicalName=org.polarsys.kitalpha.doc.gen.business.core.generic.ElementGenerateByPropterty" args="element:eObject,dataValue:property"%>
+                final Map<String, Object> callParameters = new HashMap<String, Object>();
+                callParameters.put("eObject", element);
+                callParameters.put("property", features);
+                CallHelper.executeWithParameterInjection("platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#_cWGxMONUEd-euK0PeLuaMA",
+                        new ExecutionContext((InternalPatternContext) ctx), callParameters);
+                stringBuffer.setLength(0);
+            }
 
-				InternalPatternContext ictx = (InternalPatternContext) ctx;
-				new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
-				stringBuffer.setLength(0);
+            stringBuffer.append(TEXT_2);
+            stringBuffer.append(StringUtil.stringListToBulette(featuresCollection));
+            stringBuffer.append(TEXT_3);
+        }
 
-				final Map<String, Object> callParameters = new HashMap<String, Object>();
-				callParameters.put("eObject", element);
-				callParameters.put("property", dataValue);
-				CallHelper.executeWithParameterInjection(
-						"platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#_cWGxMONUEd-euK0PeLuaMA",
-						new ExecutionContext((InternalPatternContext) ctx), callParameters);
-				stringBuffer.setLength(0);
-			}
+        Collection<String> literalsCollection = CapellaDataTypeService.getLiterals(element, projectName, outputFolder);
+        if (literalsCollection.size() >= 1) {
+            stringBuffer.append(TEXT_4);
+            String propertyValue = "Literals";
+            stringBuffer.append(TEXT_2);
+            {
+                //<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#LogicalName=org.polarsys.kitalpha.doc.gen.business.core.generic.ElementGenerateByPropterty" args="element:eObject,propertyValue:property"%>
 
-			stringBuffer.append(TEXT_2);
-			stringBuffer.append(StringUtil.stringListToBulette(dataValuesCollection));
-			stringBuffer.append(TEXT_3);
-		}
+                InternalPatternContext ictx = (InternalPatternContext) ctx;
+                new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
+                stringBuffer.setLength(0);
 
-		Collection<String> typeOfCollection = CapellaDataTypeService.getTypeOf((DataType) element, projectName,
-				outputFolder);
-		if (typeOfCollection.size() >= 1) {
-			stringBuffer.append(TEXT_6);
-			stringBuffer.append(TEXT_2);
-			stringBuffer.append(StringUtil.stringListToBulette(typeOfCollection));
-		}
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
-	}
+                final Map<String, Object> callParameters = new HashMap<String, Object>();
+                callParameters.put("eObject", element);
+                callParameters.put("property", propertyValue);
+                CallHelper.executeWithParameterInjection("platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#_cWGxMONUEd-euK0PeLuaMA",
+                        new ExecutionContext((InternalPatternContext) ctx), callParameters);
+                stringBuffer.setLength(0);
+            }
 
-	protected void method_setTitle(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+            stringBuffer.append(TEXT_2);
+            stringBuffer.append(StringUtil.stringListToBulette(literalsCollection));
+            stringBuffer.append(TEXT_3);
+        }
 
-		String visibility = "";
-		if (((DataType) element).getVisibility().getValue() != VisibilityKind.UNSET_VALUE)
-			visibility = "{" + ((DataType) element).getVisibility().getLiteral().toLowerCase() + "} ";
-		String type = element.eClass().getName();
-		String elementFullName = CapellaServices.getHyperlinkFromElement(element);
-		documentTitle = "<span class=\"elementMetaClass\">" + visibility + "</span> " + elementFullName;
+        Collection<String> dataValuesCollection = CapellaDataValuePkgService.getDataValues(element, projectName, outputFolder);
+        if (dataValuesCollection.size() >= 1) {
+            stringBuffer.append(TEXT_5);
+            String dataValue = "Data Values";
+            stringBuffer.append(TEXT_2);
+            {
+                //<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#LogicalName=org.polarsys.kitalpha.doc.gen.business.core.generic.ElementGenerateByPropterty" args="element:eObject,dataValue:property"%>
 
-		stringBuffer.append(TEXT_2);
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "setTitle", stringBuffer.toString());
-	}
+                InternalPatternContext ictx = (InternalPatternContext) ctx;
+                new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
+                stringBuffer.setLength(0);
 
-	public boolean preCondition(PatternContext ctx) throws Exception {
-		return (this.parameter instanceof DataType);
-	}
+                final Map<String, Object> callParameters = new HashMap<String, Object>();
+                callParameters.put("eObject", element);
+                callParameters.put("property", dataValue);
+                CallHelper.executeWithParameterInjection("platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#_cWGxMONUEd-euK0PeLuaMA",
+                        new ExecutionContext((InternalPatternContext) ctx), callParameters);
+                stringBuffer.setLength(0);
+            }
+
+            stringBuffer.append(TEXT_2);
+            stringBuffer.append(StringUtil.stringListToBulette(dataValuesCollection));
+            stringBuffer.append(TEXT_3);
+        }
+
+        Collection<String> typeOfCollection = CapellaDataTypeService.getTypeOf((DataType) element, projectName, outputFolder);
+        if (typeOfCollection.size() >= 1) {
+            stringBuffer.append(TEXT_6);
+            stringBuffer.append(TEXT_2);
+            stringBuffer.append(StringUtil.stringListToBulette(typeOfCollection));
+        }
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
+    }
+
+    protected void method_setTitle(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+
+        String visibility = "";
+        if (((DataType) element).getVisibility().getValue() != VisibilityKind.UNSET_VALUE)
+            visibility = "{" + ((DataType) element).getVisibility().getLiteral().toLowerCase() + "} ";
+        String type = element.eClass().getName();
+        String elementFullName = CapellaServices.getHyperlinkFromElement(element);
+        documentTitle = "<span class=\"elementMetaClass\">" + visibility + "</span> " + elementFullName;
+
+        stringBuffer.append(TEXT_2);
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "setTitle", stringBuffer.toString());
+    }
+
+    public boolean preCondition(PatternContext ctx) throws Exception {
+        return (this.parameter instanceof DataType);
+    }
 }

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/DataValueContainerPkg.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/DataValueContainerPkg.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.1.201906060805
+//Generated with EGF 1.6.3.202110291409
 package org.polarsys.capella.docgen.content;
 
 import org.eclipse.egf.common.helper.*;
@@ -11,119 +11,121 @@ import org.polarsys.capella.docgen.util.StringUtil;
 import org.polarsys.capella.docgen.util.DataValuePkgService;
 
 public class DataValueContainerPkg extends org.polarsys.capella.docgen.content.packageDocGen {
-	protected static String nl;
+    protected static String nl;
 
-	public static synchronized DataValueContainerPkg create(String lineSeparator) {
-		nl = lineSeparator;
-		DataValueContainerPkg result = new DataValueContainerPkg();
-		nl = null;
-		return result;
-	}
+    public static synchronized DataValueContainerPkg create(String lineSeparator) {
+        nl = lineSeparator;
+        DataValueContainerPkg result = new DataValueContainerPkg();
+        nl = null;
+        return result;
+    }
 
-	public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
-	protected final String TEXT_1 = "";
-	protected final String TEXT_2 = NL + "<div title=\"Data Values\">";
-	protected final String TEXT_3 = NL;
-	protected final String TEXT_4 = NL + "</div>";
+    public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
 
-	public DataValueContainerPkg() {
-		//Here is the constructor
-		StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_1 = "";
 
-		// add initialisation of the pattern variables (declaration has been already done).
+    protected final String TEXT_2 = NL + "<div title=\"Data Values\">";
 
-	}
+    protected final String TEXT_3 = NL;
 
-	public String generate(Object argument) throws Exception {
-		final StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_4 = NL + "</div>";
 
-		InternalPatternContext ctx = (InternalPatternContext) argument;
-		Map<String, String> queryCtx = null;
-		IQuery.ParameterDescription paramDesc = null;
-		Node.Container currentNode = ctx.getNode();
+    public DataValueContainerPkg() {
+        //Here is the constructor
+        StringBuffer stringBuffer = new StringBuffer();
 
-		List<Object> parameterList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
+        // add initialisation of the pattern variables (declaration has been already done).
 
-		for (Object parameterParameter : parameterList) {
+    }
 
-			this.parameter = (org.polarsys.capella.core.data.capellacore.Structure) parameterParameter;
+    public String generate(Object argument) throws Exception {
+        final StringBuffer stringBuffer = new StringBuffer();
 
-			if (preCondition(ctx)) {
-				ctx.setNode(new Node.Container(currentNode, getClass()));
-				orchestration(ctx);
-			}
+        InternalPatternContext ctx = (InternalPatternContext) argument;
+        Map<String, String> queryCtx = null;
+        IQuery.ParameterDescription paramDesc = null;
+        Node.Container currentNode = ctx.getNode();
 
-		}
-		ctx.setNode(currentNode);
-		if (ctx.useReporter()) {
-			ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
-		}
+        List<Object> parameterList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
 
-		stringBuffer.append(TEXT_3);
-		stringBuffer.append(TEXT_3);
-		return stringBuffer.toString();
-	}
+        for (Object parameterParameter : parameterList) {
 
-	public String orchestration(PatternContext ctx) throws Exception {
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
+            this.parameter = (org.polarsys.capella.core.data.capellacore.Structure) parameterParameter;
 
-		super.orchestration(new SuperOrchestrationContext(ictx));
+            if (preCondition(ctx)) {
+                ctx.setNode(new Node.Container(currentNode, getClass()));
+                orchestration(ctx);
+            }
 
-		if (ictx.useReporter()) {
-			Map<String, Object> parameterValues = new HashMap<String, Object>();
-			parameterValues.put("parameter", this.parameter);
-			String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
-			String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
-			ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
-		}
-		return null;
-	}
+        }
+        ctx.setNode(currentNode);
+        if (ctx.useReporter()) {
+            ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
+        }
 
-	public Map<String, Object> getParameters() {
-		final Map<String, Object> parameters = new HashMap<String, Object>();
-		parameters.put("parameter", this.parameter);
-		return parameters;
-	}
+        stringBuffer.append(TEXT_3);
+        stringBuffer.append(TEXT_3);
+        return stringBuffer.toString();
+    }
 
-	protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+    public String orchestration(PatternContext ctx) throws Exception {
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
 
-		super.method_content(new StringBuffer(), ctx);
-		stringBuffer.append(TEXT_1);
+        super.orchestration(new SuperOrchestrationContext(ictx));
 
-		String projectName = ctx.getValue("projectName").toString();
-		String outputFolder = ctx.getValue("outputFolder").toString();
+        if (ictx.useReporter()) {
+            Map<String, Object> parameterValues = new HashMap<String, Object>();
+            parameterValues.put("parameter", this.parameter);
+            String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
+            String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
+            ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
+        }
+        return null;
+    }
 
-		if (DataValuePkgService.getDataValues(element, projectName, outputFolder).size() >= 1) {
-			stringBuffer.append(TEXT_2);
-			String dataValue = "Data Values";
-			stringBuffer.append(TEXT_3);
-			{
-				//<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#LogicalName=org.polarsys.kitalpha.doc.gen.business.core.generic.ElementGenerateByPropterty" args="element:eObject,dataValue:property"%>
+    public Map<String, Object> getParameters() {
+        final Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("parameter", this.parameter);
+        return parameters;
+    }
 
-				InternalPatternContext ictx = (InternalPatternContext) ctx;
-				new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
-				stringBuffer.setLength(0);
+    protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-				final Map<String, Object> callParameters = new HashMap<String, Object>();
-				callParameters.put("eObject", element);
-				callParameters.put("property", dataValue);
-				CallHelper.executeWithParameterInjection(
-						"platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#_cWGxMONUEd-euK0PeLuaMA",
-						new ExecutionContext((InternalPatternContext) ctx), callParameters);
-				stringBuffer.setLength(0);
-			}
+        super.method_content(new StringBuffer(), ctx);
+        stringBuffer.append(TEXT_1);
 
-			stringBuffer.append(TEXT_3);
-			stringBuffer.append(StringUtil
-					.stringListToBulette(DataValuePkgService.getDataValues(element, projectName, outputFolder)));
-			stringBuffer.append(TEXT_4);
-		}
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
-	}
+        String projectName = ctx.getValue("projectName").toString();
+        String outputFolder = ctx.getValue("outputFolder").toString();
 
-	public boolean preCondition(PatternContext ctx) throws Exception {
-		return (parameter instanceof org.polarsys.capella.core.data.information.DataPkg);
-	}
+        if (DataValuePkgService.getDataValues(element, projectName, outputFolder).size() >= 1) {
+            stringBuffer.append(TEXT_2);
+            String dataValue = "Data Values";
+            stringBuffer.append(TEXT_3);
+            {
+                //<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#LogicalName=org.polarsys.kitalpha.doc.gen.business.core.generic.ElementGenerateByPropterty" args="element:eObject,dataValue:property"%>
+
+                InternalPatternContext ictx = (InternalPatternContext) ctx;
+                new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
+                stringBuffer.setLength(0);
+
+                final Map<String, Object> callParameters = new HashMap<String, Object>();
+                callParameters.put("eObject", element);
+                callParameters.put("property", dataValue);
+                CallHelper.executeWithParameterInjection("platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#_cWGxMONUEd-euK0PeLuaMA",
+                        new ExecutionContext((InternalPatternContext) ctx), callParameters);
+                stringBuffer.setLength(0);
+            }
+
+            stringBuffer.append(TEXT_3);
+            stringBuffer.append(StringUtil.stringListToBulette(DataValuePkgService.getDataValues(element, projectName, outputFolder)));
+            stringBuffer.append(TEXT_4);
+        }
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
+    }
+
+    public boolean preCondition(PatternContext ctx) throws Exception {
+        return (parameter instanceof org.polarsys.capella.core.data.information.DataPkg);
+    }
 }

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/EntityContentDocGen.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/EntityContentDocGen.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.1.201906060805
+//Generated with EGF 1.6.3.202110291409
 package org.polarsys.capella.docgen.content;
 
 import org.eclipse.egf.common.helper.*;
@@ -11,131 +11,132 @@ import org.polarsys.capella.core.data.oa.Entity;
 import org.polarsys.capella.docgen.util.pattern.helper.CapellaEntityHelper;
 
 public class EntityContentDocGen {
-	protected static String nl;
+    protected static String nl;
 
-	public static synchronized EntityContentDocGen create(String lineSeparator) {
-		nl = lineSeparator;
-		EntityContentDocGen result = new EntityContentDocGen();
-		nl = null;
-		return result;
-	}
+    public static synchronized EntityContentDocGen create(String lineSeparator) {
+        nl = lineSeparator;
+        EntityContentDocGen result = new EntityContentDocGen();
+        nl = null;
+        return result;
+    }
 
-	public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
-	protected final String TEXT_1 = "<h2>Incoming Communication Means</h2>" + NL + "<table>" + NL + "\t<tr>" + NL
-			+ "\t\t<th>Communication Means</th>" + NL + "\t\t<th>Source</th>" + NL + "\t\t<th>Description</th>" + NL
-			+ "\t\t<th>Allocated Functional Exchanges</th>" + NL + "\t</tr>" + NL + "\t";
-	protected final String TEXT_2 = NL + "\t";
-	protected final String TEXT_3 = NL + "</table>";
-	protected final String TEXT_4 = NL + "<h2>Outgoing Communication Means</h2>" + NL + "<table>" + NL + "\t<tr>" + NL
-			+ "\t\t<th>Communication Means</th>" + NL + "\t\t<th>Target</th>" + NL + "\t\t<th>Description</th>" + NL
-			+ "\t\t<th>Allocated Functional Exchanges</th>" + NL + "\t</tr>" + NL + "\t";
-	protected final String TEXT_5 = NL;
+    public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
 
-	public EntityContentDocGen() {
-		//Here is the constructor
-		StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_1 = "<h2>Incoming Communication Means</h2>" + NL + "<table>" + NL + "\t<tr>" + NL + "\t\t<th>Communication Means</th>" + NL + "\t\t<th>Source</th>" + NL
+            + "\t\t<th>Description</th>" + NL + "\t\t<th>Allocated Functional Exchanges</th>" + NL + "\t</tr>" + NL + "\t";
 
-		// add initialisation of the pattern variables (declaration has been already done).
+    protected final String TEXT_2 = NL + "\t";
 
-	}
+    protected final String TEXT_3 = NL + "</table>";
 
-	public String generate(Object argument) throws Exception {
-		final StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_4 = NL + "<h2>Outgoing Communication Means</h2>" + NL + "<table>" + NL + "\t<tr>" + NL + "\t\t<th>Communication Means</th>" + NL + "\t\t<th>Target</th>" + NL
+            + "\t\t<th>Description</th>" + NL + "\t\t<th>Allocated Functional Exchanges</th>" + NL + "\t</tr>" + NL + "\t";
 
-		InternalPatternContext ctx = (InternalPatternContext) argument;
-		Map<String, String> queryCtx = null;
-		IQuery.ParameterDescription paramDesc = null;
-		Node.Container currentNode = ctx.getNode();
+    protected final String TEXT_5 = NL;
 
-		List<Object> elementList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
+    public EntityContentDocGen() {
+        //Here is the constructor
+        StringBuffer stringBuffer = new StringBuffer();
 
-		for (Object elementParameter : elementList) {
+        // add initialisation of the pattern variables (declaration has been already done).
 
-			this.element = (org.polarsys.capella.core.data.oa.Entity) elementParameter;
+    }
 
-			if (preCondition(ctx)) {
-				ctx.setNode(new Node.Container(currentNode, getClass()));
-				orchestration(ctx);
-			}
+    public String generate(Object argument) throws Exception {
+        final StringBuffer stringBuffer = new StringBuffer();
 
-		}
-		ctx.setNode(currentNode);
-		if (ctx.useReporter()) {
-			ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
-		}
+        InternalPatternContext ctx = (InternalPatternContext) argument;
+        Map<String, String> queryCtx = null;
+        IQuery.ParameterDescription paramDesc = null;
+        Node.Container currentNode = ctx.getNode();
 
-		stringBuffer.append(TEXT_5);
-		stringBuffer.append(TEXT_5);
-		return stringBuffer.toString();
-	}
+        List<Object> elementList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
 
-	public String orchestration(PatternContext ctx) throws Exception {
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
+        for (Object elementParameter : elementList) {
 
-		method_body(new StringBuffer(), ictx);
+            this.element = (org.polarsys.capella.core.data.oa.Entity) elementParameter;
 
-		if (ictx.useReporter()) {
-			Map<String, Object> parameterValues = new HashMap<String, Object>();
-			parameterValues.put("element", this.element);
-			String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
-			String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
-			ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
-		}
-		return null;
-	}
+            if (preCondition(ctx)) {
+                ctx.setNode(new Node.Container(currentNode, getClass()));
+                orchestration(ctx);
+            }
 
-	protected org.polarsys.capella.core.data.oa.Entity element = null;
+        }
+        ctx.setNode(currentNode);
+        if (ctx.useReporter()) {
+            ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
+        }
 
-	public void set_element(org.polarsys.capella.core.data.oa.Entity object) {
-		this.element = object;
-	}
+        stringBuffer.append(TEXT_5);
+        stringBuffer.append(TEXT_5);
+        return stringBuffer.toString();
+    }
 
-	public Map<String, Object> getParameters() {
-		final Map<String, Object> parameters = new HashMap<String, Object>();
-		parameters.put("element", this.element);
-		return parameters;
-	}
+    public String orchestration(PatternContext ctx) throws Exception {
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
 
-	protected void method_body(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+        method_body(new StringBuffer(), ictx);
 
-		String projectName = ctx.getValue("projectName").toString();
-		String outputFolder = ctx.getValue("outputFolder").toString();
+        if (ictx.useReporter()) {
+            Map<String, Object> parameterValues = new HashMap<String, Object>();
+            parameterValues.put("element", this.element);
+            String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
+            String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
+            ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
+        }
+        return null;
+    }
 
-		Collection<String> incomingCommunicationMeans = CapellaEntityHelper
-				.getIncomingCommunicationMeansLines((Entity) element, projectName, outputFolder);
-		if (incomingCommunicationMeans.size() > 0) {
+    protected org.polarsys.capella.core.data.oa.Entity element = null;
 
-			stringBuffer.append(TEXT_1);
-			for (String communicationMean : incomingCommunicationMeans) {
+    public void set_element(org.polarsys.capella.core.data.oa.Entity object) {
+        this.element = object;
+    }
 
-				stringBuffer.append(TEXT_2);
-				stringBuffer.append(communicationMean);
-				stringBuffer.append(TEXT_2);
+    public Map<String, Object> getParameters() {
+        final Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("element", this.element);
+        return parameters;
+    }
 
-			}
-			stringBuffer.append(TEXT_3);
-		}
+    protected void method_body(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-		Collection<String> outgoingCommunicationMeans = CapellaEntityHelper
-				.getOutgoingCommunicationMeansLines((Entity) element, projectName, outputFolder);
-		if (outgoingCommunicationMeans.size() > 0) {
+        String projectName = ctx.getValue("projectName").toString();
+        String outputFolder = ctx.getValue("outputFolder").toString();
 
-			stringBuffer.append(TEXT_4);
-			for (String communicationMean : outgoingCommunicationMeans) {
+        Collection<String> incomingCommunicationMeans = CapellaEntityHelper.getIncomingCommunicationMeansLines((Entity) element, projectName, outputFolder);
+        if (incomingCommunicationMeans.size() > 0) {
 
-				stringBuffer.append(TEXT_2);
-				stringBuffer.append(communicationMean);
-				stringBuffer.append(TEXT_2);
+            stringBuffer.append(TEXT_1);
+            for (String communicationMean : incomingCommunicationMeans) {
 
-			}
-			stringBuffer.append(TEXT_3);
-		}
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "body", stringBuffer.toString());
-	}
+                stringBuffer.append(TEXT_2);
+                stringBuffer.append(communicationMean);
+                stringBuffer.append(TEXT_2);
 
-	public boolean preCondition(PatternContext ctx) throws Exception {
-		return true;
-	}
+            }
+            stringBuffer.append(TEXT_3);
+        }
+
+        Collection<String> outgoingCommunicationMeans = CapellaEntityHelper.getOutgoingCommunicationMeansLines((Entity) element, projectName, outputFolder);
+        if (outgoingCommunicationMeans.size() > 0) {
+
+            stringBuffer.append(TEXT_4);
+            for (String communicationMean : outgoingCommunicationMeans) {
+
+                stringBuffer.append(TEXT_2);
+                stringBuffer.append(communicationMean);
+                stringBuffer.append(TEXT_2);
+
+            }
+            stringBuffer.append(TEXT_3);
+        }
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "body", stringBuffer.toString());
+    }
+
+    public boolean preCondition(PatternContext ctx) throws Exception {
+        return true;
+    }
 }

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/EntityDocGen.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/EntityDocGen.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.1.201906060805
+//Generated with EGF 1.6.3.202110291409
 package org.polarsys.capella.docgen.content;
 
 import org.eclipse.egf.common.helper.*;
@@ -10,104 +10,105 @@ import org.eclipse.egf.pattern.query.*;
 import org.polarsys.capella.core.data.oa.Entity;
 
 public class EntityDocGen extends org.polarsys.capella.docgen.content.LogicalComponentDocGen {
-	protected static String nl;
+    protected static String nl;
 
-	public static synchronized EntityDocGen create(String lineSeparator) {
-		nl = lineSeparator;
-		EntityDocGen result = new EntityDocGen();
-		nl = null;
-		return result;
-	}
+    public static synchronized EntityDocGen create(String lineSeparator) {
+        nl = lineSeparator;
+        EntityDocGen result = new EntityDocGen();
+        nl = null;
+        return result;
+    }
 
-	public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
-	protected final String TEXT_1 = "";
-	protected final String TEXT_2 = NL;
+    public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
 
-	public EntityDocGen() {
-		//Here is the constructor
-		StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_1 = "";
 
-		// add initialisation of the pattern variables (declaration has been already done).
+    protected final String TEXT_2 = NL;
 
-	}
+    public EntityDocGen() {
+        //Here is the constructor
+        StringBuffer stringBuffer = new StringBuffer();
 
-	public String generate(Object argument) throws Exception {
-		final StringBuffer stringBuffer = new StringBuffer();
+        // add initialisation of the pattern variables (declaration has been already done).
 
-		InternalPatternContext ctx = (InternalPatternContext) argument;
-		Map<String, String> queryCtx = null;
-		IQuery.ParameterDescription paramDesc = null;
-		Node.Container currentNode = ctx.getNode();
+    }
 
-		List<Object> parameterList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
+    public String generate(Object argument) throws Exception {
+        final StringBuffer stringBuffer = new StringBuffer();
 
-		for (Object parameterParameter : parameterList) {
+        InternalPatternContext ctx = (InternalPatternContext) argument;
+        Map<String, String> queryCtx = null;
+        IQuery.ParameterDescription paramDesc = null;
+        Node.Container currentNode = ctx.getNode();
 
-			this.parameter = (org.polarsys.capella.core.data.cs.Component) parameterParameter;
+        List<Object> parameterList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
 
-			if (preCondition(ctx)) {
-				ctx.setNode(new Node.Container(currentNode, getClass()));
-				orchestration(ctx);
-			}
+        for (Object parameterParameter : parameterList) {
 
-		}
-		ctx.setNode(currentNode);
-		if (ctx.useReporter()) {
-			ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
-		}
+            this.parameter = (org.polarsys.capella.core.data.cs.Component) parameterParameter;
 
-		stringBuffer.append(TEXT_2);
-		stringBuffer.append(TEXT_2);
-		return stringBuffer.toString();
-	}
+            if (preCondition(ctx)) {
+                ctx.setNode(new Node.Container(currentNode, getClass()));
+                orchestration(ctx);
+            }
 
-	public String orchestration(PatternContext ctx) throws Exception {
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
+        }
+        ctx.setNode(currentNode);
+        if (ctx.useReporter()) {
+            ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
+        }
 
-		super.orchestration(new SuperOrchestrationContext(ictx));
+        stringBuffer.append(TEXT_2);
+        stringBuffer.append(TEXT_2);
+        return stringBuffer.toString();
+    }
 
-		if (ictx.useReporter()) {
-			Map<String, Object> parameterValues = new HashMap<String, Object>();
-			parameterValues.put("parameter", this.parameter);
-			String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
-			String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
-			ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
-		}
-		return null;
-	}
+    public String orchestration(PatternContext ctx) throws Exception {
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
 
-	public Map<String, Object> getParameters() {
-		final Map<String, Object> parameters = new HashMap<String, Object>();
-		parameters.put("parameter", this.parameter);
-		return parameters;
-	}
+        super.orchestration(new SuperOrchestrationContext(ictx));
 
-	protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+        if (ictx.useReporter()) {
+            Map<String, Object> parameterValues = new HashMap<String, Object>();
+            parameterValues.put("parameter", this.parameter);
+            String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
+            String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
+            ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
+        }
+        return null;
+    }
 
-		super.method_content(new StringBuffer(), ctx);
+    public Map<String, Object> getParameters() {
+        final Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("parameter", this.parameter);
+        return parameters;
+    }
 
-		stringBuffer.append(TEXT_1);
-		{
-			//<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#LogicalName=org.polarsys.capella.docgen.content.EntityContentDocGen" args="element:element"%>
+    protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-			InternalPatternContext ictx = (InternalPatternContext) ctx;
-			new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
-			stringBuffer.setLength(0);
+        super.method_content(new StringBuffer(), ctx);
 
-			final Map<String, Object> callParameters = new HashMap<String, Object>();
-			callParameters.put("element", element);
-			CallHelper.executeWithParameterInjection(
-					"platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#_XX5iAaxbEeCYVYqpiRcXMA",
-					new ExecutionContext((InternalPatternContext) ctx), callParameters);
-			stringBuffer.setLength(0);
-		}
+        stringBuffer.append(TEXT_1);
+        {
+            //<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#LogicalName=org.polarsys.capella.docgen.content.EntityContentDocGen" args="element:element"%>
 
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
-	}
+            InternalPatternContext ictx = (InternalPatternContext) ctx;
+            new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
+            stringBuffer.setLength(0);
 
-	public boolean preCondition(PatternContext ctx) throws Exception {
-		return parameter instanceof Entity;
-	}
+            final Map<String, Object> callParameters = new HashMap<String, Object>();
+            callParameters.put("element", element);
+            CallHelper.executeWithParameterInjection("platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#_XX5iAaxbEeCYVYqpiRcXMA",
+                    new ExecutionContext((InternalPatternContext) ctx), callParameters);
+            stringBuffer.setLength(0);
+        }
+
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
+    }
+
+    public boolean preCondition(PatternContext ctx) throws Exception {
+        return parameter instanceof Entity;
+    }
 }

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/ExchangeItemDocGen.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/ExchangeItemDocGen.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.1.201906060805
+//Generated with EGF 1.6.3.202110291409
 package org.polarsys.capella.docgen.content;
 
 import org.eclipse.egf.common.helper.*;
@@ -14,176 +14,177 @@ import org.polarsys.capella.docgen.util.StringUtil;
 import org.polarsys.capella.docgen.util.pattern.helper.CapellaExchangeItemHelper;
 
 public class ExchangeItemDocGen extends org.polarsys.capella.docgen.foundations.NamedElementDocGen {
-	protected static String nl;
+    protected static String nl;
 
-	public static synchronized ExchangeItemDocGen create(String lineSeparator) {
-		nl = lineSeparator;
-		ExchangeItemDocGen result = new ExchangeItemDocGen();
-		nl = null;
-		return result;
-	}
+    public static synchronized ExchangeItemDocGen create(String lineSeparator) {
+        nl = lineSeparator;
+        ExchangeItemDocGen result = new ExchangeItemDocGen();
+        nl = null;
+        return result;
+    }
 
-	public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
-	protected final String TEXT_1 = "<h2>Involving Functional Chains</h2>";
-	protected final String TEXT_2 = NL;
-	protected final String TEXT_3 = NL + "\t\t\t<h2>Interfaces</h2>" + NL + "\t\t\t";
-	protected final String TEXT_4 = NL + "\t\t";
-	protected final String TEXT_5 = NL + "\t\t\t<h2>Exchange Item Elements</h2>" + NL + "\t\t\t";
-	protected final String TEXT_6 = NL + "\t<h2>Functional Exchanges</h2>" + NL + "\t";
-	protected final String TEXT_7 = NL + "<div title=\"Properties Value\">";
-	protected final String TEXT_8 = NL + "</div>";
+    public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
 
-	public ExchangeItemDocGen() {
-		//Here is the constructor
-		StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_1 = "<h2>Involving Functional Chains</h2>";
 
-		// add initialisation of the pattern variables (declaration has been already done).
+    protected final String TEXT_2 = NL;
 
-	}
+    protected final String TEXT_3 = NL + "\t\t\t<h2>Interfaces</h2>" + NL + "\t\t\t";
 
-	public String generate(Object argument) throws Exception {
-		final StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_4 = NL + "\t\t";
 
-		InternalPatternContext ctx = (InternalPatternContext) argument;
-		Map<String, String> queryCtx = null;
-		IQuery.ParameterDescription paramDesc = null;
-		Node.Container currentNode = ctx.getNode();
+    protected final String TEXT_5 = NL + "\t\t\t<h2>Exchange Item Elements</h2>" + NL + "\t\t\t";
 
-		List<Object> parameterList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
+    protected final String TEXT_6 = NL + "\t<h2>Functional Exchanges</h2>" + NL + "\t";
 
-		for (Object parameterParameter : parameterList) {
+    protected final String TEXT_7 = NL + "<div title=\"Properties Value\">";
 
-			this.parameter = (org.polarsys.capella.core.data.information.ExchangeItem) parameterParameter;
+    protected final String TEXT_8 = NL + "</div>";
 
-			if (preCondition(ctx)) {
-				ctx.setNode(new Node.Container(currentNode, getClass()));
-				orchestration(ctx);
-			}
+    public ExchangeItemDocGen() {
+        //Here is the constructor
+        StringBuffer stringBuffer = new StringBuffer();
 
-		}
-		ctx.setNode(currentNode);
-		if (ctx.useReporter()) {
-			ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
-		}
+        // add initialisation of the pattern variables (declaration has been already done).
 
-		stringBuffer.append(TEXT_2);
-		stringBuffer.append(TEXT_2);
-		return stringBuffer.toString();
-	}
+    }
 
-	public String orchestration(PatternContext ctx) throws Exception {
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
+    public String generate(Object argument) throws Exception {
+        final StringBuffer stringBuffer = new StringBuffer();
 
-		super.orchestration(new SuperOrchestrationContext(ictx));
+        InternalPatternContext ctx = (InternalPatternContext) argument;
+        Map<String, String> queryCtx = null;
+        IQuery.ParameterDescription paramDesc = null;
+        Node.Container currentNode = ctx.getNode();
 
-		if (ictx.useReporter()) {
-			Map<String, Object> parameterValues = new HashMap<String, Object>();
-			parameterValues.put("parameter", this.parameter);
-			String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
-			String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
-			ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
-		}
-		return null;
-	}
+        List<Object> parameterList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
 
-	protected org.polarsys.capella.core.data.information.ExchangeItem parameter = null;
+        for (Object parameterParameter : parameterList) {
 
-	public void set_parameter(org.polarsys.capella.core.data.information.ExchangeItem object) {
-		this.parameter = object;
-	}
+            this.parameter = (org.polarsys.capella.core.data.information.ExchangeItem) parameterParameter;
 
-	public Map<String, Object> getParameters() {
-		final Map<String, Object> parameters = new HashMap<String, Object>();
-		parameters.put("parameter", this.parameter);
-		return parameters;
-	}
+            if (preCondition(ctx)) {
+                ctx.setNode(new Node.Container(currentNode, getClass()));
+                orchestration(ctx);
+            }
 
-	protected void method_setCapellaContext(final StringBuffer stringBuffer, final PatternContext ctx)
-			throws Exception {
+        }
+        ctx.setNode(currentNode);
+        if (ctx.useReporter()) {
+            ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
+        }
 
-		element = parameter;
+        stringBuffer.append(TEXT_2);
+        stringBuffer.append(TEXT_2);
+        return stringBuffer.toString();
+    }
 
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "setCapellaContext", stringBuffer.toString());
-	}
+    public String orchestration(PatternContext ctx) throws Exception {
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
 
-	protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+        super.orchestration(new SuperOrchestrationContext(ictx));
 
-		super.method_content(new StringBuffer(), ctx);
-		String projectName = ctx.getValue("projectName").toString();
-		String outputFolder = ctx.getValue("outputFolder").toString();
+        if (ictx.useReporter()) {
+            Map<String, Object> parameterValues = new HashMap<String, Object>();
+            parameterValues.put("parameter", this.parameter);
+            String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
+            String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
+            ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
+        }
+        return null;
+    }
 
-		Collection<String> involvingFunctionalChains = CapellaExchangeItemHelper
-				.getInvolvingFunctionalChains((ExchangeItem) element, projectName, outputFolder);
-		if (involvingFunctionalChains.size() > 0) {
-			stringBuffer.append(TEXT_1);
-			stringBuffer.append(TEXT_2);
-			stringBuffer.append(StringUtil.stringListToBulette(involvingFunctionalChains));
-		}
+    protected org.polarsys.capella.core.data.information.ExchangeItem parameter = null;
 
-		Collection<String> exchangeItemInterfaces = CapellaExchangeItemHelper
-				.getExchangeItemInterfaces((ExchangeItem) element, projectName, outputFolder);
+    public void set_parameter(org.polarsys.capella.core.data.information.ExchangeItem object) {
+        this.parameter = object;
+    }
 
-		if (exchangeItemInterfaces.size() > 0) {
-			stringBuffer.append(TEXT_3);
-			stringBuffer.append(StringUtil.stringListToBulette(exchangeItemInterfaces));
-			stringBuffer.append(TEXT_4);
-		}
+    public Map<String, Object> getParameters() {
+        final Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("parameter", this.parameter);
+        return parameters;
+    }
 
-		Collection<String> exchangeItemElements = CapellaExchangeItemHelper
-				.getExchangeItemElements((ExchangeItem) element, projectName, outputFolder);
-		if (exchangeItemElements.size() > 0) {
-			stringBuffer.append(TEXT_5);
-			stringBuffer.append(StringUtil.stringListToBulette(exchangeItemElements));
-			stringBuffer.append(TEXT_4);
-		}
+    protected void method_setCapellaContext(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-		Collection<String> referencingExchanges = CapellaExchangeItemHelper
-				.getReferencingFunctionalExchanges((ExchangeItem) element, projectName, outputFolder);
-		if (referencingExchanges.size() > 0) {
-			stringBuffer.append(TEXT_6);
-			stringBuffer.append(StringUtil.stringListToBulette(referencingExchanges));
-		}
+        element = parameter;
 
-		Collection<String> propertiesValueCollection = CapellaElementService.getPropertiesValue(element, projectName,
-				outputFolder);
-		if (propertiesValueCollection.size() >= 1) {
-			stringBuffer.append(TEXT_7);
-			String propertyValue = "Properties Value";
-			stringBuffer.append(TEXT_2);
-			{
-				//<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#LogicalName=org.polarsys.kitalpha.doc.gen.business.core.generic.ElementGenerateByPropterty" args="element:eObject,propertyValue:property"%>
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "setCapellaContext", stringBuffer.toString());
+    }
 
-				InternalPatternContext ictx = (InternalPatternContext) ctx;
-				new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
-				stringBuffer.setLength(0);
+    protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-				final Map<String, Object> callParameters = new HashMap<String, Object>();
-				callParameters.put("eObject", element);
-				callParameters.put("property", propertyValue);
-				CallHelper.executeWithParameterInjection(
-						"platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#_cWGxMONUEd-euK0PeLuaMA",
-						new ExecutionContext((InternalPatternContext) ctx), callParameters);
-				stringBuffer.setLength(0);
-			}
+        super.method_content(new StringBuffer(), ctx);
+        String projectName = ctx.getValue("projectName").toString();
+        String outputFolder = ctx.getValue("outputFolder").toString();
 
-			stringBuffer.append(TEXT_2);
-			stringBuffer.append(StringUtil.stringListToBulette(propertiesValueCollection));
-			stringBuffer.append(TEXT_8);
-		}
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
-	}
+        Collection<String> involvingFunctionalChains = CapellaExchangeItemHelper.getInvolvingFunctionalChains((ExchangeItem) element, projectName, outputFolder);
+        if (involvingFunctionalChains.size() > 0) {
+            stringBuffer.append(TEXT_1);
+            stringBuffer.append(TEXT_2);
+            stringBuffer.append(StringUtil.stringListToBulette(involvingFunctionalChains));
+        }
 
-	protected void method_setTitle(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+        Collection<String> exchangeItemInterfaces = CapellaExchangeItemHelper.getExchangeItemInterfaces((ExchangeItem) element, projectName, outputFolder);
 
-		String mecanism = ((ExchangeItem) element).getExchangeMechanism().getName();
-		String elementName = CapellaServices.getHyperlinkFromElement(element);
-		//String elementType = EscapeChars.forHTML(element.eClass().getName());
-		documentTitle = "<span class=\"elementMetaClass\">" + mecanism + "</span> " + elementName;
+        if (exchangeItemInterfaces.size() > 0) {
+            stringBuffer.append(TEXT_3);
+            stringBuffer.append(StringUtil.stringListToBulette(exchangeItemInterfaces));
+            stringBuffer.append(TEXT_4);
+        }
 
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "setTitle", stringBuffer.toString());
-	}
+        Collection<String> exchangeItemElements = CapellaExchangeItemHelper.getExchangeItemElements((ExchangeItem) element, projectName, outputFolder);
+        if (exchangeItemElements.size() > 0) {
+            stringBuffer.append(TEXT_5);
+            stringBuffer.append(StringUtil.stringListToBulette(exchangeItemElements));
+            stringBuffer.append(TEXT_4);
+        }
+
+        Collection<String> referencingExchanges = CapellaExchangeItemHelper.getReferencingFunctionalExchanges((ExchangeItem) element, projectName, outputFolder);
+        if (referencingExchanges.size() > 0) {
+            stringBuffer.append(TEXT_6);
+            stringBuffer.append(StringUtil.stringListToBulette(referencingExchanges));
+        }
+
+        Collection<String> propertiesValueCollection = CapellaElementService.getPropertiesValue(element, projectName, outputFolder);
+        if (propertiesValueCollection.size() >= 1) {
+            stringBuffer.append(TEXT_7);
+            String propertyValue = "Properties Value";
+            stringBuffer.append(TEXT_2);
+            {
+                //<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#LogicalName=org.polarsys.kitalpha.doc.gen.business.core.generic.ElementGenerateByPropterty" args="element:eObject,propertyValue:property"%>
+
+                InternalPatternContext ictx = (InternalPatternContext) ctx;
+                new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
+                stringBuffer.setLength(0);
+
+                final Map<String, Object> callParameters = new HashMap<String, Object>();
+                callParameters.put("eObject", element);
+                callParameters.put("property", propertyValue);
+                CallHelper.executeWithParameterInjection("platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#_cWGxMONUEd-euK0PeLuaMA",
+                        new ExecutionContext((InternalPatternContext) ctx), callParameters);
+                stringBuffer.setLength(0);
+            }
+
+            stringBuffer.append(TEXT_2);
+            stringBuffer.append(StringUtil.stringListToBulette(propertiesValueCollection));
+            stringBuffer.append(TEXT_8);
+        }
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
+    }
+
+    protected void method_setTitle(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+
+        String mecanism = ((ExchangeItem) element).getExchangeMechanism().getName();
+        String elementName = CapellaServices.getHyperlinkFromElement(element);
+        //String elementType = EscapeChars.forHTML(element.eClass().getName());
+        documentTitle = "<span class=\"elementMetaClass\">" + mecanism + "</span> " + elementName;
+
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "setTitle", stringBuffer.toString());
+    }
 }

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/FunctionPortDocGen.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/FunctionPortDocGen.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.1.201906060805
+//Generated with EGF 1.6.3.202110291409
 package org.polarsys.capella.docgen.content;
 
 import org.eclipse.egf.common.helper.*;
@@ -13,145 +13,140 @@ import org.polarsys.capella.docgen.util.CapellaFunctionPortServices;
 import org.polarsys.capella.core.data.fa.FunctionPort;
 
 public class FunctionPortDocGen extends org.polarsys.capella.docgen.foundations.NamedElementDocGen {
-	protected static String nl;
+    protected static String nl;
 
-	public static synchronized FunctionPortDocGen create(String lineSeparator) {
-		nl = lineSeparator;
-		FunctionPortDocGen result = new FunctionPortDocGen();
-		nl = null;
-		return result;
-	}
+    public static synchronized FunctionPortDocGen create(String lineSeparator) {
+        nl = lineSeparator;
+        FunctionPortDocGen result = new FunctionPortDocGen();
+        nl = null;
+        return result;
+    }
 
-	public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
-	protected final String TEXT_1 = "<h2>Incoming Functional Exchanges</h2>" + NL + "" + NL + "<table>" + NL + "\t<tr>"
-			+ NL + "\t\t<th>Exchange</th>" + NL + "\t\t<th>Involving Functional Chains</th>" + NL
-			+ "\t\t<th>Allocating Component Exchanges</th>" + NL + "\t\t<th>Source Port</th>" + NL
-			+ "\t\t<th>Source Function</th>" + NL + "\t\t<th>Description</th>" + NL
-			+ "\t\t<th>Allocated Exchange Items</th>" + NL + "\t\t<th>Realized Functional Exchanges</th>" + NL
-			+ "\t\t<th>Realizing Functional Exchanges</th>" + NL + "\t</tr>";
-	protected final String TEXT_2 = NL + "\t";
-	protected final String TEXT_3 = NL + "</table>";
-	protected final String TEXT_4 = NL + " <h2>Outgoing Functional Exchanges</h2>" + NL + "" + NL + "    <table>" + NL
-			+ "\t<tr>" + NL + "\t\t<th>Exchange</th>" + NL + "\t\t<th>Involving Functional Chains</th>" + NL
-			+ "\t\t<th>Allocating Component Exchanges</th>" + NL + "\t\t<th>Target Port</th>" + NL
-			+ "\t\t<th>Target Function</th>" + NL + "\t\t<th>Description</th>" + NL
-			+ "\t\t<th>Allocated Exchange Items</th>" + NL + "\t\t<th>Realized Functional Exchanges</th>" + NL
-			+ "\t\t<th>Realizing Functional Exchanges</th>" + NL + "\t</tr>";
-	protected final String TEXT_5 = NL;
+    public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
 
-	public FunctionPortDocGen() {
-		//Here is the constructor
-		StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_1 = "<h2>Incoming Functional Exchanges</h2>" + NL + "" + NL + "<table>" + NL + "\t<tr>" + NL + "\t\t<th>Exchange</th>" + NL + "\t\t<th>Involving Functional Chains</th>"
+            + NL + "\t\t<th>Allocating Component Exchanges</th>" + NL + "\t\t<th>Source Port</th>" + NL + "\t\t<th>Source Function</th>" + NL + "\t\t<th>Description</th>" + NL
+            + "\t\t<th>Allocated Exchange Items</th>" + NL + "\t\t<th>Realized Functional Exchanges</th>" + NL + "\t\t<th>Realizing Functional Exchanges</th>" + NL + "\t</tr>";
 
-		// add initialisation of the pattern variables (declaration has been already done).
+    protected final String TEXT_2 = NL + "\t";
 
-	}
+    protected final String TEXT_3 = NL + "</table>";
 
-	public String generate(Object argument) throws Exception {
-		final StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_4 = NL + " <h2>Outgoing Functional Exchanges</h2>" + NL + "" + NL + "    <table>" + NL + "\t<tr>" + NL + "\t\t<th>Exchange</th>" + NL
+            + "\t\t<th>Involving Functional Chains</th>" + NL + "\t\t<th>Allocating Component Exchanges</th>" + NL + "\t\t<th>Target Port</th>" + NL + "\t\t<th>Target Function</th>" + NL
+            + "\t\t<th>Description</th>" + NL + "\t\t<th>Allocated Exchange Items</th>" + NL + "\t\t<th>Realized Functional Exchanges</th>" + NL + "\t\t<th>Realizing Functional Exchanges</th>" + NL
+            + "\t</tr>";
 
-		InternalPatternContext ctx = (InternalPatternContext) argument;
-		Map<String, String> queryCtx = null;
-		IQuery.ParameterDescription paramDesc = null;
-		Node.Container currentNode = ctx.getNode();
+    protected final String TEXT_5 = NL;
 
-		List<Object> parameterList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
+    public FunctionPortDocGen() {
+        //Here is the constructor
+        StringBuffer stringBuffer = new StringBuffer();
 
-		for (Object parameterParameter : parameterList) {
+        // add initialisation of the pattern variables (declaration has been already done).
 
-			this.parameter = (org.polarsys.capella.core.data.fa.FunctionPort) parameterParameter;
+    }
 
-			if (preCondition(ctx)) {
-				ctx.setNode(new Node.Container(currentNode, getClass()));
-				orchestration(ctx);
-			}
+    public String generate(Object argument) throws Exception {
+        final StringBuffer stringBuffer = new StringBuffer();
 
-		}
-		ctx.setNode(currentNode);
-		if (ctx.useReporter()) {
-			ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
-		}
+        InternalPatternContext ctx = (InternalPatternContext) argument;
+        Map<String, String> queryCtx = null;
+        IQuery.ParameterDescription paramDesc = null;
+        Node.Container currentNode = ctx.getNode();
 
-		stringBuffer.append(TEXT_5);
-		stringBuffer.append(TEXT_5);
-		return stringBuffer.toString();
-	}
+        List<Object> parameterList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
 
-	public String orchestration(PatternContext ctx) throws Exception {
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
+        for (Object parameterParameter : parameterList) {
 
-		super.orchestration(new SuperOrchestrationContext(ictx));
+            this.parameter = (org.polarsys.capella.core.data.fa.FunctionPort) parameterParameter;
 
-		if (ictx.useReporter()) {
-			Map<String, Object> parameterValues = new HashMap<String, Object>();
-			parameterValues.put("parameter", this.parameter);
-			String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
-			String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
-			ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
-		}
-		return null;
-	}
+            if (preCondition(ctx)) {
+                ctx.setNode(new Node.Container(currentNode, getClass()));
+                orchestration(ctx);
+            }
 
-	protected org.polarsys.capella.core.data.fa.FunctionPort parameter = null;
+        }
+        ctx.setNode(currentNode);
+        if (ctx.useReporter()) {
+            ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
+        }
 
-	public void set_parameter(org.polarsys.capella.core.data.fa.FunctionPort object) {
-		this.parameter = object;
-	}
+        stringBuffer.append(TEXT_5);
+        stringBuffer.append(TEXT_5);
+        return stringBuffer.toString();
+    }
 
-	public Map<String, Object> getParameters() {
-		final Map<String, Object> parameters = new HashMap<String, Object>();
-		parameters.put("parameter", this.parameter);
-		return parameters;
-	}
+    public String orchestration(PatternContext ctx) throws Exception {
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
 
-	protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+        super.orchestration(new SuperOrchestrationContext(ictx));
 
-		super.method_content(new StringBuffer(), ctx);
-		String projectName = ctx.getValue("projectName").toString();
-		String outputFolder = ctx.getValue("outputFolder").toString();
+        if (ictx.useReporter()) {
+            Map<String, Object> parameterValues = new HashMap<String, Object>();
+            parameterValues.put("parameter", this.parameter);
+            String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
+            String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
+            ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
+        }
+        return null;
+    }
 
-		Collection<FunctionalExchange> incomingFunctionalExchanges = CapellaFunctionPortServices
-				.getIncomingFunctionalExchanges((FunctionPort) element);
-		if (incomingFunctionalExchanges.size() > 0) {
+    protected org.polarsys.capella.core.data.fa.FunctionPort parameter = null;
 
-			stringBuffer.append(TEXT_1);
-			for (FunctionalExchange functionalExchange : incomingFunctionalExchanges) {
+    public void set_parameter(org.polarsys.capella.core.data.fa.FunctionPort object) {
+        this.parameter = object;
+    }
 
-				stringBuffer.append(TEXT_2);
-				stringBuffer.append(CapellaFunctionServices.incomingFunctionalExchangeToTableLine(functionalExchange,
-						projectName, outputFolder));
-				stringBuffer.append(TEXT_2);
+    public Map<String, Object> getParameters() {
+        final Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("parameter", this.parameter);
+        return parameters;
+    }
 
-			}
-			stringBuffer.append(TEXT_3);
+    protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-		}
+        super.method_content(new StringBuffer(), ctx);
+        String projectName = ctx.getValue("projectName").toString();
+        String outputFolder = ctx.getValue("outputFolder").toString();
 
-		Collection<FunctionalExchange> outgoingFunctionalExchanges = CapellaFunctionPortServices
-				.getOutgoingFunctionalExchanges((FunctionPort) element);
-		if (outgoingFunctionalExchanges.size() > 0) {
+        Collection<FunctionalExchange> incomingFunctionalExchanges = CapellaFunctionPortServices.getIncomingFunctionalExchanges((FunctionPort) element);
+        if (incomingFunctionalExchanges.size() > 0) {
 
-			stringBuffer.append(TEXT_4);
-			for (FunctionalExchange functionalExchange : outgoingFunctionalExchanges) {
-				stringBuffer.append(TEXT_2);
-				stringBuffer.append(CapellaFunctionServices.outgoingFunctionalExchangeToTableLine(functionalExchange,
-						projectName, outputFolder));
-			}
-			stringBuffer.append(TEXT_3);
+            stringBuffer.append(TEXT_1);
+            for (FunctionalExchange functionalExchange : incomingFunctionalExchanges) {
 
-		}
+                stringBuffer.append(TEXT_2);
+                stringBuffer.append(CapellaFunctionServices.incomingFunctionalExchangeToTableLine(functionalExchange, projectName, outputFolder));
+                stringBuffer.append(TEXT_2);
 
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
-	}
+            }
+            stringBuffer.append(TEXT_3);
 
-	protected void method_setCapellaContext(final StringBuffer stringBuffer, final PatternContext ctx)
-			throws Exception {
+        }
 
-		element = parameter;
+        Collection<FunctionalExchange> outgoingFunctionalExchanges = CapellaFunctionPortServices.getOutgoingFunctionalExchanges((FunctionPort) element);
+        if (outgoingFunctionalExchanges.size() > 0) {
 
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "setCapellaContext", stringBuffer.toString());
-	}
+            stringBuffer.append(TEXT_4);
+            for (FunctionalExchange functionalExchange : outgoingFunctionalExchanges) {
+                stringBuffer.append(TEXT_2);
+                stringBuffer.append(CapellaFunctionServices.outgoingFunctionalExchangeToTableLine(functionalExchange, projectName, outputFolder));
+            }
+            stringBuffer.append(TEXT_3);
+
+        }
+
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
+    }
+
+    protected void method_setCapellaContext(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+
+        element = parameter;
+
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "setCapellaContext", stringBuffer.toString());
+    }
 }

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/FunctionalChainGenDoc.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/FunctionalChainGenDoc.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.1.201906060805
+//Generated with EGF 1.6.3.202110291409
 package org.polarsys.capella.docgen.content;
 
 import java.util.*;
@@ -11,156 +11,156 @@ import org.polarsys.capella.core.data.fa.FunctionalChain;
 import org.polarsys.capella.core.data.oa.OperationalProcess;
 
 public class FunctionalChainGenDoc extends org.polarsys.capella.docgen.foundations.NamedElementDocGen {
-	protected static String nl;
+    protected static String nl;
 
-	public static synchronized FunctionalChainGenDoc create(String lineSeparator) {
-		nl = lineSeparator;
-		FunctionalChainGenDoc result = new FunctionalChainGenDoc();
-		nl = null;
-		return result;
-	}
+    public static synchronized FunctionalChainGenDoc create(String lineSeparator) {
+        nl = lineSeparator;
+        FunctionalChainGenDoc result = new FunctionalChainGenDoc();
+        nl = null;
+        return result;
+    }
 
-	public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
-	protected final String TEXT_1 = "<h2>Modes and States</h2>";
-	protected final String TEXT_2 = NL;
-	protected final String TEXT_3 = NL + "<h2>Involved activities</h2>";
-	protected final String TEXT_4 = NL + "<h2>Involved functions</h2>";
-	protected final String TEXT_5 = NL + "<h2>Involved interactions</h2>";
-	protected final String TEXT_6 = NL + "<h2>Involved functional exchanges</h2>";
+    public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
 
-	public FunctionalChainGenDoc() {
-		//Here is the constructor
-		StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_1 = "<h2>Modes and States</h2>";
 
-		// add initialisation of the pattern variables (declaration has been already done).
+    protected final String TEXT_2 = NL;
 
-	}
+    protected final String TEXT_3 = NL + "<h2>Involved activities</h2>";
 
-	public String generate(Object argument) throws Exception {
-		final StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_4 = NL + "<h2>Involved functions</h2>";
 
-		InternalPatternContext ctx = (InternalPatternContext) argument;
-		Map<String, String> queryCtx = null;
-		IQuery.ParameterDescription paramDesc = null;
-		Node.Container currentNode = ctx.getNode();
+    protected final String TEXT_5 = NL + "<h2>Involved interactions</h2>";
 
-		List<Object> parameterList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
+    protected final String TEXT_6 = NL + "<h2>Involved functional exchanges</h2>";
 
-		for (Object parameterParameter : parameterList) {
+    public FunctionalChainGenDoc() {
+        //Here is the constructor
+        StringBuffer stringBuffer = new StringBuffer();
 
-			this.parameter = (org.polarsys.capella.core.data.fa.FunctionalChain) parameterParameter;
+        // add initialisation of the pattern variables (declaration has been already done).
 
-			if (preCondition(ctx)) {
-				ctx.setNode(new Node.Container(currentNode, getClass()));
-				orchestration(ctx);
-			}
+    }
 
-		}
-		ctx.setNode(currentNode);
-		if (ctx.useReporter()) {
-			ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
-		}
+    public String generate(Object argument) throws Exception {
+        final StringBuffer stringBuffer = new StringBuffer();
 
-		stringBuffer.append(TEXT_2);
-		stringBuffer.append(TEXT_2);
-		return stringBuffer.toString();
-	}
+        InternalPatternContext ctx = (InternalPatternContext) argument;
+        Map<String, String> queryCtx = null;
+        IQuery.ParameterDescription paramDesc = null;
+        Node.Container currentNode = ctx.getNode();
 
-	public String orchestration(PatternContext ctx) throws Exception {
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
+        List<Object> parameterList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
 
-		super.orchestration(new SuperOrchestrationContext(ictx));
+        for (Object parameterParameter : parameterList) {
 
-		if (ictx.useReporter()) {
-			Map<String, Object> parameterValues = new HashMap<String, Object>();
-			parameterValues.put("parameter", this.parameter);
-			String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
-			String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
-			ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
-		}
-		return null;
-	}
+            this.parameter = (org.polarsys.capella.core.data.fa.FunctionalChain) parameterParameter;
 
-	protected org.polarsys.capella.core.data.fa.FunctionalChain parameter = null;
+            if (preCondition(ctx)) {
+                ctx.setNode(new Node.Container(currentNode, getClass()));
+                orchestration(ctx);
+            }
 
-	public void set_parameter(org.polarsys.capella.core.data.fa.FunctionalChain object) {
-		this.parameter = object;
-	}
+        }
+        ctx.setNode(currentNode);
+        if (ctx.useReporter()) {
+            ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
+        }
 
-	public Map<String, Object> getParameters() {
-		final Map<String, Object> parameters = new HashMap<String, Object>();
-		parameters.put("parameter", this.parameter);
-		return parameters;
-	}
+        stringBuffer.append(TEXT_2);
+        stringBuffer.append(TEXT_2);
+        return stringBuffer.toString();
+    }
 
-	protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+    public String orchestration(PatternContext ctx) throws Exception {
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
 
-		super.method_content(new StringBuffer(), ctx);
-		String projectName = ctx.getValue("projectName").toString();
-		String outputFolder = ctx.getValue("outputFolder").toString();
+        super.orchestration(new SuperOrchestrationContext(ictx));
 
-		Collection<String> availableModeAndState = FunctionalChainHelper.getAvailableModeAndState(projectName,
-				outputFolder, (FunctionalChain) parameter);
+        if (ictx.useReporter()) {
+            Map<String, Object> parameterValues = new HashMap<String, Object>();
+            parameterValues.put("parameter", this.parameter);
+            String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
+            String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
+            ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
+        }
+        return null;
+    }
 
-		if (availableModeAndState.size() > 0) {
+    protected org.polarsys.capella.core.data.fa.FunctionalChain parameter = null;
 
-			stringBuffer.append(TEXT_1);
-			stringBuffer.append(TEXT_2);
-			stringBuffer.append(StringUtil.stringListToBulette(availableModeAndState));
+    public void set_parameter(org.polarsys.capella.core.data.fa.FunctionalChain object) {
+        this.parameter = object;
+    }
 
-		}
+    public Map<String, Object> getParameters() {
+        final Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("parameter", this.parameter);
+        return parameters;
+    }
 
-		Map<String, String> functionAndDesc = FunctionalChainHelper
-				.getAvailableFunctionWithInvolvementDescription(projectName, outputFolder, (FunctionalChain) parameter);
+    protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-		if (functionAndDesc.size() > 0) {
-			if (parameter instanceof OperationalProcess) {
+        super.method_content(new StringBuffer(), ctx);
+        String projectName = ctx.getValue("projectName").toString();
+        String outputFolder = ctx.getValue("outputFolder").toString();
 
-				stringBuffer.append(TEXT_3);
-				stringBuffer.append(TEXT_2);
-				stringBuffer.append(StringUtil.mapToHTMLTable(functionAndDesc, "Activity", "Involvement Description"));
+        Collection<String> availableModeAndState = FunctionalChainHelper.getAvailableModeAndState(projectName, outputFolder, (FunctionalChain) parameter);
 
-			} else {
+        if (availableModeAndState.size() > 0) {
 
-				stringBuffer.append(TEXT_4);
-				stringBuffer.append(TEXT_2);
-				stringBuffer.append(StringUtil.mapToHTMLTable(functionAndDesc, "Function", "Involvement Description"));
+            stringBuffer.append(TEXT_1);
+            stringBuffer.append(TEXT_2);
+            stringBuffer.append(StringUtil.stringListToBulette(availableModeAndState));
 
-			}
-		}
+        }
 
-		Map<String, String> functionalExchangesAndDesc = FunctionalChainHelper
-				.getInvolvedFunctionalExchanges(projectName, outputFolder, (FunctionalChain) parameter);
+        Map<String, String> functionAndDesc = FunctionalChainHelper.getAvailableFunctionWithInvolvementDescription(projectName, outputFolder, (FunctionalChain) parameter);
 
-		if (functionalExchangesAndDesc.size() > 0) {
-			if (parameter instanceof OperationalProcess) {
+        if (functionAndDesc.size() > 0) {
+            if (parameter instanceof OperationalProcess) {
 
-				stringBuffer.append(TEXT_5);
-				stringBuffer.append(TEXT_2);
-				stringBuffer.append(StringUtil.mapToHTMLTable(functionalExchangesAndDesc, "Interaction",
-						"Involvement Description"));
+                stringBuffer.append(TEXT_3);
+                stringBuffer.append(TEXT_2);
+                stringBuffer.append(StringUtil.mapToHTMLTable(functionAndDesc, "Activity", "Involvement Description"));
 
-			} else {
+            } else {
 
-				stringBuffer.append(TEXT_6);
-				stringBuffer.append(TEXT_2);
-				stringBuffer.append(StringUtil.mapToHTMLTable(functionalExchangesAndDesc, "Functional Exchange",
-						"Involvement Description"));
+                stringBuffer.append(TEXT_4);
+                stringBuffer.append(TEXT_2);
+                stringBuffer.append(StringUtil.mapToHTMLTable(functionAndDesc, "Function", "Involvement Description"));
 
-			}
-		}
+            }
+        }
 
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
-	}
+        Map<String, String> functionalExchangesAndDesc = FunctionalChainHelper.getInvolvedFunctionalExchanges(projectName, outputFolder, (FunctionalChain) parameter);
 
-	protected void method_setCapellaContext(final StringBuffer stringBuffer, final PatternContext ctx)
-			throws Exception {
+        if (functionalExchangesAndDesc.size() > 0) {
+            if (parameter instanceof OperationalProcess) {
 
-		element = parameter;
+                stringBuffer.append(TEXT_5);
+                stringBuffer.append(TEXT_2);
+                stringBuffer.append(StringUtil.mapToHTMLTable(functionalExchangesAndDesc, "Interaction", "Involvement Description"));
 
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "setCapellaContext", stringBuffer.toString());
-	}
+            } else {
+
+                stringBuffer.append(TEXT_6);
+                stringBuffer.append(TEXT_2);
+                stringBuffer.append(StringUtil.mapToHTMLTable(functionalExchangesAndDesc, "Functional Exchange", "Involvement Description"));
+
+            }
+        }
+
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
+    }
+
+    protected void method_setCapellaContext(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+
+        element = parameter;
+
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "setCapellaContext", stringBuffer.toString());
+    }
 }

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/FunctionalExchangeDocGen.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/FunctionalExchangeDocGen.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.1.201906060805
+//Generated with EGF 1.6.3.202110291409
 package org.polarsys.capella.docgen.content;
 
 import org.eclipse.emf.common.util.EList;
@@ -15,118 +15,119 @@ import org.polarsys.capella.core.data.fa.FunctionalExchange;
 import org.polarsys.capella.docgen.preference.CapellaDocgenPreferenceHelper;
 
 public class FunctionalExchangeDocGen extends org.polarsys.capella.docgen.foundations.AbstractExchangeDocGen {
-	protected static String nl;
+    protected static String nl;
 
-	public static synchronized FunctionalExchangeDocGen create(String lineSeparator) {
-		nl = lineSeparator;
-		FunctionalExchangeDocGen result = new FunctionalExchangeDocGen();
-		nl = null;
-		return result;
-	}
+    public static synchronized FunctionalExchangeDocGen create(String lineSeparator) {
+        nl = lineSeparator;
+        FunctionalExchangeDocGen result = new FunctionalExchangeDocGen();
+        nl = null;
+        return result;
+    }
 
-	public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
-	protected final String TEXT_1 = "";
-	protected final String TEXT_2 = NL + "<h2>Involving Functional Chains</h2>" + NL;
-	protected final String TEXT_3 = NL;
+    public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
 
-	public FunctionalExchangeDocGen() {
-		//Here is the constructor
-		StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_1 = "";
 
-		// add initialisation of the pattern variables (declaration has been already done).
+    protected final String TEXT_2 = NL + "<h2>Involving Functional Chains</h2>" + NL;
 
-	}
+    protected final String TEXT_3 = NL;
 
-	public String generate(Object argument) throws Exception {
-		final StringBuffer stringBuffer = new StringBuffer();
-		stringBuffer.append(TEXT_1);
+    public FunctionalExchangeDocGen() {
+        //Here is the constructor
+        StringBuffer stringBuffer = new StringBuffer();
 
-		InternalPatternContext ctx = (InternalPatternContext) argument;
-		Map<String, String> queryCtx = null;
-		IQuery.ParameterDescription paramDesc = null;
-		Node.Container currentNode = ctx.getNode();
+        // add initialisation of the pattern variables (declaration has been already done).
 
-		List<Object> parameterList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
+    }
 
-		for (Object parameterParameter : parameterList) {
+    public String generate(Object argument) throws Exception {
+        final StringBuffer stringBuffer = new StringBuffer();
+        stringBuffer.append(TEXT_1);
 
-			this.parameter = (org.polarsys.capella.core.data.fa.FunctionalExchange) parameterParameter;
+        InternalPatternContext ctx = (InternalPatternContext) argument;
+        Map<String, String> queryCtx = null;
+        IQuery.ParameterDescription paramDesc = null;
+        Node.Container currentNode = ctx.getNode();
 
-			if (preCondition(ctx)) {
-				ctx.setNode(new Node.Container(currentNode, getClass()));
-				orchestration(ctx);
-			}
+        List<Object> parameterList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
 
-		}
-		ctx.setNode(currentNode);
-		if (ctx.useReporter()) {
-			ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
-		}
+        for (Object parameterParameter : parameterList) {
 
-		stringBuffer.append(TEXT_3);
-		stringBuffer.append(TEXT_3);
-		return stringBuffer.toString();
-	}
+            this.parameter = (org.polarsys.capella.core.data.fa.FunctionalExchange) parameterParameter;
 
-	public String orchestration(PatternContext ctx) throws Exception {
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
+            if (preCondition(ctx)) {
+                ctx.setNode(new Node.Container(currentNode, getClass()));
+                orchestration(ctx);
+            }
 
-		super.orchestration(new SuperOrchestrationContext(ictx));
+        }
+        ctx.setNode(currentNode);
+        if (ctx.useReporter()) {
+            ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
+        }
 
-		if (ictx.useReporter()) {
-			Map<String, Object> parameterValues = new HashMap<String, Object>();
-			parameterValues.put("parameter", this.parameter);
-			String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
-			String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
-			ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
-		}
-		return null;
-	}
+        stringBuffer.append(TEXT_3);
+        stringBuffer.append(TEXT_3);
+        return stringBuffer.toString();
+    }
 
-	protected org.polarsys.capella.core.data.fa.FunctionalExchange parameter = null;
+    public String orchestration(PatternContext ctx) throws Exception {
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
 
-	public void set_parameter(org.polarsys.capella.core.data.fa.FunctionalExchange object) {
-		this.parameter = object;
-	}
+        super.orchestration(new SuperOrchestrationContext(ictx));
 
-	public Map<String, Object> getParameters() {
-		final Map<String, Object> parameters = new HashMap<String, Object>();
-		parameters.put("parameter", this.parameter);
-		return parameters;
-	}
+        if (ictx.useReporter()) {
+            Map<String, Object> parameterValues = new HashMap<String, Object>();
+            parameterValues.put("parameter", this.parameter);
+            String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
+            String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
+            ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
+        }
+        return null;
+    }
 
-	protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+    protected org.polarsys.capella.core.data.fa.FunctionalExchange parameter = null;
 
-		super.method_content(new StringBuffer(), ctx);
-		String projectName = ctx.getValue("projectName").toString();
-		String outputFolder = ctx.getValue("outputFolder").toString();
+    public void set_parameter(org.polarsys.capella.core.data.fa.FunctionalExchange object) {
+        this.parameter = object;
+    }
 
-		EList<FunctionalChain> involvingFunctionalChains = ((FunctionalExchange) element)
-				.getInvolvingFunctionalChains();
-		if (involvingFunctionalChains.size() > 0) {
+    public Map<String, Object> getParameters() {
+        final Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("parameter", this.parameter);
+        return parameters;
+    }
 
-			stringBuffer.append(TEXT_2);
-			stringBuffer.append(TEXT_3);
-			stringBuffer.append(StringUtil.stringListToBulette(involvingFunctionalChains, projectName, outputFolder));
+    protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-		}
+        super.method_content(new StringBuffer(), ctx);
+        String projectName = ctx.getValue("projectName").toString();
+        String outputFolder = ctx.getValue("outputFolder").toString();
 
-		stringBuffer.append(TEXT_3);
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
-	}
+        EList<FunctionalChain> involvingFunctionalChains = ((FunctionalExchange) element).getInvolvingFunctionalChains();
+        if (involvingFunctionalChains.size() > 0) {
 
-	protected void method_setCapellaContext(final StringBuffer stringBuffer, final PatternContext ctx)
-			throws Exception {
+            stringBuffer.append(TEXT_2);
+            stringBuffer.append(TEXT_3);
+            stringBuffer.append(StringUtil.stringListToBulette(involvingFunctionalChains, projectName, outputFolder));
 
-		element = parameter;
+        }
 
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "setCapellaContext", stringBuffer.toString());
-	}
+        stringBuffer.append(TEXT_3);
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
+    }
 
-	public boolean preCondition(PatternContext ctx) throws Exception {
-		return CapellaDocgenPreferenceHelper.isExportFunctionalExchange();
-	}
+    protected void method_setCapellaContext(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+
+        element = parameter;
+
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "setCapellaContext", stringBuffer.toString());
+    }
+
+    public boolean preCondition(PatternContext ctx) throws Exception {
+        return CapellaDocgenPreferenceHelper.isExportFunctionalExchange();
+    }
 }

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/GeneralizableElementDocGen.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/GeneralizableElementDocGen.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.1.201906060805
+//Generated with EGF 1.6.3.202110291409
 package org.polarsys.capella.docgen.content;
 
 import org.eclipse.egf.common.helper.*;
@@ -11,142 +11,143 @@ import org.polarsys.capella.docgen.util.GeneralizableElementServices;
 import org.polarsys.capella.docgen.util.StringUtil;
 
 public class GeneralizableElementDocGen extends org.polarsys.capella.docgen.foundations.NamedElementDocGen {
-	protected static String nl;
+    protected static String nl;
 
-	public static synchronized GeneralizableElementDocGen create(String lineSeparator) {
-		nl = lineSeparator;
-		GeneralizableElementDocGen result = new GeneralizableElementDocGen();
-		nl = null;
-		return result;
-	}
+    public static synchronized GeneralizableElementDocGen create(String lineSeparator) {
+        nl = lineSeparator;
+        GeneralizableElementDocGen result = new GeneralizableElementDocGen();
+        nl = null;
+        return result;
+    }
 
-	public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
-	protected final String TEXT_1 = "";
-	protected final String TEXT_2 = NL + "<h2>Inheriting from</h2>";
-	protected final String TEXT_3 = NL;
-	protected final String TEXT_4 = NL + "<div title=\"Inherited by\">";
-	protected final String TEXT_5 = NL + "</div>";
+    public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
 
-	public GeneralizableElementDocGen() {
-		//Here is the constructor
-		StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_1 = "";
 
-		// add initialisation of the pattern variables (declaration has been already done).
+    protected final String TEXT_2 = NL + "<h2>Inheriting from</h2>";
 
-	}
+    protected final String TEXT_3 = NL;
 
-	public String generate(Object argument) throws Exception {
-		final StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_4 = NL + "<div title=\"Inherited by\">";
 
-		InternalPatternContext ctx = (InternalPatternContext) argument;
-		Map<String, String> queryCtx = null;
-		IQuery.ParameterDescription paramDesc = null;
-		Node.Container currentNode = ctx.getNode();
+    protected final String TEXT_5 = NL + "</div>";
 
-		List<Object> parameterList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
+    public GeneralizableElementDocGen() {
+        //Here is the constructor
+        StringBuffer stringBuffer = new StringBuffer();
 
-		for (Object parameterParameter : parameterList) {
+        // add initialisation of the pattern variables (declaration has been already done).
 
-			this.parameter = (org.polarsys.capella.core.data.capellacore.GeneralizableElement) parameterParameter;
+    }
 
-			if (preCondition(ctx)) {
-				ctx.setNode(new Node.Container(currentNode, getClass()));
-				orchestration(ctx);
-			}
+    public String generate(Object argument) throws Exception {
+        final StringBuffer stringBuffer = new StringBuffer();
 
-		}
-		ctx.setNode(currentNode);
-		if (ctx.useReporter()) {
-			ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
-		}
+        InternalPatternContext ctx = (InternalPatternContext) argument;
+        Map<String, String> queryCtx = null;
+        IQuery.ParameterDescription paramDesc = null;
+        Node.Container currentNode = ctx.getNode();
 
-		stringBuffer.append(TEXT_3);
-		stringBuffer.append(TEXT_3);
-		return stringBuffer.toString();
-	}
+        List<Object> parameterList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
 
-	public String orchestration(PatternContext ctx) throws Exception {
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
+        for (Object parameterParameter : parameterList) {
 
-		super.orchestration(new SuperOrchestrationContext(ictx));
+            this.parameter = (org.polarsys.capella.core.data.capellacore.GeneralizableElement) parameterParameter;
 
-		if (ictx.useReporter()) {
-			Map<String, Object> parameterValues = new HashMap<String, Object>();
-			parameterValues.put("parameter", this.parameter);
-			String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
-			String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
-			ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
-		}
-		return null;
-	}
+            if (preCondition(ctx)) {
+                ctx.setNode(new Node.Container(currentNode, getClass()));
+                orchestration(ctx);
+            }
 
-	protected org.polarsys.capella.core.data.capellacore.GeneralizableElement parameter = null;
+        }
+        ctx.setNode(currentNode);
+        if (ctx.useReporter()) {
+            ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
+        }
 
-	public void set_parameter(org.polarsys.capella.core.data.capellacore.GeneralizableElement object) {
-		this.parameter = object;
-	}
+        stringBuffer.append(TEXT_3);
+        stringBuffer.append(TEXT_3);
+        return stringBuffer.toString();
+    }
 
-	public Map<String, Object> getParameters() {
-		final Map<String, Object> parameters = new HashMap<String, Object>();
-		parameters.put("parameter", this.parameter);
-		return parameters;
-	}
+    public String orchestration(PatternContext ctx) throws Exception {
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
 
-	protected void method_setCapellaContext(final StringBuffer stringBuffer, final PatternContext ctx)
-			throws Exception {
+        super.orchestration(new SuperOrchestrationContext(ictx));
 
-		element = parameter;
+        if (ictx.useReporter()) {
+            Map<String, Object> parameterValues = new HashMap<String, Object>();
+            parameterValues.put("parameter", this.parameter);
+            String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
+            String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
+            ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
+        }
+        return null;
+    }
 
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "setCapellaContext", stringBuffer.toString());
-	}
+    protected org.polarsys.capella.core.data.capellacore.GeneralizableElement parameter = null;
 
-	protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+    public void set_parameter(org.polarsys.capella.core.data.capellacore.GeneralizableElement object) {
+        this.parameter = object;
+    }
 
-		super.method_content(new StringBuffer(), ctx);
-		String projectName = ctx.getValue("projectName").toString();
-		String outputFolder = ctx.getValue("outputFolder").toString();
+    public Map<String, Object> getParameters() {
+        final Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("parameter", this.parameter);
+        return parameters;
+    }
 
-		stringBuffer.append(TEXT_1);
+    protected void method_setCapellaContext(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-		Collection<String> inheritingFromCollection = GeneralizableElementServices.getClassInheritingFrom(element,
-				projectName, outputFolder);
-		if (inheritingFromCollection.size() >= 1) {
-			stringBuffer.append(TEXT_2);
-			stringBuffer.append(TEXT_3);
-			stringBuffer.append(StringUtil.stringListToBulette(inheritingFromCollection));
-			stringBuffer.append(TEXT_3);
-		}
-		stringBuffer.append(TEXT_3);
+        element = parameter;
 
-		Collection<String> inheritedByCollection = GeneralizableElementServices.getClassInheritedBy(element,
-				projectName, outputFolder);
-		if (inheritedByCollection.size() >= 1) {
-			stringBuffer.append(TEXT_4);
-			String inheritedBy = "Inherited by";
-			stringBuffer.append(TEXT_3);
-			{
-				//<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#LogicalName=org.polarsys.kitalpha.doc.gen.business.core.generic.ElementGenerateByPropterty" args="element:eObject,inheritedBy:property"%>
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "setCapellaContext", stringBuffer.toString());
+    }
 
-				InternalPatternContext ictx = (InternalPatternContext) ctx;
-				new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
-				stringBuffer.setLength(0);
+    protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-				final Map<String, Object> callParameters = new HashMap<String, Object>();
-				callParameters.put("eObject", element);
-				callParameters.put("property", inheritedBy);
-				CallHelper.executeWithParameterInjection(
-						"platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#_cWGxMONUEd-euK0PeLuaMA",
-						new ExecutionContext((InternalPatternContext) ctx), callParameters);
-				stringBuffer.setLength(0);
-			}
+        super.method_content(new StringBuffer(), ctx);
+        String projectName = ctx.getValue("projectName").toString();
+        String outputFolder = ctx.getValue("outputFolder").toString();
 
-			stringBuffer.append(TEXT_3);
-			stringBuffer.append(StringUtil.stringListToBulette(inheritedByCollection));
-			stringBuffer.append(TEXT_5);
-		}
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
-	}
+        stringBuffer.append(TEXT_1);
+
+        Collection<String> inheritingFromCollection = GeneralizableElementServices.getClassInheritingFrom(element, projectName, outputFolder);
+        if (inheritingFromCollection.size() >= 1) {
+            stringBuffer.append(TEXT_2);
+            stringBuffer.append(TEXT_3);
+            stringBuffer.append(StringUtil.stringListToBulette(inheritingFromCollection));
+            stringBuffer.append(TEXT_3);
+        }
+        stringBuffer.append(TEXT_3);
+
+        Collection<String> inheritedByCollection = GeneralizableElementServices.getClassInheritedBy(element, projectName, outputFolder);
+        if (inheritedByCollection.size() >= 1) {
+            stringBuffer.append(TEXT_4);
+            String inheritedBy = "Inherited by";
+            stringBuffer.append(TEXT_3);
+            {
+                //<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#LogicalName=org.polarsys.kitalpha.doc.gen.business.core.generic.ElementGenerateByPropterty" args="element:eObject,inheritedBy:property"%>
+
+                InternalPatternContext ictx = (InternalPatternContext) ctx;
+                new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
+                stringBuffer.setLength(0);
+
+                final Map<String, Object> callParameters = new HashMap<String, Object>();
+                callParameters.put("eObject", element);
+                callParameters.put("property", inheritedBy);
+                CallHelper.executeWithParameterInjection("platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#_cWGxMONUEd-euK0PeLuaMA",
+                        new ExecutionContext((InternalPatternContext) ctx), callParameters);
+                stringBuffer.setLength(0);
+            }
+
+            stringBuffer.append(TEXT_3);
+            stringBuffer.append(StringUtil.stringListToBulette(inheritedByCollection));
+            stringBuffer.append(TEXT_5);
+        }
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
+    }
 }

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/InterfaceDocGen.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/InterfaceDocGen.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.1.201906060805
+//Generated with EGF 1.6.3.202110291409
 package org.polarsys.capella.docgen.content;
 
 import org.eclipse.egf.common.helper.*;
@@ -14,194 +14,195 @@ import org.polarsys.capella.core.data.capellacore.VisibilityKind;
 import org.polarsys.capella.core.data.cs.Interface;
 
 public class InterfaceDocGen extends org.polarsys.capella.docgen.content.ClassifierDocGen {
-	protected static String nl;
+    protected static String nl;
 
-	public static synchronized InterfaceDocGen create(String lineSeparator) {
-		nl = lineSeparator;
-		InterfaceDocGen result = new InterfaceDocGen();
-		nl = null;
-		return result;
-	}
+    public static synchronized InterfaceDocGen create(String lineSeparator) {
+        nl = lineSeparator;
+        InterfaceDocGen result = new InterfaceDocGen();
+        nl = null;
+        return result;
+    }
 
-	public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
-	protected final String TEXT_1 = "<h2>Usage</h2>";
-	protected final String TEXT_2 = NL + "\t <h3>Provided by</h3>" + NL + " \t";
-	protected final String TEXT_3 = NL + "\t <h3>Implemented by</h3>" + NL + " \t";
-	protected final String TEXT_4 = NL + " \t<h3>Required by</h3>" + NL + " \t";
-	protected final String TEXT_5 = NL + "\t <h3>Used by</h3>" + NL + " \t";
-	protected final String TEXT_6 = NL + "<h2>Operations</h2>";
-	protected final String TEXT_7 = NL;
-	protected final String TEXT_8 = NL + "<h2> Flow </h2>";
-	protected final String TEXT_9 = NL + "<h2>Shared Data</h2>";
-	protected final String TEXT_10 = NL + "<h2>Events</h2>";
-	protected final String TEXT_11 = NL + "<h2>Unset Exchange Items</h2>";
+    public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
 
-	public InterfaceDocGen() {
-		//Here is the constructor
-		StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_1 = "<h2>Usage</h2>";
 
-		// add initialisation of the pattern variables (declaration has been already done).
+    protected final String TEXT_2 = NL + "\t <h3>Provided by</h3>" + NL + " \t";
 
-	}
+    protected final String TEXT_3 = NL + "\t <h3>Implemented by</h3>" + NL + " \t";
 
-	public String generate(Object argument) throws Exception {
-		final StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_4 = NL + " \t<h3>Required by</h3>" + NL + " \t";
 
-		InternalPatternContext ctx = (InternalPatternContext) argument;
-		Map<String, String> queryCtx = null;
-		IQuery.ParameterDescription paramDesc = null;
-		Node.Container currentNode = ctx.getNode();
+    protected final String TEXT_5 = NL + "\t <h3>Used by</h3>" + NL + " \t";
 
-		List<Object> parameterList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
+    protected final String TEXT_6 = NL + "<h2>Operations</h2>";
 
-		for (Object parameterParameter : parameterList) {
+    protected final String TEXT_7 = NL;
 
-			this.parameter = (org.polarsys.capella.core.data.capellacore.GeneralizableElement) parameterParameter;
+    protected final String TEXT_8 = NL + "<h2> Flow </h2>";
 
-			if (preCondition(ctx)) {
-				ctx.setNode(new Node.Container(currentNode, getClass()));
-				orchestration(ctx);
-			}
+    protected final String TEXT_9 = NL + "<h2>Shared Data</h2>";
 
-		}
-		ctx.setNode(currentNode);
-		if (ctx.useReporter()) {
-			ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
-		}
+    protected final String TEXT_10 = NL + "<h2>Events</h2>";
 
-		stringBuffer.append(TEXT_7);
-		stringBuffer.append(TEXT_7);
-		return stringBuffer.toString();
-	}
+    protected final String TEXT_11 = NL + "<h2>Unset Exchange Items</h2>";
 
-	public String orchestration(PatternContext ctx) throws Exception {
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
+    public InterfaceDocGen() {
+        //Here is the constructor
+        StringBuffer stringBuffer = new StringBuffer();
 
-		super.orchestration(new SuperOrchestrationContext(ictx));
+        // add initialisation of the pattern variables (declaration has been already done).
 
-		if (ictx.useReporter()) {
-			Map<String, Object> parameterValues = new HashMap<String, Object>();
-			parameterValues.put("parameter", this.parameter);
-			String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
-			String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
-			ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
-		}
-		return null;
-	}
+    }
 
-	public Map<String, Object> getParameters() {
-		final Map<String, Object> parameters = new HashMap<String, Object>();
-		parameters.put("parameter", this.parameter);
-		return parameters;
-	}
+    public String generate(Object argument) throws Exception {
+        final StringBuffer stringBuffer = new StringBuffer();
 
-	protected void method_setTitle(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+        InternalPatternContext ctx = (InternalPatternContext) argument;
+        Map<String, String> queryCtx = null;
+        IQuery.ParameterDescription paramDesc = null;
+        Node.Container currentNode = ctx.getNode();
 
-		String visibility = "";
-		if (((Interface) element).getVisibility().getValue() != VisibilityKind.UNSET_VALUE)
-			visibility = "{" + ((Interface) element).getVisibility().getLiteral().toLowerCase() + "} ";
-		String type = element.eClass().getName();
-		String elementFullName = CapellaServices.getFullDataPkgHierarchyLink(element);
-		documentTitle = "<span class=\"elementMetaClass\">" + visibility + "</span> " + elementFullName;
+        List<Object> parameterList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
 
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "setTitle", stringBuffer.toString());
-	}
+        for (Object parameterParameter : parameterList) {
 
-	protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+            this.parameter = (org.polarsys.capella.core.data.capellacore.GeneralizableElement) parameterParameter;
 
-		super.method_content(new StringBuffer(), ctx);
-		String projectName = ctx.getValue("projectName").toString();
-		String outputFolder = ctx.getValue("outputFolder").toString();
+            if (preCondition(ctx)) {
+                ctx.setNode(new Node.Container(currentNode, getClass()));
+                orchestration(ctx);
+            }
 
-		Collection<String> providedComponents = CapellaInterfaceHelper.getProvidedBy((Interface) element, projectName,
-				outputFolder);
+        }
+        ctx.setNode(currentNode);
+        if (ctx.useReporter()) {
+            ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
+        }
 
-		Collection<String> implementedComponents = CapellaInterfaceHelper.getImplementedBy((Interface) element,
-				projectName, outputFolder);
+        stringBuffer.append(TEXT_7);
+        stringBuffer.append(TEXT_7);
+        return stringBuffer.toString();
+    }
 
-		Collection<String> requiredComponents = CapellaInterfaceHelper.getRequiredBy((Interface) element, projectName,
-				outputFolder);
+    public String orchestration(PatternContext ctx) throws Exception {
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
 
-		Collection<String> usedComponents = CapellaInterfaceHelper.getUsedBy((Interface) element, projectName,
-				outputFolder);
+        super.orchestration(new SuperOrchestrationContext(ictx));
 
-		if (providedComponents.size() > 0 || implementedComponents.size() > 0 || requiredComponents.size() > 0
-				|| usedComponents.size() > 0) {
+        if (ictx.useReporter()) {
+            Map<String, Object> parameterValues = new HashMap<String, Object>();
+            parameterValues.put("parameter", this.parameter);
+            String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
+            String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
+            ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
+        }
+        return null;
+    }
 
-			stringBuffer.append(TEXT_1);
+    public Map<String, Object> getParameters() {
+        final Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("parameter", this.parameter);
+        return parameters;
+    }
 
-			if (providedComponents.size() > 0) {
-				stringBuffer.append(TEXT_2);
-				stringBuffer.append(StringUtil.stringListToBulette(providedComponents));
-			}
+    protected void method_setTitle(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-			if (implementedComponents.size() > 0) {
-				stringBuffer.append(TEXT_3);
-				stringBuffer.append(StringUtil.stringListToBulette(implementedComponents));
-			}
+        String visibility = "";
+        if (((Interface) element).getVisibility().getValue() != VisibilityKind.UNSET_VALUE)
+            visibility = "{" + ((Interface) element).getVisibility().getLiteral().toLowerCase() + "} ";
+        String type = element.eClass().getName();
+        String elementFullName = CapellaServices.getFullDataPkgHierarchyLink(element);
+        documentTitle = "<span class=\"elementMetaClass\">" + visibility + "</span> " + elementFullName;
 
-			if (requiredComponents.size() > 0) {
-				stringBuffer.append(TEXT_4);
-				stringBuffer.append(StringUtil.stringListToBulette(requiredComponents));
-			}
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "setTitle", stringBuffer.toString());
+    }
 
-			if (usedComponents.size() > 0) {
-				stringBuffer.append(TEXT_5);
-				stringBuffer.append(StringUtil.stringListToBulette(usedComponents));
-			}
-		}
+    protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-		Collection<String> operationExchangeItems = CapellaInterfaceHelper
-				.getOperationExchangeItems((Interface) element, projectName, outputFolder);
-		if (operationExchangeItems.size() > 0) {
+        super.method_content(new StringBuffer(), ctx);
+        String projectName = ctx.getValue("projectName").toString();
+        String outputFolder = ctx.getValue("outputFolder").toString();
 
-			stringBuffer.append(TEXT_6);
-			stringBuffer.append(TEXT_7);
-			stringBuffer.append(StringUtil.stringListToBulette(operationExchangeItems));
-		}
-		stringBuffer.append(TEXT_7);
-		Collection<String> sharedFlowExchangeItems = CapellaInterfaceHelper.getFlowExchangeItems((Interface) element,
-				projectName, outputFolder);
-		if (sharedFlowExchangeItems.size() > 0) {
+        Collection<String> providedComponents = CapellaInterfaceHelper.getProvidedBy((Interface) element, projectName, outputFolder);
 
-			stringBuffer.append(TEXT_8);
-			stringBuffer.append(TEXT_7);
-			stringBuffer.append(StringUtil.stringListToBulette(sharedFlowExchangeItems));
-		}
-		stringBuffer.append(TEXT_7);
-		Collection<String> sharedDataExchangeItems = CapellaInterfaceHelper
-				.getSharedDataExchangeItems((Interface) element, projectName, outputFolder);
-		if (sharedDataExchangeItems.size() > 0) {
+        Collection<String> implementedComponents = CapellaInterfaceHelper.getImplementedBy((Interface) element, projectName, outputFolder);
 
-			stringBuffer.append(TEXT_9);
-			stringBuffer.append(TEXT_7);
-			stringBuffer.append(StringUtil.stringListToBulette(sharedDataExchangeItems));
-		}
-		stringBuffer.append(TEXT_7);
-		Collection<String> eventExchangeItems = CapellaInterfaceHelper.getEventExchangeItems((Interface) element,
-				projectName, outputFolder);
-		if (eventExchangeItems.size() > 0) {
+        Collection<String> requiredComponents = CapellaInterfaceHelper.getRequiredBy((Interface) element, projectName, outputFolder);
 
-			stringBuffer.append(TEXT_10);
-			stringBuffer.append(TEXT_7);
-			stringBuffer.append(StringUtil.stringListToBulette(eventExchangeItems));
-		}
-		stringBuffer.append(TEXT_7);
-		Collection<String> unsetExchangeItems = CapellaInterfaceHelper.getUnsetExchangeItems((Interface) element,
-				projectName, outputFolder);
-		if (unsetExchangeItems.size() > 0) {
+        Collection<String> usedComponents = CapellaInterfaceHelper.getUsedBy((Interface) element, projectName, outputFolder);
 
-			stringBuffer.append(TEXT_11);
-			stringBuffer.append(TEXT_7);
-			stringBuffer.append(StringUtil.stringListToBulette(unsetExchangeItems));
-		}
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
-	}
+        if (providedComponents.size() > 0 || implementedComponents.size() > 0 || requiredComponents.size() > 0 || usedComponents.size() > 0) {
 
-	public boolean preCondition(PatternContext ctx) throws Exception {
-		return (this.parameter instanceof Interface);
-	}
+            stringBuffer.append(TEXT_1);
+
+            if (providedComponents.size() > 0) {
+                stringBuffer.append(TEXT_2);
+                stringBuffer.append(StringUtil.stringListToBulette(providedComponents));
+            }
+
+            if (implementedComponents.size() > 0) {
+                stringBuffer.append(TEXT_3);
+                stringBuffer.append(StringUtil.stringListToBulette(implementedComponents));
+            }
+
+            if (requiredComponents.size() > 0) {
+                stringBuffer.append(TEXT_4);
+                stringBuffer.append(StringUtil.stringListToBulette(requiredComponents));
+            }
+
+            if (usedComponents.size() > 0) {
+                stringBuffer.append(TEXT_5);
+                stringBuffer.append(StringUtil.stringListToBulette(usedComponents));
+            }
+        }
+
+        Collection<String> operationExchangeItems = CapellaInterfaceHelper.getOperationExchangeItems((Interface) element, projectName, outputFolder);
+        if (operationExchangeItems.size() > 0) {
+
+            stringBuffer.append(TEXT_6);
+            stringBuffer.append(TEXT_7);
+            stringBuffer.append(StringUtil.stringListToBulette(operationExchangeItems));
+        }
+        stringBuffer.append(TEXT_7);
+        Collection<String> sharedFlowExchangeItems = CapellaInterfaceHelper.getFlowExchangeItems((Interface) element, projectName, outputFolder);
+        if (sharedFlowExchangeItems.size() > 0) {
+
+            stringBuffer.append(TEXT_8);
+            stringBuffer.append(TEXT_7);
+            stringBuffer.append(StringUtil.stringListToBulette(sharedFlowExchangeItems));
+        }
+        stringBuffer.append(TEXT_7);
+        Collection<String> sharedDataExchangeItems = CapellaInterfaceHelper.getSharedDataExchangeItems((Interface) element, projectName, outputFolder);
+        if (sharedDataExchangeItems.size() > 0) {
+
+            stringBuffer.append(TEXT_9);
+            stringBuffer.append(TEXT_7);
+            stringBuffer.append(StringUtil.stringListToBulette(sharedDataExchangeItems));
+        }
+        stringBuffer.append(TEXT_7);
+        Collection<String> eventExchangeItems = CapellaInterfaceHelper.getEventExchangeItems((Interface) element, projectName, outputFolder);
+        if (eventExchangeItems.size() > 0) {
+
+            stringBuffer.append(TEXT_10);
+            stringBuffer.append(TEXT_7);
+            stringBuffer.append(StringUtil.stringListToBulette(eventExchangeItems));
+        }
+        stringBuffer.append(TEXT_7);
+        Collection<String> unsetExchangeItems = CapellaInterfaceHelper.getUnsetExchangeItems((Interface) element, projectName, outputFolder);
+        if (unsetExchangeItems.size() > 0) {
+
+            stringBuffer.append(TEXT_11);
+            stringBuffer.append(TEXT_7);
+            stringBuffer.append(StringUtil.stringListToBulette(unsetExchangeItems));
+        }
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
+    }
+
+    public boolean preCondition(PatternContext ctx) throws Exception {
+        return (this.parameter instanceof Interface);
+    }
 }

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/LogicalComponentDocGen.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/LogicalComponentDocGen.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.1.201906060805
+//Generated with EGF 1.6.3.202110291409
 package org.polarsys.capella.docgen.content;
 
 import org.eclipse.egf.common.helper.*;
@@ -9,119 +9,119 @@ import org.eclipse.egf.pattern.execution.*;
 import org.eclipse.egf.pattern.query.*;
 
 public class LogicalComponentDocGen extends org.polarsys.capella.docgen.foundations.NamedElementDocGen {
-	protected static String nl;
+    protected static String nl;
 
-	public static synchronized LogicalComponentDocGen create(String lineSeparator) {
-		nl = lineSeparator;
-		LogicalComponentDocGen result = new LogicalComponentDocGen();
-		nl = null;
-		return result;
-	}
+    public static synchronized LogicalComponentDocGen create(String lineSeparator) {
+        nl = lineSeparator;
+        LogicalComponentDocGen result = new LogicalComponentDocGen();
+        nl = null;
+        return result;
+    }
 
-	public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
-	protected final String TEXT_1 = "";
-	protected final String TEXT_2 = NL;
+    public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
 
-	public LogicalComponentDocGen() {
-		//Here is the constructor
-		StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_1 = "";
 
-		// add initialisation of the pattern variables (declaration has been already done).
+    protected final String TEXT_2 = NL;
 
-	}
+    public LogicalComponentDocGen() {
+        //Here is the constructor
+        StringBuffer stringBuffer = new StringBuffer();
 
-	public String generate(Object argument) throws Exception {
-		final StringBuffer stringBuffer = new StringBuffer();
+        // add initialisation of the pattern variables (declaration has been already done).
 
-		InternalPatternContext ctx = (InternalPatternContext) argument;
-		Map<String, String> queryCtx = null;
-		IQuery.ParameterDescription paramDesc = null;
-		Node.Container currentNode = ctx.getNode();
+    }
 
-		List<Object> parameterList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
+    public String generate(Object argument) throws Exception {
+        final StringBuffer stringBuffer = new StringBuffer();
 
-		for (Object parameterParameter : parameterList) {
+        InternalPatternContext ctx = (InternalPatternContext) argument;
+        Map<String, String> queryCtx = null;
+        IQuery.ParameterDescription paramDesc = null;
+        Node.Container currentNode = ctx.getNode();
 
-			this.parameter = (org.polarsys.capella.core.data.cs.Component) parameterParameter;
+        List<Object> parameterList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
 
-			if (preCondition(ctx)) {
-				ctx.setNode(new Node.Container(currentNode, getClass()));
-				orchestration(ctx);
-			}
+        for (Object parameterParameter : parameterList) {
 
-		}
-		ctx.setNode(currentNode);
-		if (ctx.useReporter()) {
-			ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
-		}
+            this.parameter = (org.polarsys.capella.core.data.cs.Component) parameterParameter;
 
-		stringBuffer.append(TEXT_2);
-		stringBuffer.append(TEXT_2);
-		return stringBuffer.toString();
-	}
+            if (preCondition(ctx)) {
+                ctx.setNode(new Node.Container(currentNode, getClass()));
+                orchestration(ctx);
+            }
 
-	public String orchestration(PatternContext ctx) throws Exception {
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
+        }
+        ctx.setNode(currentNode);
+        if (ctx.useReporter()) {
+            ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
+        }
 
-		super.orchestration(new SuperOrchestrationContext(ictx));
+        stringBuffer.append(TEXT_2);
+        stringBuffer.append(TEXT_2);
+        return stringBuffer.toString();
+    }
 
-		if (ictx.useReporter()) {
-			Map<String, Object> parameterValues = new HashMap<String, Object>();
-			parameterValues.put("parameter", this.parameter);
-			String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
-			String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
-			ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
-		}
-		return null;
-	}
+    public String orchestration(PatternContext ctx) throws Exception {
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
 
-	protected org.polarsys.capella.core.data.cs.Component parameter = null;
+        super.orchestration(new SuperOrchestrationContext(ictx));
 
-	public void set_parameter(org.polarsys.capella.core.data.cs.Component object) {
-		this.parameter = object;
-	}
+        if (ictx.useReporter()) {
+            Map<String, Object> parameterValues = new HashMap<String, Object>();
+            parameterValues.put("parameter", this.parameter);
+            String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
+            String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
+            ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
+        }
+        return null;
+    }
 
-	public Map<String, Object> getParameters() {
-		final Map<String, Object> parameters = new HashMap<String, Object>();
-		parameters.put("parameter", this.parameter);
-		return parameters;
-	}
+    protected org.polarsys.capella.core.data.cs.Component parameter = null;
 
-	protected void method_setCapellaContext(final StringBuffer stringBuffer, final PatternContext ctx)
-			throws Exception {
+    public void set_parameter(org.polarsys.capella.core.data.cs.Component object) {
+        this.parameter = object;
+    }
 
-		element = parameter;
+    public Map<String, Object> getParameters() {
+        final Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("parameter", this.parameter);
+        return parameters;
+    }
 
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "setCapellaContext", stringBuffer.toString());
-	}
+    protected void method_setCapellaContext(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-	protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+        element = parameter;
 
-		super.method_content(new StringBuffer(), ctx);
-		String projectName = ctx.getValue("projectName").toString();
-		String outputFolder = ctx.getValue("outputFolder").toString();
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "setCapellaContext", stringBuffer.toString());
+    }
 
-		stringBuffer.append(TEXT_1);
-		{
-			//<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#LogicalName=org.polarsys.capella.docgen.content.ComponentContentDocGen" args="element:element, projectName:projectName, outputFolder:outputFolder"%>
+    protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-			InternalPatternContext ictx = (InternalPatternContext) ctx;
-			new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
-			stringBuffer.setLength(0);
+        super.method_content(new StringBuffer(), ctx);
+        String projectName = ctx.getValue("projectName").toString();
+        String outputFolder = ctx.getValue("outputFolder").toString();
 
-			final Map<String, Object> callParameters = new HashMap<String, Object>();
-			callParameters.put("element", element);
-			callParameters.put("projectName", projectName);
-			callParameters.put("outputFolder", outputFolder);
-			CallHelper.executeWithParameterInjection(
-					"platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#_bbMz4auhEeCWrf9pgx3zjA",
-					new ExecutionContext((InternalPatternContext) ctx), callParameters);
-			stringBuffer.setLength(0);
-		}
+        stringBuffer.append(TEXT_1);
+        {
+            //<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#LogicalName=org.polarsys.capella.docgen.content.ComponentContentDocGen" args="element:element, projectName:projectName, outputFolder:outputFolder"%>
 
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
-	}
+            InternalPatternContext ictx = (InternalPatternContext) ctx;
+            new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
+            stringBuffer.setLength(0);
+
+            final Map<String, Object> callParameters = new HashMap<String, Object>();
+            callParameters.put("element", element);
+            callParameters.put("projectName", projectName);
+            callParameters.put("outputFolder", outputFolder);
+            CallHelper.executeWithParameterInjection("platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#_bbMz4auhEeCWrf9pgx3zjA",
+                    new ExecutionContext((InternalPatternContext) ctx), callParameters);
+            stringBuffer.setLength(0);
+        }
+
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
+    }
 }

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/MissionGenDoc.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/MissionGenDoc.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.1.201906060805
+//Generated with EGF 1.6.3.202110291409
 package org.polarsys.capella.docgen.content;
 
 import org.eclipse.egf.common.helper.*;
@@ -12,125 +12,126 @@ import org.polarsys.capella.docgen.util.StringUtil;
 import org.polarsys.capella.docgen.util.pattern.helper.CapellaMissionHelper;
 
 public class MissionGenDoc extends org.polarsys.capella.docgen.foundations.NamedElementDocGen {
-	protected static String nl;
+    protected static String nl;
 
-	public static synchronized MissionGenDoc create(String lineSeparator) {
-		nl = lineSeparator;
-		MissionGenDoc result = new MissionGenDoc();
-		nl = null;
-		return result;
-	}
+    public static synchronized MissionGenDoc create(String lineSeparator) {
+        nl = lineSeparator;
+        MissionGenDoc result = new MissionGenDoc();
+        nl = null;
+        return result;
+    }
 
-	public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
-	protected final String TEXT_1 = "<h2>Capabilities</h2>";
-	protected final String TEXT_2 = NL;
-	protected final String TEXT_3 = NL + "<h2>Involved Actors</h2>";
-	protected final String TEXT_4 = NL + NL;
+    public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
 
-	public MissionGenDoc() {
-		//Here is the constructor
-		StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_1 = "<h2>Capabilities</h2>";
 
-		// add initialisation of the pattern variables (declaration has been already done).
+    protected final String TEXT_2 = NL;
 
-	}
+    protected final String TEXT_3 = NL + "<h2>Involved Actors</h2>";
 
-	public String generate(Object argument) throws Exception {
-		final StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_4 = NL + NL;
 
-		InternalPatternContext ctx = (InternalPatternContext) argument;
-		Map<String, String> queryCtx = null;
-		IQuery.ParameterDescription paramDesc = null;
-		Node.Container currentNode = ctx.getNode();
+    public MissionGenDoc() {
+        //Here is the constructor
+        StringBuffer stringBuffer = new StringBuffer();
 
-		List<Object> parameterList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
+        // add initialisation of the pattern variables (declaration has been already done).
 
-		for (Object parameterParameter : parameterList) {
+    }
 
-			this.parameter = (org.polarsys.capella.core.data.ctx.Mission) parameterParameter;
+    public String generate(Object argument) throws Exception {
+        final StringBuffer stringBuffer = new StringBuffer();
 
-			if (preCondition(ctx)) {
-				ctx.setNode(new Node.Container(currentNode, getClass()));
-				orchestration(ctx);
-			}
+        InternalPatternContext ctx = (InternalPatternContext) argument;
+        Map<String, String> queryCtx = null;
+        IQuery.ParameterDescription paramDesc = null;
+        Node.Container currentNode = ctx.getNode();
 
-		}
-		ctx.setNode(currentNode);
-		if (ctx.useReporter()) {
-			ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
-		}
+        List<Object> parameterList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
 
-		stringBuffer.append(TEXT_2);
-		stringBuffer.append(TEXT_2);
-		return stringBuffer.toString();
-	}
+        for (Object parameterParameter : parameterList) {
 
-	public String orchestration(PatternContext ctx) throws Exception {
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
+            this.parameter = (org.polarsys.capella.core.data.ctx.Mission) parameterParameter;
 
-		super.orchestration(new SuperOrchestrationContext(ictx));
+            if (preCondition(ctx)) {
+                ctx.setNode(new Node.Container(currentNode, getClass()));
+                orchestration(ctx);
+            }
 
-		if (ictx.useReporter()) {
-			Map<String, Object> parameterValues = new HashMap<String, Object>();
-			parameterValues.put("parameter", this.parameter);
-			String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
-			String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
-			ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
-		}
-		return null;
-	}
+        }
+        ctx.setNode(currentNode);
+        if (ctx.useReporter()) {
+            ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
+        }
 
-	protected org.polarsys.capella.core.data.ctx.Mission parameter = null;
+        stringBuffer.append(TEXT_2);
+        stringBuffer.append(TEXT_2);
+        return stringBuffer.toString();
+    }
 
-	public void set_parameter(org.polarsys.capella.core.data.ctx.Mission object) {
-		this.parameter = object;
-	}
+    public String orchestration(PatternContext ctx) throws Exception {
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
 
-	public Map<String, Object> getParameters() {
-		final Map<String, Object> parameters = new HashMap<String, Object>();
-		parameters.put("parameter", this.parameter);
-		return parameters;
-	}
+        super.orchestration(new SuperOrchestrationContext(ictx));
 
-	protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+        if (ictx.useReporter()) {
+            Map<String, Object> parameterValues = new HashMap<String, Object>();
+            parameterValues.put("parameter", this.parameter);
+            String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
+            String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
+            ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
+        }
+        return null;
+    }
 
-		super.method_content(new StringBuffer(), ctx);
-		String projectName = ctx.getValue("projectName").toString();
-		String outputFolder = ctx.getValue("outputFolder").toString();
+    protected org.polarsys.capella.core.data.ctx.Mission parameter = null;
 
-		Collection<String> capabilities = CapellaMissionHelper.getCapabilities(projectName, outputFolder,
-				(Mission) element);
+    public void set_parameter(org.polarsys.capella.core.data.ctx.Mission object) {
+        this.parameter = object;
+    }
 
-		if (capabilities.size() > 0) {
+    public Map<String, Object> getParameters() {
+        final Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("parameter", this.parameter);
+        return parameters;
+    }
 
-			stringBuffer.append(TEXT_1);
-			stringBuffer.append(TEXT_2);
-			stringBuffer.append(StringUtil.stringListToBulette(capabilities));
+    protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-		}
-		Collection<String> involvedActors = CapellaMissionHelper.getInvolvedActors(projectName, outputFolder,
-				(Mission) element);
+        super.method_content(new StringBuffer(), ctx);
+        String projectName = ctx.getValue("projectName").toString();
+        String outputFolder = ctx.getValue("outputFolder").toString();
 
-		if (involvedActors.size() > 0) {
+        Collection<String> capabilities = CapellaMissionHelper.getCapabilities(projectName, outputFolder, (Mission) element);
 
-			stringBuffer.append(TEXT_3);
-			stringBuffer.append(TEXT_2);
-			stringBuffer.append(StringUtil.stringListToBulette(involvedActors));
+        if (capabilities.size() > 0) {
 
-		}
+            stringBuffer.append(TEXT_1);
+            stringBuffer.append(TEXT_2);
+            stringBuffer.append(StringUtil.stringListToBulette(capabilities));
 
-		stringBuffer.append(TEXT_4);
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
-	}
+        }
+        Collection<String> involvedActors = CapellaMissionHelper.getInvolvedActors(projectName, outputFolder, (Mission) element);
 
-	protected void method_setCapellaContext(final StringBuffer stringBuffer, final PatternContext ctx)
-			throws Exception {
+        if (involvedActors.size() > 0) {
 
-		element = parameter;
+            stringBuffer.append(TEXT_3);
+            stringBuffer.append(TEXT_2);
+            stringBuffer.append(StringUtil.stringListToBulette(involvedActors));
 
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "setCapellaContext", stringBuffer.toString());
-	}
+        }
+
+        stringBuffer.append(TEXT_4);
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
+    }
+
+    protected void method_setCapellaContext(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+
+        element = parameter;
+
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "setCapellaContext", stringBuffer.toString());
+    }
 }

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/PartDocGen.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/PartDocGen.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.1.201906060805
+//Generated with EGF 1.6.3.202110291409
 package org.polarsys.capella.docgen.content;
 
 import org.eclipse.egf.common.helper.*;
@@ -14,271 +14,273 @@ import org.polarsys.capella.docgen.util.CapellaServices;
 import org.polarsys.kitalpha.doc.gen.business.core.util.EscapeChars;
 
 public class PartDocGen extends org.polarsys.capella.docgen.foundations.NamedElementDocGen {
-	protected static String nl;
+    protected static String nl;
 
-	public static synchronized PartDocGen create(String lineSeparator) {
-		nl = lineSeparator;
-		PartDocGen result = new PartDocGen();
-		nl = null;
-		return result;
-	}
+    public static synchronized PartDocGen create(String lineSeparator) {
+        nl = lineSeparator;
+        PartDocGen result = new PartDocGen();
+        nl = null;
+        return result;
+    }
 
-	public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
-	protected final String TEXT_1 = "<img src=\"../icon/";
-	protected final String TEXT_2 = "\" alt=\"";
-	protected final String TEXT_3 = "\" style=\"float:left; margin-right:10px\" /><h1>";
-	protected final String TEXT_4 = "</h1>" + NL
-			+ "<p style=\"margin-top:3px; margin-bottom:3px\"><span class=\"elementMetaClass\">";
-	protected final String TEXT_5 = "</span></p>" + NL + "<em class=\"elementPath\">";
-	protected final String TEXT_6 = "</em>" + NL + "<p><em>Type : ";
-	protected final String TEXT_7 = "No type specified";
-	protected final String TEXT_8 = "</em></p>" + NL;
-	protected final String TEXT_9 = NL;
-	protected final String TEXT_10 = NL + NL;
-	protected final String TEXT_11 = NL + "\t";
-	protected final String TEXT_12 = "</div>";
+    public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
 
-	public PartDocGen() {
-		//Here is the constructor
-		StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_1 = "<img src=\"../icon/";
 
-		// add initialisation of the pattern variables (declaration has been already done).
+    protected final String TEXT_2 = "\" alt=\"";
 
-	}
+    protected final String TEXT_3 = "\" style=\"float:left; margin-right:10px\" /><h1>";
 
-	public String generate(Object argument) throws Exception {
-		final StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_4 = "</h1>" + NL + "<p style=\"margin-top:3px; margin-bottom:3px\"><span class=\"elementMetaClass\">";
 
-		InternalPatternContext ctx = (InternalPatternContext) argument;
-		Map<String, String> queryCtx = null;
-		IQuery.ParameterDescription paramDesc = null;
-		Node.Container currentNode = ctx.getNode();
+    protected final String TEXT_5 = "</span></p>" + NL + "<em class=\"elementPath\">";
 
-		List<Object> parameterList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
+    protected final String TEXT_6 = "</em>" + NL + "<p><em>Type : ";
 
-		for (Object parameterParameter : parameterList) {
+    protected final String TEXT_7 = "No type specified";
 
-			this.parameter = (org.polarsys.capella.core.data.cs.Part) parameterParameter;
+    protected final String TEXT_8 = "</em></p>" + NL;
 
-			if (preCondition(ctx)) {
-				ctx.setNode(new Node.Container(currentNode, getClass()));
-				orchestration(ctx);
-			}
+    protected final String TEXT_9 = NL;
 
-		}
-		ctx.setNode(currentNode);
-		if (ctx.useReporter()) {
-			ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
-		}
+    protected final String TEXT_10 = NL + NL;
 
-		stringBuffer.append(TEXT_9);
-		stringBuffer.append(TEXT_9);
-		return stringBuffer.toString();
-	}
+    protected final String TEXT_11 = NL + "\t";
 
-	public String orchestration(PatternContext ctx) throws Exception {
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
+    protected final String TEXT_12 = "</div>";
 
-		super.orchestration(new SuperOrchestrationContext(ictx));
+    public PartDocGen() {
+        //Here is the constructor
+        StringBuffer stringBuffer = new StringBuffer();
 
-		if (ictx.useReporter()) {
-			Map<String, Object> parameterValues = new HashMap<String, Object>();
-			parameterValues.put("parameter", this.parameter);
-			String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
-			String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
-			ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
-		}
-		return null;
-	}
+        // add initialisation of the pattern variables (declaration has been already done).
 
-	protected org.polarsys.capella.core.data.cs.Part parameter = null;
+    }
 
-	public void set_parameter(org.polarsys.capella.core.data.cs.Part object) {
-		this.parameter = object;
-	}
+    public String generate(Object argument) throws Exception {
+        final StringBuffer stringBuffer = new StringBuffer();
 
-	public Map<String, Object> getParameters() {
-		final Map<String, Object> parameters = new HashMap<String, Object>();
-		parameters.put("parameter", this.parameter);
-		return parameters;
-	}
+        InternalPatternContext ctx = (InternalPatternContext) argument;
+        Map<String, String> queryCtx = null;
+        IQuery.ParameterDescription paramDesc = null;
+        Node.Container currentNode = ctx.getNode();
 
-	protected void method_setCapellaContext(final StringBuffer stringBuffer, final PatternContext ctx)
-			throws Exception {
+        List<Object> parameterList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
 
-		element = parameter;
+        for (Object parameterParameter : parameterList) {
 
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "setCapellaContext", stringBuffer.toString());
-	}
+            this.parameter = (org.polarsys.capella.core.data.cs.Part) parameterParameter;
 
-	protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+            if (preCondition(ctx)) {
+                ctx.setNode(new Node.Container(currentNode, getClass()));
+                orchestration(ctx);
+            }
 
-		String projectName = ctx.getValue("projectName").toString();
-		String outputFolder = ctx.getValue("outputFolder").toString();
-		String elementName = CapellaServices.getHyperlinkFromElement(element, ((Part) element).getName());
-		String elementType = "<span class=\"elementMetaClass\">" + EscapeChars.forHTML(element.eClass().getName())
-				+ "</span>";
-		EObject type = ((Part) element).getType();
-		String logo = ImageHelper.INSTANCE.getTypePng(element, projectName, outputFolder);
-		String documentTitle = elementName;
-		stringBuffer.append(TEXT_1);
-		stringBuffer.append(logo);
-		stringBuffer.append(TEXT_2);
-		stringBuffer.append(EscapeChars.forHTML(element.eClass().getName()));
-		stringBuffer.append(TEXT_3);
-		stringBuffer.append(documentTitle);
-		stringBuffer.append(TEXT_4);
-		stringBuffer.append(elementType);
-		stringBuffer.append(TEXT_5);
-		stringBuffer.append(elementPath);
-		stringBuffer.append(TEXT_6);
-		if (type != null) {
+        }
+        ctx.setNode(currentNode);
+        if (ctx.useReporter()) {
+            ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
+        }
 
-			stringBuffer.append(CapellaServices.getHyperlinkFromElement(type));
-		} else {
-			stringBuffer.append(TEXT_7);
-		}
-		stringBuffer.append(TEXT_8);
-		// Summary and description generation
-		stringBuffer.append(TEXT_9);
-		{
-			//<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#LogicalName=org.polarsys.capella.docgen.foundations.SummaryAndDescriptionGeneration" args="element:element"%>
+        stringBuffer.append(TEXT_9);
+        stringBuffer.append(TEXT_9);
+        return stringBuffer.toString();
+    }
 
-			InternalPatternContext ictx = (InternalPatternContext) ctx;
-			new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
-			stringBuffer.setLength(0);
+    public String orchestration(PatternContext ctx) throws Exception {
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
 
-			final Map<String, Object> callParameters = new HashMap<String, Object>();
-			callParameters.put("element", element);
-			CallHelper.executeWithParameterInjection(
-					"platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#_fiM9sOZdEd-YVt45ZEg4_w",
-					new ExecutionContext((InternalPatternContext) ctx), callParameters);
-			stringBuffer.setLength(0);
-		}
+        super.orchestration(new SuperOrchestrationContext(ictx));
 
-		stringBuffer.append(TEXT_9);
-		// Generating status and review information 
-		stringBuffer.append(TEXT_9);
-		{
-			//<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#LogicalName=org.polarsys.capella.docgen.foundations.StatusAndReviewGeneration" args="element:element"%>
+        if (ictx.useReporter()) {
+            Map<String, Object> parameterValues = new HashMap<String, Object>();
+            parameterValues.put("parameter", this.parameter);
+            String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
+            String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
+            ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
+        }
+        return null;
+    }
 
-			InternalPatternContext ictx = (InternalPatternContext) ctx;
-			new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
-			stringBuffer.setLength(0);
+    protected org.polarsys.capella.core.data.cs.Part parameter = null;
 
-			final Map<String, Object> callParameters = new HashMap<String, Object>();
-			callParameters.put("element", element);
-			CallHelper.executeWithParameterInjection(
-					"platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#_2sAHwHWMEemiHtSfRhpXIQ",
-					new ExecutionContext((InternalPatternContext) ctx), callParameters);
-			stringBuffer.setLength(0);
-		}
+    public void set_parameter(org.polarsys.capella.core.data.cs.Part object) {
+        this.parameter = object;
+    }
 
-		stringBuffer.append(TEXT_9);
-		// owned diagrams and Contained in diagrams generation
-		stringBuffer.append(TEXT_9);
-		{
-			//<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#LogicalName=org.polarsys.capella.docgen.foundations.DiagramsGeneration" args="element:element"%>
+    public Map<String, Object> getParameters() {
+        final Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("parameter", this.parameter);
+        return parameters;
+    }
 
-			InternalPatternContext ictx = (InternalPatternContext) ctx;
-			new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
-			stringBuffer.setLength(0);
+    protected void method_setCapellaContext(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-			final Map<String, Object> callParameters = new HashMap<String, Object>();
-			callParameters.put("element", element);
-			CallHelper.executeWithParameterInjection(
-					"platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#_PVePETXrEeCNvtb1bUM2fQ",
-					new ExecutionContext((InternalPatternContext) ctx), callParameters);
-			stringBuffer.setLength(0);
-		}
+        element = parameter;
 
-		stringBuffer.append(TEXT_10);
-		// type 
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "setCapellaContext", stringBuffer.toString());
+    }
 
-		if (type != null) {
-			stringBuffer.append(TEXT_11);
-			stringBuffer.append(TEXT_9);
-			{
-				//<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#LogicalName=org.polarsys.capella.docgen.foundations.CapellaElementContentDocGen" args="type:element, documentTitle:documentTitle"%>
+    protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-				InternalPatternContext ictx = (InternalPatternContext) ctx;
-				new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
-				stringBuffer.setLength(0);
+        String projectName = ctx.getValue("projectName").toString();
+        String outputFolder = ctx.getValue("outputFolder").toString();
+        String elementName = CapellaServices.getHyperlinkFromElement(element, ((Part) element).getName());
+        String elementType = "<span class=\"elementMetaClass\">" + EscapeChars.forHTML(element.eClass().getName()) + "</span>";
+        EObject type = ((Part) element).getType();
+        String logo = ImageHelper.getTypePng(element, projectName, outputFolder);
+        String documentTitle = elementName;
+        stringBuffer.append(TEXT_1);
+        stringBuffer.append(logo);
+        stringBuffer.append(TEXT_2);
+        stringBuffer.append(EscapeChars.forHTML(element.eClass().getName()));
+        stringBuffer.append(TEXT_3);
+        stringBuffer.append(documentTitle);
+        stringBuffer.append(TEXT_4);
+        stringBuffer.append(elementType);
+        stringBuffer.append(TEXT_5);
+        stringBuffer.append(elementPath);
+        stringBuffer.append(TEXT_6);
+        if (type != null) {
 
-				final Map<String, Object> callParameters = new HashMap<String, Object>();
-				callParameters.put("element", type);
-				callParameters.put("documentTitle", documentTitle);
-				CallHelper.executeWithParameterInjection(
-						"platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#_2twVYKu9EeCWrf9pgx3zjA",
-						new ExecutionContext((InternalPatternContext) ctx), callParameters);
-				stringBuffer.setLength(0);
-			}
+            stringBuffer.append(CapellaServices.getHyperlinkFromElement(type));
+        } else {
+            stringBuffer.append(TEXT_7);
+        }
+        stringBuffer.append(TEXT_8);
+        // Summary and description generation
+        stringBuffer.append(TEXT_9);
+        {
+            //<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#LogicalName=org.polarsys.capella.docgen.foundations.SummaryAndDescriptionGeneration" args="element:element"%>
 
-			stringBuffer.append(TEXT_9);
-			{
-				//<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#LogicalName=org.polarsys.capella.docgen.content.ComponentContentDocGen" args="type:element, projectName:projectName, outputFolder:outputFolder"%>
+            InternalPatternContext ictx = (InternalPatternContext) ctx;
+            new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
+            stringBuffer.setLength(0);
 
-				InternalPatternContext ictx = (InternalPatternContext) ctx;
-				new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
-				stringBuffer.setLength(0);
+            final Map<String, Object> callParameters = new HashMap<String, Object>();
+            callParameters.put("element", element);
+            CallHelper.executeWithParameterInjection("platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#_fiM9sOZdEd-YVt45ZEg4_w",
+                    new ExecutionContext((InternalPatternContext) ctx), callParameters);
+            stringBuffer.setLength(0);
+        }
 
-				final Map<String, Object> callParameters = new HashMap<String, Object>();
-				callParameters.put("element", type);
-				callParameters.put("projectName", projectName);
-				callParameters.put("outputFolder", outputFolder);
-				CallHelper.executeWithParameterInjection(
-						"platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#_bbMz4auhEeCWrf9pgx3zjA",
-						new ExecutionContext((InternalPatternContext) ctx), callParameters);
-				stringBuffer.setLength(0);
-			}
+        stringBuffer.append(TEXT_9);
+        // Generating status and review information 
+        stringBuffer.append(TEXT_9);
+        {
+            //<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#LogicalName=org.polarsys.capella.docgen.foundations.StatusAndReviewGeneration" args="element:element"%>
 
-			if (type instanceof Entity) {
-				stringBuffer.append(TEXT_11);
-				{
-					//<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#LogicalName=org.polarsys.capella.docgen.content.EntityContentDocGen" args="type:element"%>
+            InternalPatternContext ictx = (InternalPatternContext) ctx;
+            new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
+            stringBuffer.setLength(0);
 
-					InternalPatternContext ictx = (InternalPatternContext) ctx;
-					new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
-					stringBuffer.setLength(0);
+            final Map<String, Object> callParameters = new HashMap<String, Object>();
+            callParameters.put("element", element);
+            CallHelper.executeWithParameterInjection("platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#_2sAHwHWMEemiHtSfRhpXIQ",
+                    new ExecutionContext((InternalPatternContext) ctx), callParameters);
+            stringBuffer.setLength(0);
+        }
 
-					final Map<String, Object> callParameters = new HashMap<String, Object>();
-					callParameters.put("element", type);
-					CallHelper.executeWithParameterInjection(
-							"platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#_XX5iAaxbEeCYVYqpiRcXMA",
-							new ExecutionContext((InternalPatternContext) ctx), callParameters);
-					stringBuffer.setLength(0);
-				}
+        stringBuffer.append(TEXT_9);
+        // owned diagrams and Contained in diagrams generation
+        stringBuffer.append(TEXT_9);
+        {
+            //<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#LogicalName=org.polarsys.capella.docgen.foundations.DiagramsGeneration" args="element:element"%>
 
-			}
-			stringBuffer.append(TEXT_9);
-			{
-				//<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#LogicalName=org.polarsys.capella.docgen.foundations.CapellaElementEndContentDocGen" args="type:element"%>
+            InternalPatternContext ictx = (InternalPatternContext) ctx;
+            new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
+            stringBuffer.setLength(0);
 
-				InternalPatternContext ictx = (InternalPatternContext) ctx;
-				new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
-				stringBuffer.setLength(0);
+            final Map<String, Object> callParameters = new HashMap<String, Object>();
+            callParameters.put("element", element);
+            CallHelper.executeWithParameterInjection("platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#_PVePETXrEeCNvtb1bUM2fQ",
+                    new ExecutionContext((InternalPatternContext) ctx), callParameters);
+            stringBuffer.setLength(0);
+        }
 
-				final Map<String, Object> callParameters = new HashMap<String, Object>();
-				callParameters.put("element", type);
-				CallHelper.executeWithParameterInjection(
-						"platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#_H6iekavLEeCas-LHcur3rg",
-						new ExecutionContext((InternalPatternContext) ctx), callParameters);
-				stringBuffer.setLength(0);
-			}
+        stringBuffer.append(TEXT_10);
+        // type 
 
-		}
+        if (type != null) {
+            stringBuffer.append(TEXT_11);
+            stringBuffer.append(TEXT_9);
+            {
+                //<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#LogicalName=org.polarsys.capella.docgen.foundations.CapellaElementContentDocGen" args="type:element, documentTitle:documentTitle"%>
 
-		stringBuffer.append(TEXT_10);
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
-	}
+                InternalPatternContext ictx = (InternalPatternContext) ctx;
+                new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
+                stringBuffer.setLength(0);
 
-	protected void method_endContent(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+                final Map<String, Object> callParameters = new HashMap<String, Object>();
+                callParameters.put("element", type);
+                callParameters.put("documentTitle", documentTitle);
+                CallHelper.executeWithParameterInjection("platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#_2twVYKu9EeCWrf9pgx3zjA",
+                        new ExecutionContext((InternalPatternContext) ctx), callParameters);
+                stringBuffer.setLength(0);
+            }
 
-		stringBuffer.append(TEXT_12);
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "endContent", stringBuffer.toString());
-	}
+            stringBuffer.append(TEXT_9);
+            {
+                //<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#LogicalName=org.polarsys.capella.docgen.content.ComponentContentDocGen" args="type:element, projectName:projectName, outputFolder:outputFolder"%>
+
+                InternalPatternContext ictx = (InternalPatternContext) ctx;
+                new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
+                stringBuffer.setLength(0);
+
+                final Map<String, Object> callParameters = new HashMap<String, Object>();
+                callParameters.put("element", type);
+                callParameters.put("projectName", projectName);
+                callParameters.put("outputFolder", outputFolder);
+                CallHelper.executeWithParameterInjection("platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#_bbMz4auhEeCWrf9pgx3zjA",
+                        new ExecutionContext((InternalPatternContext) ctx), callParameters);
+                stringBuffer.setLength(0);
+            }
+
+            if (type instanceof Entity) {
+                stringBuffer.append(TEXT_11);
+                {
+                    //<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#LogicalName=org.polarsys.capella.docgen.content.EntityContentDocGen" args="type:element"%>
+
+                    InternalPatternContext ictx = (InternalPatternContext) ctx;
+                    new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
+                    stringBuffer.setLength(0);
+
+                    final Map<String, Object> callParameters = new HashMap<String, Object>();
+                    callParameters.put("element", type);
+                    CallHelper.executeWithParameterInjection("platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#_XX5iAaxbEeCYVYqpiRcXMA",
+                            new ExecutionContext((InternalPatternContext) ctx), callParameters);
+                    stringBuffer.setLength(0);
+                }
+
+            }
+            stringBuffer.append(TEXT_9);
+            {
+                //<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#LogicalName=org.polarsys.capella.docgen.foundations.CapellaElementEndContentDocGen" args="type:element"%>
+
+                InternalPatternContext ictx = (InternalPatternContext) ctx;
+                new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
+                stringBuffer.setLength(0);
+
+                final Map<String, Object> callParameters = new HashMap<String, Object>();
+                callParameters.put("element", type);
+                CallHelper.executeWithParameterInjection("platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#_H6iekavLEeCas-LHcur3rg",
+                        new ExecutionContext((InternalPatternContext) ctx), callParameters);
+                stringBuffer.setLength(0);
+            }
+
+        }
+
+        stringBuffer.append(TEXT_10);
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
+    }
+
+    protected void method_endContent(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+
+        stringBuffer.append(TEXT_12);
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "endContent", stringBuffer.toString());
+    }
 }

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/PhysicalLinkDocGen.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/PhysicalLinkDocGen.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.1.201906060805
+//Generated with EGF 1.6.3.202110291409
 package org.polarsys.capella.docgen.content;
 
 import org.eclipse.egf.common.helper.*;
@@ -11,94 +11,95 @@ import org.polarsys.capella.core.data.cs.PhysicalLink;
 import org.polarsys.capella.docgen.preference.CapellaDocgenPreferenceHelper;
 
 public class PhysicalLinkDocGen extends org.polarsys.capella.docgen.foundations.AbstractExchangeDocGen {
-	protected static String nl;
+    protected static String nl;
 
-	public static synchronized PhysicalLinkDocGen create(String lineSeparator) {
-		nl = lineSeparator;
-		PhysicalLinkDocGen result = new PhysicalLinkDocGen();
-		nl = null;
-		return result;
-	}
+    public static synchronized PhysicalLinkDocGen create(String lineSeparator) {
+        nl = lineSeparator;
+        PhysicalLinkDocGen result = new PhysicalLinkDocGen();
+        nl = null;
+        return result;
+    }
 
-	public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
-	protected final String TEXT_1 = "";
-	protected final String TEXT_2 = NL;
+    public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
 
-	public PhysicalLinkDocGen() {
-		//Here is the constructor
-		StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_1 = "";
 
-		// add initialisation of the pattern variables (declaration has been already done).
+    protected final String TEXT_2 = NL;
 
-	}
+    public PhysicalLinkDocGen() {
+        //Here is the constructor
+        StringBuffer stringBuffer = new StringBuffer();
 
-	public String generate(Object argument) throws Exception {
-		final StringBuffer stringBuffer = new StringBuffer();
+        // add initialisation of the pattern variables (declaration has been already done).
 
-		InternalPatternContext ctx = (InternalPatternContext) argument;
-		Map<String, String> queryCtx = null;
-		IQuery.ParameterDescription paramDesc = null;
-		Node.Container currentNode = ctx.getNode();
+    }
 
-		List<Object> parameterList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
+    public String generate(Object argument) throws Exception {
+        final StringBuffer stringBuffer = new StringBuffer();
 
-		for (Object parameterParameter : parameterList) {
+        InternalPatternContext ctx = (InternalPatternContext) argument;
+        Map<String, String> queryCtx = null;
+        IQuery.ParameterDescription paramDesc = null;
+        Node.Container currentNode = ctx.getNode();
 
-			this.parameter = (org.polarsys.capella.core.data.cs.PhysicalLink) parameterParameter;
+        List<Object> parameterList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
 
-			if (preCondition(ctx)) {
-				ctx.setNode(new Node.Container(currentNode, getClass()));
-				orchestration(ctx);
-			}
+        for (Object parameterParameter : parameterList) {
 
-		}
-		ctx.setNode(currentNode);
-		if (ctx.useReporter()) {
-			ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
-		}
+            this.parameter = (org.polarsys.capella.core.data.cs.PhysicalLink) parameterParameter;
 
-		stringBuffer.append(TEXT_1);
-		stringBuffer.append(TEXT_2);
-		return stringBuffer.toString();
-	}
+            if (preCondition(ctx)) {
+                ctx.setNode(new Node.Container(currentNode, getClass()));
+                orchestration(ctx);
+            }
 
-	public String orchestration(PatternContext ctx) throws Exception {
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
+        }
+        ctx.setNode(currentNode);
+        if (ctx.useReporter()) {
+            ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
+        }
 
-		super.orchestration(new SuperOrchestrationContext(ictx));
+        stringBuffer.append(TEXT_1);
+        stringBuffer.append(TEXT_2);
+        return stringBuffer.toString();
+    }
 
-		if (ictx.useReporter()) {
-			Map<String, Object> parameterValues = new HashMap<String, Object>();
-			parameterValues.put("parameter", this.parameter);
-			String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
-			String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
-			ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
-		}
-		return null;
-	}
+    public String orchestration(PatternContext ctx) throws Exception {
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
 
-	protected org.polarsys.capella.core.data.cs.PhysicalLink parameter = null;
+        super.orchestration(new SuperOrchestrationContext(ictx));
 
-	public void set_parameter(org.polarsys.capella.core.data.cs.PhysicalLink object) {
-		this.parameter = object;
-	}
+        if (ictx.useReporter()) {
+            Map<String, Object> parameterValues = new HashMap<String, Object>();
+            parameterValues.put("parameter", this.parameter);
+            String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
+            String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
+            ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
+        }
+        return null;
+    }
 
-	public Map<String, Object> getParameters() {
-		final Map<String, Object> parameters = new HashMap<String, Object>();
-		parameters.put("parameter", this.parameter);
-		return parameters;
-	}
+    protected org.polarsys.capella.core.data.cs.PhysicalLink parameter = null;
 
-	protected void method_setCapellaContext(final StringBuffer stringBuffer, final PatternContext ctx)
-			throws Exception {
+    public void set_parameter(org.polarsys.capella.core.data.cs.PhysicalLink object) {
+        this.parameter = object;
+    }
 
-		element = parameter;
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "setCapellaContext", stringBuffer.toString());
-	}
+    public Map<String, Object> getParameters() {
+        final Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("parameter", this.parameter);
+        return parameters;
+    }
 
-	public boolean preCondition(PatternContext ctx) throws Exception {
-		return CapellaDocgenPreferenceHelper.isExportPhysialLink();
-	}
+    protected void method_setCapellaContext(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+
+        element = parameter;
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "setCapellaContext", stringBuffer.toString());
+    }
+
+    public boolean preCondition(PatternContext ctx) throws Exception {
+        return CapellaDocgenPreferenceHelper.isExportPhysialLink();
+    }
 }

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/RegionDocGen.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/RegionDocGen.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.1.201906060805
+//Generated with EGF 1.6.3.202110291409
 package org.polarsys.capella.docgen.content;
 
 import org.polarsys.capella.core.linkedtext.ui.CapellaEmbeddedLinkedTextEditorInput;
@@ -16,242 +16,243 @@ import org.polarsys.capella.common.data.behavior.AbstractEvent;
 import org.eclipse.emf.common.util.EList;
 
 public class RegionDocGen extends org.polarsys.capella.docgen.foundations.NamedElementDocGen {
-	protected static String nl;
+    protected static String nl;
 
-	public static synchronized RegionDocGen create(String lineSeparator) {
-		nl = lineSeparator;
-		RegionDocGen result = new RegionDocGen();
-		nl = null;
-		return result;
-	}
+    public static synchronized RegionDocGen create(String lineSeparator) {
+        nl = lineSeparator;
+        RegionDocGen result = new RegionDocGen();
+        nl = null;
+        return result;
+    }
 
-	public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
-	protected final String TEXT_1 = "<h2>Modes and States</h2>";
-	protected final String TEXT_2 = NL;
-	protected final String TEXT_3 = NL + "<h2>Realized Elements</h2>" + NL;
-	protected final String TEXT_4 = NL + "<h2>Realizing Elements </h2>" + NL;
-	protected final String TEXT_5 = NL + "<h2>Owned Transitions</h2>" + NL + "<table max-width=\"screen.width\">" + NL
-			+ "   <thead> " + NL + "       <tr>" + NL + "           <th>Transition</th>" + NL
-			+ "           <th>Source</th>" + NL + "           <th>Target</th>" + NL + "           <th>Trigger</th>" + NL
-			+ "           <th>Effect</th>" + NL + "           <th>Description</th>" + NL + "       </tr>" + NL
-			+ "   </thead>" + NL + "   <tbody>";
-	protected final String TEXT_6 = NL + "\t   <tr>" + NL + "           <td>";
-	protected final String TEXT_7 = "</td>" + NL + "           <td>";
-	protected final String TEXT_8 = "</td>" + NL + "       </tr>" + NL + "\t\t";
-	protected final String TEXT_9 = NL + NL + "</div>";
+    public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
 
-	public RegionDocGen() {
-		//Here is the constructor
-		StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_1 = "<h2>Modes and States</h2>";
 
-		// add initialisation of the pattern variables (declaration has been already done).
+    protected final String TEXT_2 = NL;
 
-	}
+    protected final String TEXT_3 = NL + "<h2>Realized Elements</h2>" + NL;
 
-	public String generate(Object argument) throws Exception {
-		final StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_4 = NL + "<h2>Realizing Elements </h2>" + NL;
 
-		InternalPatternContext ctx = (InternalPatternContext) argument;
-		Map<String, String> queryCtx = null;
-		IQuery.ParameterDescription paramDesc = null;
-		Node.Container currentNode = ctx.getNode();
+    protected final String TEXT_5 = NL + "<h2>Owned Transitions</h2>" + NL + "<table max-width=\"screen.width\">" + NL + "   <thead> " + NL + "       <tr>" + NL + "           <th>Transition</th>" + NL
+            + "           <th>Source</th>" + NL + "           <th>Target</th>" + NL + "           <th>Trigger</th>" + NL + "           <th>Effect</th>" + NL + "           <th>Description</th>" + NL
+            + "       </tr>" + NL + "   </thead>" + NL + "   <tbody>";
 
-		List<Object> parameterList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
+    protected final String TEXT_6 = NL + "\t   <tr>" + NL + "           <td>";
 
-		for (Object parameterParameter : parameterList) {
+    protected final String TEXT_7 = "</td>" + NL + "           <td>";
 
-			this.parameter = (org.polarsys.capella.core.data.capellacommon.Region) parameterParameter;
+    protected final String TEXT_8 = "</td>" + NL + "       </tr>" + NL + "\t\t";
 
-			if (preCondition(ctx)) {
-				ctx.setNode(new Node.Container(currentNode, getClass()));
-				orchestration(ctx);
-			}
+    protected final String TEXT_9 = NL + NL + "</div>";
 
-		}
-		ctx.setNode(currentNode);
-		if (ctx.useReporter()) {
-			ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
-		}
+    public RegionDocGen() {
+        //Here is the constructor
+        StringBuffer stringBuffer = new StringBuffer();
 
-		stringBuffer.append(TEXT_2);
-		stringBuffer.append(TEXT_2);
-		return stringBuffer.toString();
-	}
+        // add initialisation of the pattern variables (declaration has been already done).
 
-	public String orchestration(PatternContext ctx) throws Exception {
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
+    }
 
-		super.orchestration(new SuperOrchestrationContext(ictx));
+    public String generate(Object argument) throws Exception {
+        final StringBuffer stringBuffer = new StringBuffer();
 
-		if (ictx.useReporter()) {
-			Map<String, Object> parameterValues = new HashMap<String, Object>();
-			parameterValues.put("parameter", this.parameter);
-			String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
-			String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
-			ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
-		}
-		return null;
-	}
+        InternalPatternContext ctx = (InternalPatternContext) argument;
+        Map<String, String> queryCtx = null;
+        IQuery.ParameterDescription paramDesc = null;
+        Node.Container currentNode = ctx.getNode();
 
-	protected org.polarsys.capella.core.data.capellacommon.Region parameter = null;
+        List<Object> parameterList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
 
-	public void set_parameter(org.polarsys.capella.core.data.capellacommon.Region object) {
-		this.parameter = object;
-	}
+        for (Object parameterParameter : parameterList) {
 
-	public Map<String, Object> getParameters() {
-		final Map<String, Object> parameters = new HashMap<String, Object>();
-		parameters.put("parameter", this.parameter);
-		return parameters;
-	}
+            this.parameter = (org.polarsys.capella.core.data.capellacommon.Region) parameterParameter;
 
-	protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+            if (preCondition(ctx)) {
+                ctx.setNode(new Node.Container(currentNode, getClass()));
+                orchestration(ctx);
+            }
 
-		super.method_content(new StringBuffer(), ctx);
-		String projectName = ctx.getValue("projectName").toString();
-		String outputFolder = ctx.getValue("outputFolder").toString();
+        }
+        ctx.setNode(currentNode);
+        if (ctx.useReporter()) {
+            ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
+        }
 
-		Collection<String> states = RegionHelper.getState(projectName, outputFolder, (Region) element);
+        stringBuffer.append(TEXT_2);
+        stringBuffer.append(TEXT_2);
+        return stringBuffer.toString();
+    }
 
-		if (states.size() > 0) {
+    public String orchestration(PatternContext ctx) throws Exception {
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
 
-			stringBuffer.append(TEXT_1);
-			stringBuffer.append(TEXT_2);
-			stringBuffer.append(StringUtil.stringListToBulette(states));
+        super.orchestration(new SuperOrchestrationContext(ictx));
 
-		}
+        if (ictx.useReporter()) {
+            Map<String, Object> parameterValues = new HashMap<String, Object>();
+            parameterValues.put("parameter", this.parameter);
+            String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
+            String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
+            ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
+        }
+        return null;
+    }
 
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
-	}
+    protected org.polarsys.capella.core.data.capellacommon.Region parameter = null;
 
-	protected void method_setCapellaContext(final StringBuffer stringBuffer, final PatternContext ctx)
-			throws Exception {
+    public void set_parameter(org.polarsys.capella.core.data.capellacommon.Region object) {
+        this.parameter = object;
+    }
 
-		element = parameter;
+    public Map<String, Object> getParameters() {
+        final Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("parameter", this.parameter);
+        return parameters;
+    }
 
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "setCapellaContext", stringBuffer.toString());
-	}
+    protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-	protected void method_endContent(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+        super.method_content(new StringBuffer(), ctx);
+        String projectName = ctx.getValue("projectName").toString();
+        String outputFolder = ctx.getValue("outputFolder").toString();
 
-		// Realized Elements 
+        Collection<String> states = RegionHelper.getState(projectName, outputFolder, (Region) element);
 
-		String outputFolder = ctx.getValue("outputFolder").toString();
-		String projectName = ctx.getValue("projectName").toString();
-		Collection<String> allocations = CapellaElementService.getOutGoingAllocation(element, projectName,
-				outputFolder);
-		if (allocations.size() > 0) {
-			stringBuffer.append(TEXT_3);
-			stringBuffer.append(TEXT_2);
-			stringBuffer.append(StringUtil.stringListToBulette(allocations));
-			stringBuffer.append(TEXT_2);
-		}
-		stringBuffer.append(TEXT_2);
-		// Realizing Elements 
+        if (states.size() > 0) {
 
-		//String outputFolder = ctx.getValue("outputFolder").toString();
-		//String projectName = ctx.getValue("projectName").toString();
-		Collection<String> allocations2 = CapellaElementService.getIncomingAllocation(element, projectName,
-				outputFolder);
-		if (allocations2.size() > 0) {
-			stringBuffer.append(TEXT_4);
-			stringBuffer.append(TEXT_2);
-			stringBuffer.append(StringUtil.stringListToBulette(allocations2));
-			stringBuffer.append(TEXT_2);
-		}
-		stringBuffer.append(TEXT_2);
-		// owned diagrams
-		stringBuffer.append(TEXT_2);
-		{
-			//<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#LogicalName=org.polarsys.capella.docgen.foundations.DiagramsGeneration" args="element:element"%>
+            stringBuffer.append(TEXT_1);
+            stringBuffer.append(TEXT_2);
+            stringBuffer.append(StringUtil.stringListToBulette(states));
 
-			InternalPatternContext ictx = (InternalPatternContext) ctx;
-			new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
-			stringBuffer.setLength(0);
+        }
 
-			final Map<String, Object> callParameters = new HashMap<String, Object>();
-			callParameters.put("element", element);
-			CallHelper.executeWithParameterInjection(
-					"platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#_PVePETXrEeCNvtb1bUM2fQ",
-					new ExecutionContext((InternalPatternContext) ctx), callParameters);
-			stringBuffer.setLength(0);
-		}
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
+    }
 
-		stringBuffer.append(TEXT_2);
-		if (parameter.getOwnedTransitions() != null && parameter.getOwnedTransitions().size() > 0) {
-			stringBuffer.append(TEXT_5);
-			for (StateTransition transition : parameter.getOwnedTransitions()) {
-				String triggerName = "";
-				EList<AbstractEvent> triggers = transition.getTriggers();
-				if (triggers != null && !triggers.isEmpty()) {
-					triggerName = triggers.get(0).getName();
-					for (int i = 1; i < triggers.size(); i++) {
-						triggerName += ", " + triggers.get(i).getName();
-					}
-				}
+    protected void method_setCapellaContext(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-				String guard = "";
+        element = parameter;
 
-				// FIXME: (Old code) Keep until migration validation
-				//guard = ( transition.getGuard() != null && transition.getGuard().length() > 0 ? "["+transition.getGuard()+"]" : "");
-				// New code
-				Constraint constraint = transition.getGuard();
-				if (constraint != null && constraint.getName() != null) {
-					String guardName = CapellaEmbeddedLinkedTextEditorInput.getDefaultText(constraint);
-					guard = guardName != null ? "[" + guardName + "]" : "";
-				}
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "setCapellaContext", stringBuffer.toString());
+    }
 
-				EList<AbstractEvent> effects = transition.getEffect();
-				String trans_effect = "";
-				for (AbstractEvent abstractEvent : effects) {
-					trans_effect += abstractEvent.getName();
-					if (effects.indexOf(abstractEvent) != effects.size()) {
-						trans_effect += ", ";
-					}
-				}
+    protected void method_endContent(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-				if (!trans_effect.isEmpty() && effects.size() > 1) {
-					trans_effect = "(" + trans_effect + ")";
-				}
+        // Realized Elements 
 
-				// String trans_effect = (transition.getEffect() != null ? transition.getEffect().getName() : "");
+        String outputFolder = ctx.getValue("outputFolder").toString();
+        String projectName = ctx.getValue("projectName").toString();
+        Collection<String> allocations = CapellaElementService.getOutGoingAllocation(element, projectName, outputFolder);
+        if (allocations.size() > 0) {
+            stringBuffer.append(TEXT_3);
+            stringBuffer.append(TEXT_2);
+            stringBuffer.append(StringUtil.stringListToBulette(allocations));
+            stringBuffer.append(TEXT_2);
+        }
+        stringBuffer.append(TEXT_2);
+        // Realizing Elements 
 
-				String trans_label = (triggerName.trim().length() > 0 ? triggerName
-						: transition.getTriggerDescription()) + " " + guard
-						+ (trans_effect.trim().length() > 0 ? " / " + trans_effect : "");
+        //String outputFolder = ctx.getValue("outputFolder").toString();
+        //String projectName = ctx.getValue("projectName").toString();
+        Collection<String> allocations2 = CapellaElementService.getIncomingAllocation(element, projectName, outputFolder);
+        if (allocations2.size() > 0) {
+            stringBuffer.append(TEXT_4);
+            stringBuffer.append(TEXT_2);
+            stringBuffer.append(StringUtil.stringListToBulette(allocations2));
+            stringBuffer.append(TEXT_2);
+        }
+        stringBuffer.append(TEXT_2);
+        // owned diagrams
+        stringBuffer.append(TEXT_2);
+        {
+            //<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#LogicalName=org.polarsys.capella.docgen.foundations.DiagramsGeneration" args="element:element"%>
 
-				String trans_source = (transition.getSource() != null ? transition.getSource().getName() : "");
+            InternalPatternContext ictx = (InternalPatternContext) ctx;
+            new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
+            stringBuffer.setLength(0);
 
-				String trans_target = (transition.getTarget() != null ? transition.getTarget().getName() : "");
+            final Map<String, Object> callParameters = new HashMap<String, Object>();
+            callParameters.put("element", element);
+            CallHelper.executeWithParameterInjection("platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#_PVePETXrEeCNvtb1bUM2fQ",
+                    new ExecutionContext((InternalPatternContext) ctx), callParameters);
+            stringBuffer.setLength(0);
+        }
 
-				String trans_description = "";
+        stringBuffer.append(TEXT_2);
+        if (parameter.getOwnedTransitions() != null && parameter.getOwnedTransitions().size() > 0) {
+            stringBuffer.append(TEXT_5);
+            for (StateTransition transition : parameter.getOwnedTransitions()) {
+                String triggerName = "";
+                EList<AbstractEvent> triggers = transition.getTriggers();
+                if (triggers != null && !triggers.isEmpty()) {
+                    triggerName = triggers.get(0).getName();
+                    for (int i = 1; i < triggers.size(); i++) {
+                        triggerName += ", " + triggers.get(i).getName();
+                    }
+                }
 
-				if (transition instanceof StateTransition) {
-					StateTransition tt = (StateTransition) transition;
-					trans_description = tt.getDescription();
-					trans_description = StringUtil.transformAREFString(transition, trans_description, projectName,
-							outputFolder);
-				}
-				stringBuffer.append(TEXT_6);
-				stringBuffer.append(trans_label);
-				stringBuffer.append(TEXT_7);
-				stringBuffer.append(trans_source);
-				stringBuffer.append(TEXT_7);
-				stringBuffer.append(trans_target);
-				stringBuffer.append(TEXT_7);
-				stringBuffer.append(triggerName);
-				stringBuffer.append(TEXT_7);
-				stringBuffer.append(trans_effect);
-				stringBuffer.append(TEXT_7);
-				stringBuffer.append(trans_description);
-				stringBuffer.append(TEXT_8);
-			}
-		}
-		stringBuffer.append(TEXT_9);
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "endContent", stringBuffer.toString());
-	}
+                String guard = "";
+
+                // FIXME: (Old code) Keep until migration validation
+                //guard = ( transition.getGuard() != null && transition.getGuard().length() > 0 ? "["+transition.getGuard()+"]" : "");
+                // New code
+                Constraint constraint = transition.getGuard();
+                if (constraint != null && constraint.getName() != null) {
+                    String guardName = CapellaEmbeddedLinkedTextEditorInput.getDefaultText(constraint);
+                    guard = guardName != null ? "[" + guardName + "]" : "";
+                }
+
+                EList<AbstractEvent> effects = transition.getEffect();
+                String trans_effect = "";
+                for (AbstractEvent abstractEvent : effects) {
+                    trans_effect += abstractEvent.getName();
+                    if (effects.indexOf(abstractEvent) != effects.size()) {
+                        trans_effect += ", ";
+                    }
+                }
+
+                if (!trans_effect.isEmpty() && effects.size() > 1) {
+                    trans_effect = "(" + trans_effect + ")";
+                }
+
+                // String trans_effect = (transition.getEffect() != null ? transition.getEffect().getName() : "");
+
+                String trans_label = (triggerName.trim().length() > 0 ? triggerName : transition.getTriggerDescription()) + " " + guard
+                        + (trans_effect.trim().length() > 0 ? " / " + trans_effect : "");
+
+                String trans_source = (transition.getSource() != null ? transition.getSource().getName() : "");
+
+                String trans_target = (transition.getTarget() != null ? transition.getTarget().getName() : "");
+
+                String trans_description = "";
+
+                if (transition instanceof StateTransition) {
+                    StateTransition tt = (StateTransition) transition;
+                    trans_description = tt.getDescription();
+                    trans_description = StringUtil.transformAREFString(transition, trans_description, projectName, outputFolder);
+                }
+                stringBuffer.append(TEXT_6);
+                stringBuffer.append(trans_label);
+                stringBuffer.append(TEXT_7);
+                stringBuffer.append(trans_source);
+                stringBuffer.append(TEXT_7);
+                stringBuffer.append(trans_target);
+                stringBuffer.append(TEXT_7);
+                stringBuffer.append(triggerName);
+                stringBuffer.append(TEXT_7);
+                stringBuffer.append(trans_effect);
+                stringBuffer.append(TEXT_7);
+                stringBuffer.append(trans_description);
+                stringBuffer.append(TEXT_8);
+            }
+        }
+        stringBuffer.append(TEXT_9);
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "endContent", stringBuffer.toString());
+    }
 }

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/RequirementDocGen.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/RequirementDocGen.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.1.201906060805
+//Generated with EGF 1.6.3.202110291409
 package org.polarsys.capella.docgen.content;
 
 import org.eclipse.egf.common.helper.*;
@@ -12,110 +12,110 @@ import org.polarsys.capella.docgen.util.StringUtil;
 import org.polarsys.capella.docgen.util.pattern.helper.CapellaRequirementHelper;
 
 public class RequirementDocGen extends org.polarsys.capella.docgen.foundations.NamedElementDocGen {
-	protected static String nl;
+    protected static String nl;
 
-	public static synchronized RequirementDocGen create(String lineSeparator) {
-		nl = lineSeparator;
-		RequirementDocGen result = new RequirementDocGen();
-		nl = null;
-		return result;
-	}
+    public static synchronized RequirementDocGen create(String lineSeparator) {
+        nl = lineSeparator;
+        RequirementDocGen result = new RequirementDocGen();
+        nl = null;
+        return result;
+    }
 
-	public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
-	protected final String TEXT_1 = "<h2>Tracing Model Elements</h2>" + NL;
-	protected final String TEXT_2 = NL;
+    public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
 
-	public RequirementDocGen() {
-		//Here is the constructor
-		StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_1 = "<h2>Tracing Model Elements</h2>" + NL;
 
-		// add initialisation of the pattern variables (declaration has been already done).
+    protected final String TEXT_2 = NL;
 
-	}
+    public RequirementDocGen() {
+        //Here is the constructor
+        StringBuffer stringBuffer = new StringBuffer();
 
-	public String generate(Object argument) throws Exception {
-		final StringBuffer stringBuffer = new StringBuffer();
+        // add initialisation of the pattern variables (declaration has been already done).
 
-		InternalPatternContext ctx = (InternalPatternContext) argument;
-		Map<String, String> queryCtx = null;
-		IQuery.ParameterDescription paramDesc = null;
-		Node.Container currentNode = ctx.getNode();
+    }
 
-		List<Object> parameterList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
+    public String generate(Object argument) throws Exception {
+        final StringBuffer stringBuffer = new StringBuffer();
 
-		for (Object parameterParameter : parameterList) {
+        InternalPatternContext ctx = (InternalPatternContext) argument;
+        Map<String, String> queryCtx = null;
+        IQuery.ParameterDescription paramDesc = null;
+        Node.Container currentNode = ctx.getNode();
 
-			this.parameter = (org.polarsys.capella.core.data.requirement.Requirement) parameterParameter;
+        List<Object> parameterList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
 
-			if (preCondition(ctx)) {
-				ctx.setNode(new Node.Container(currentNode, getClass()));
-				orchestration(ctx);
-			}
+        for (Object parameterParameter : parameterList) {
 
-		}
-		ctx.setNode(currentNode);
-		if (ctx.useReporter()) {
-			ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
-		}
+            this.parameter = (org.polarsys.capella.core.data.requirement.Requirement) parameterParameter;
 
-		stringBuffer.append(TEXT_2);
-		stringBuffer.append(TEXT_2);
-		return stringBuffer.toString();
-	}
+            if (preCondition(ctx)) {
+                ctx.setNode(new Node.Container(currentNode, getClass()));
+                orchestration(ctx);
+            }
 
-	public String orchestration(PatternContext ctx) throws Exception {
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
+        }
+        ctx.setNode(currentNode);
+        if (ctx.useReporter()) {
+            ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
+        }
 
-		super.orchestration(new SuperOrchestrationContext(ictx));
+        stringBuffer.append(TEXT_2);
+        stringBuffer.append(TEXT_2);
+        return stringBuffer.toString();
+    }
 
-		if (ictx.useReporter()) {
-			Map<String, Object> parameterValues = new HashMap<String, Object>();
-			parameterValues.put("parameter", this.parameter);
-			String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
-			String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
-			ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
-		}
-		return null;
-	}
+    public String orchestration(PatternContext ctx) throws Exception {
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
 
-	protected org.polarsys.capella.core.data.requirement.Requirement parameter = null;
+        super.orchestration(new SuperOrchestrationContext(ictx));
 
-	public void set_parameter(org.polarsys.capella.core.data.requirement.Requirement object) {
-		this.parameter = object;
-	}
+        if (ictx.useReporter()) {
+            Map<String, Object> parameterValues = new HashMap<String, Object>();
+            parameterValues.put("parameter", this.parameter);
+            String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
+            String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
+            ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
+        }
+        return null;
+    }
 
-	public Map<String, Object> getParameters() {
-		final Map<String, Object> parameters = new HashMap<String, Object>();
-		parameters.put("parameter", this.parameter);
-		return parameters;
-	}
+    protected org.polarsys.capella.core.data.requirement.Requirement parameter = null;
 
-	protected void method_setCapellaContext(final StringBuffer stringBuffer, final PatternContext ctx)
-			throws Exception {
+    public void set_parameter(org.polarsys.capella.core.data.requirement.Requirement object) {
+        this.parameter = object;
+    }
 
-		element = parameter;
+    public Map<String, Object> getParameters() {
+        final Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("parameter", this.parameter);
+        return parameters;
+    }
 
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "setCapellaContext", stringBuffer.toString());
-	}
+    protected void method_setCapellaContext(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-	protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+        element = parameter;
 
-		super.method_content(new StringBuffer(), ctx);
-		String projectName = ctx.getValue("projectName").toString();
-		String outputFolder = ctx.getValue("outputFolder").toString();
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "setCapellaContext", stringBuffer.toString());
+    }
 
-		Collection<String> tracingModelElements = CapellaRequirementHelper
-				.getTracingModelElements((Requirement) element, projectName, outputFolder);
-		if (tracingModelElements.size() > 0) {
+    protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-			stringBuffer.append(TEXT_1);
-			stringBuffer.append(TEXT_2);
-			stringBuffer.append(StringUtil.stringListToBulette(tracingModelElements));
-		}
-		stringBuffer.append(TEXT_2);
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
-	}
+        super.method_content(new StringBuffer(), ctx);
+        String projectName = ctx.getValue("projectName").toString();
+        String outputFolder = ctx.getValue("outputFolder").toString();
+
+        Collection<String> tracingModelElements = CapellaRequirementHelper.getTracingModelElements((Requirement) element, projectName, outputFolder);
+        if (tracingModelElements.size() > 0) {
+
+            stringBuffer.append(TEXT_1);
+            stringBuffer.append(TEXT_2);
+            stringBuffer.append(StringUtil.stringListToBulette(tracingModelElements));
+        }
+        stringBuffer.append(TEXT_2);
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
+    }
 }

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/StateDocGen.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/StateDocGen.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.1.201906060805
+//Generated with EGF 1.6.3.202110291409
 package org.polarsys.capella.docgen.content;
 
 import org.eclipse.egf.common.helper.*;
@@ -12,194 +12,199 @@ import org.polarsys.capella.docgen.util.StringUtil;
 import org.polarsys.capella.docgen.util.pattern.helper.CapellaStateHelper;
 
 public class StateDocGen extends org.polarsys.capella.docgen.foundations.NamedElementDocGen {
-	protected static String nl;
+    protected static String nl;
 
-	public static synchronized StateDocGen create(String lineSeparator) {
-		nl = lineSeparator;
-		StateDocGen result = new StateDocGen();
-		nl = null;
-		return result;
-	}
+    public static synchronized StateDocGen create(String lineSeparator) {
+        nl = lineSeparator;
+        StateDocGen result = new StateDocGen();
+        nl = null;
+        return result;
+    }
 
-	public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
-	protected final String TEXT_1 = "<h2>Properties</h2>" + NL + "<p><strong>Do Activity:</strong> ";
-	protected final String TEXT_2 = "</p>";
-	protected final String TEXT_3 = NL + "<h2>Modes and States</h2>";
-	protected final String TEXT_4 = NL;
-	protected final String TEXT_5 = NL + "<h3>Referenced</h3>";
-	protected final String TEXT_6 = NL + "<h2>Previous States / Modes</h2>";
-	protected final String TEXT_7 = NL + "<h2>Following States / Modes</h2>";
-	protected final String TEXT_8 = NL + "<h2>Functions</h2>";
-	protected final String TEXT_9 = NL + "<h2>Functional Chains</h2>";
-	protected final String TEXT_10 = NL + "<h2>Capabilities</h2>";
+    public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
 
-	public StateDocGen() {
-		//Here is the constructor
-		StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_1 = "<h2>Properties</h2>" + NL + "<p><strong>Do Activity:</strong> ";
 
-		// add initialisation of the pattern variables (declaration has been already done).
+    protected final String TEXT_2 = "</p>";
 
-	}
+    protected final String TEXT_3 = NL + "<h2>Modes and States</h2>";
 
-	public String generate(Object argument) throws Exception {
-		final StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_4 = NL;
 
-		InternalPatternContext ctx = (InternalPatternContext) argument;
-		Map<String, String> queryCtx = null;
-		IQuery.ParameterDescription paramDesc = null;
-		Node.Container currentNode = ctx.getNode();
+    protected final String TEXT_5 = NL + "<h3>Referenced</h3>";
 
-		List<Object> parameterList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
+    protected final String TEXT_6 = NL + "<h2>Previous States / Modes</h2>";
 
-		for (Object parameterParameter : parameterList) {
+    protected final String TEXT_7 = NL + "<h2>Following States / Modes</h2>";
 
-			this.parameter = (org.polarsys.capella.core.data.capellacommon.State) parameterParameter;
+    protected final String TEXT_8 = NL + "<h2>Functions</h2>";
 
-			if (preCondition(ctx)) {
-				ctx.setNode(new Node.Container(currentNode, getClass()));
-				orchestration(ctx);
-			}
+    protected final String TEXT_9 = NL + "<h2>Functional Chains</h2>";
 
-		}
-		ctx.setNode(currentNode);
-		if (ctx.useReporter()) {
-			ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
-		}
+    protected final String TEXT_10 = NL + "<h2>Capabilities</h2>";
 
-		stringBuffer.append(TEXT_4);
-		stringBuffer.append(TEXT_4);
-		return stringBuffer.toString();
-	}
+    public StateDocGen() {
+        //Here is the constructor
+        StringBuffer stringBuffer = new StringBuffer();
 
-	public String orchestration(PatternContext ctx) throws Exception {
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
+        // add initialisation of the pattern variables (declaration has been already done).
 
-		super.orchestration(new SuperOrchestrationContext(ictx));
+    }
 
-		if (ictx.useReporter()) {
-			Map<String, Object> parameterValues = new HashMap<String, Object>();
-			parameterValues.put("parameter", this.parameter);
-			String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
-			String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
-			ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
-		}
-		return null;
-	}
+    public String generate(Object argument) throws Exception {
+        final StringBuffer stringBuffer = new StringBuffer();
 
-	protected org.polarsys.capella.core.data.capellacommon.State parameter = null;
+        InternalPatternContext ctx = (InternalPatternContext) argument;
+        Map<String, String> queryCtx = null;
+        IQuery.ParameterDescription paramDesc = null;
+        Node.Container currentNode = ctx.getNode();
 
-	public void set_parameter(org.polarsys.capella.core.data.capellacommon.State object) {
-		this.parameter = object;
-	}
+        List<Object> parameterList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
 
-	public Map<String, Object> getParameters() {
-		final Map<String, Object> parameters = new HashMap<String, Object>();
-		parameters.put("parameter", this.parameter);
-		return parameters;
-	}
+        for (Object parameterParameter : parameterList) {
 
-	protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+            this.parameter = (org.polarsys.capella.core.data.capellacommon.State) parameterParameter;
 
-		super.method_content(new StringBuffer(), ctx);
-		String projectName = ctx.getValue("projectName").toString();
-		String outputFolder = ctx.getValue("outputFolder").toString();
+            if (preCondition(ctx)) {
+                ctx.setNode(new Node.Container(currentNode, getClass()));
+                orchestration(ctx);
+            }
 
-		String doActivity = CapellaStateHelper.getDoActivity(projectName, outputFolder, (State) element);
-		if (doActivity != "") {
+        }
+        ctx.setNode(currentNode);
+        if (ctx.useReporter()) {
+            ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
+        }
 
-			stringBuffer.append(TEXT_1);
-			stringBuffer.append(doActivity);
-			stringBuffer.append(TEXT_2);
+        stringBuffer.append(TEXT_4);
+        stringBuffer.append(TEXT_4);
+        return stringBuffer.toString();
+    }
 
-		}
-		Collection<String> ownedReferencedStatesModes = CapellaStateHelper.getOwnedReferencedStatesModes(projectName,
-				outputFolder, (State) element);
-		Collection<String> referencedStatesModes = CapellaStateHelper.getReferencedStatesModes(projectName,
-				outputFolder, (State) element);
+    public String orchestration(PatternContext ctx) throws Exception {
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
 
-		if (ownedReferencedStatesModes.size() > 0 || referencedStatesModes.size() > 0) {
+        super.orchestration(new SuperOrchestrationContext(ictx));
 
-			stringBuffer.append(TEXT_3);
-			stringBuffer.append(TEXT_4);
-			stringBuffer.append(StringUtil.stringListToBulette(ownedReferencedStatesModes));
+        if (ictx.useReporter()) {
+            Map<String, Object> parameterValues = new HashMap<String, Object>();
+            parameterValues.put("parameter", this.parameter);
+            String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
+            String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
+            ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
+        }
+        return null;
+    }
 
-		}
+    protected org.polarsys.capella.core.data.capellacommon.State parameter = null;
 
-		if (referencedStatesModes.size() > 0) {
+    public void set_parameter(org.polarsys.capella.core.data.capellacommon.State object) {
+        this.parameter = object;
+    }
 
-			stringBuffer.append(TEXT_5);
-			stringBuffer.append(TEXT_4);
-			stringBuffer.append(StringUtil.stringListToBulette(referencedStatesModes));
+    public Map<String, Object> getParameters() {
+        final Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("parameter", this.parameter);
+        return parameters;
+    }
 
-		}
-		/*
-		Collection<String> previousStatesModes = CapellaStateHelper.getPreviousStatesModes(projectName,
-					outputFolder,(State) element);
-					
-					if(previousStatesModes.size() > 0) {
-		
-		    stringBuffer.append(TEXT_6);
-		    stringBuffer.append(TEXT_4);
-		    stringBuffer.append(StringUtil.stringListToBulette(previousStatesModes));
-		    
-		}
-		
-		
-		Collection<String> followingStatesModes = CapellaStateHelper.getFollowingStatesModes(projectName,
-					outputFolder,(State) element);
-					
-					if(followingStatesModes.size() > 0) {
-		
-		    stringBuffer.append(TEXT_7);
-		    stringBuffer.append(TEXT_4);
-		    stringBuffer.append(StringUtil.stringListToBulette(followingStatesModes));
-		    
-		}
-		
-		*/
-		Collection<String> functions = CapellaStateHelper.getFunctions(projectName, outputFolder, (State) element);
+    protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-		if (functions.size() > 0) {
+        super.method_content(new StringBuffer(), ctx);
+        String projectName = ctx.getValue("projectName").toString();
+        String outputFolder = ctx.getValue("outputFolder").toString();
 
-			stringBuffer.append(TEXT_8);
-			stringBuffer.append(TEXT_4);
-			stringBuffer.append(StringUtil.stringListToBulette(functions));
+        String doActivity = CapellaStateHelper.getDoActivity(projectName, outputFolder, (State) element);
+        if (doActivity != "") {
 
-		}
+            stringBuffer.append(TEXT_1);
+            stringBuffer.append(doActivity);
+            stringBuffer.append(TEXT_2);
 
-		Collection<String> functionalChain = CapellaStateHelper.getFunctionalChain(projectName, outputFolder,
-				(State) element);
+        }
+        Collection<String> ownedReferencedStatesModes = CapellaStateHelper.getOwnedReferencedStatesModes(projectName, outputFolder, (State) element);
+        Collection<String> referencedStatesModes = CapellaStateHelper.getReferencedStatesModes(projectName, outputFolder, (State) element);
 
-		if (functionalChain.size() > 0) {
+        if (ownedReferencedStatesModes.size() > 0 || referencedStatesModes.size() > 0) {
 
-			stringBuffer.append(TEXT_9);
-			stringBuffer.append(TEXT_4);
-			stringBuffer.append(StringUtil.stringListToBulette(functionalChain));
+            stringBuffer.append(TEXT_3);
+            stringBuffer.append(TEXT_4);
+            stringBuffer.append(StringUtil.stringListToBulette(ownedReferencedStatesModes));
 
-		}
+        }
 
-		Collection<String> capabilities = CapellaStateHelper.getCapabilities(projectName, outputFolder,
-				(State) element);
+        if (referencedStatesModes.size() > 0) {
 
-		if (capabilities.size() > 0) {
+            stringBuffer.append(TEXT_5);
+            stringBuffer.append(TEXT_4);
+            stringBuffer.append(StringUtil.stringListToBulette(referencedStatesModes));
 
-			stringBuffer.append(TEXT_10);
-			stringBuffer.append(TEXT_4);
-			stringBuffer.append(StringUtil.stringListToBulette(capabilities));
+        }
+        /*
+        Collection<String> previousStatesModes = CapellaStateHelper.getPreviousStatesModes(projectName,
+        			outputFolder,(State) element);
+        			
+        			if(previousStatesModes.size() > 0) {
+        
+            stringBuffer.append(TEXT_6);
+            stringBuffer.append(TEXT_4);
+            stringBuffer.append(StringUtil.stringListToBulette(previousStatesModes));
+            
+        }
+        
+        
+        Collection<String> followingStatesModes = CapellaStateHelper.getFollowingStatesModes(projectName,
+        			outputFolder,(State) element);
+        			
+        			if(followingStatesModes.size() > 0) {
+        
+            stringBuffer.append(TEXT_7);
+            stringBuffer.append(TEXT_4);
+            stringBuffer.append(StringUtil.stringListToBulette(followingStatesModes));
+            
+        }
+        
+        */
+        Collection<String> functions = CapellaStateHelper.getFunctions(projectName, outputFolder, (State) element);
 
-		}
+        if (functions.size() > 0) {
 
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
-	}
+            stringBuffer.append(TEXT_8);
+            stringBuffer.append(TEXT_4);
+            stringBuffer.append(StringUtil.stringListToBulette(functions));
 
-	protected void method_setCapellaContext(final StringBuffer stringBuffer, final PatternContext ctx)
-			throws Exception {
+        }
 
-		element = parameter;
+        Collection<String> functionalChain = CapellaStateHelper.getFunctionalChain(projectName, outputFolder, (State) element);
 
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "setCapellaContext", stringBuffer.toString());
-	}
+        if (functionalChain.size() > 0) {
+
+            stringBuffer.append(TEXT_9);
+            stringBuffer.append(TEXT_4);
+            stringBuffer.append(StringUtil.stringListToBulette(functionalChain));
+
+        }
+
+        Collection<String> capabilities = CapellaStateHelper.getCapabilities(projectName, outputFolder, (State) element);
+
+        if (capabilities.size() > 0) {
+
+            stringBuffer.append(TEXT_10);
+            stringBuffer.append(TEXT_4);
+            stringBuffer.append(StringUtil.stringListToBulette(capabilities));
+
+        }
+
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
+    }
+
+    protected void method_setCapellaContext(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+
+        element = parameter;
+
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "setCapellaContext", stringBuffer.toString());
+    }
 }

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/StateMachineDocGen.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/StateMachineDocGen.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.2.202001031546
+//Generated with EGF 1.6.3.202110291409
 package org.polarsys.capella.docgen.content;
 
 import org.eclipse.egf.common.helper.*;
@@ -15,114 +15,115 @@ import org.polarsys.kitalpha.doc.gen.business.core.util.EscapeChars;
 import org.polarsys.capella.docgen.util.CapellaLabelProviderHelper;
 
 public class StateMachineDocGen extends org.polarsys.capella.docgen.foundations.CapellaElementDocGen {
-	protected static String nl;
+    protected static String nl;
 
-	public static synchronized StateMachineDocGen create(String lineSeparator) {
-		nl = lineSeparator;
-		StateMachineDocGen result = new StateMachineDocGen();
-		nl = null;
-		return result;
-	}
+    public static synchronized StateMachineDocGen create(String lineSeparator) {
+        nl = lineSeparator;
+        StateMachineDocGen result = new StateMachineDocGen();
+        nl = null;
+        return result;
+    }
 
-	public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
-	protected final String TEXT_1 = "<h2>Owned Region</h2>";
-	protected final String TEXT_2 = NL;
+    public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
 
-	public StateMachineDocGen() {
-		//Here is the constructor
-		StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_1 = "<h2>Owned Region</h2>";
 
-		// add initialisation of the pattern variables (declaration has been already done).
+    protected final String TEXT_2 = NL;
 
-	}
+    public StateMachineDocGen() {
+        //Here is the constructor
+        StringBuffer stringBuffer = new StringBuffer();
 
-	public String generate(Object argument) throws Exception {
-		final StringBuffer stringBuffer = new StringBuffer();
+        // add initialisation of the pattern variables (declaration has been already done).
 
-		InternalPatternContext ctx = (InternalPatternContext) argument;
-		Map<String, String> queryCtx = null;
-		IQuery.ParameterDescription paramDesc = null;
-		Node.Container currentNode = ctx.getNode();
+    }
 
-		List<Object> parameterList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
+    public String generate(Object argument) throws Exception {
+        final StringBuffer stringBuffer = new StringBuffer();
 
-		for (Object parameterParameter : parameterList) {
+        InternalPatternContext ctx = (InternalPatternContext) argument;
+        Map<String, String> queryCtx = null;
+        IQuery.ParameterDescription paramDesc = null;
+        Node.Container currentNode = ctx.getNode();
 
-			this.parameter = (org.polarsys.capella.core.data.capellacommon.StateMachine) parameterParameter;
+        List<Object> parameterList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
 
-			if (preCondition(ctx)) {
-				ctx.setNode(new Node.Container(currentNode, getClass()));
-				orchestration(ctx);
-			}
+        for (Object parameterParameter : parameterList) {
 
-		}
-		ctx.setNode(currentNode);
-		if (ctx.useReporter()) {
-			ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
-		}
+            this.parameter = (org.polarsys.capella.core.data.capellacommon.StateMachine) parameterParameter;
 
-		stringBuffer.append(TEXT_2);
-		stringBuffer.append(TEXT_2);
-		return stringBuffer.toString();
-	}
+            if (preCondition(ctx)) {
+                ctx.setNode(new Node.Container(currentNode, getClass()));
+                orchestration(ctx);
+            }
 
-	public String orchestration(PatternContext ctx) throws Exception {
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
+        }
+        ctx.setNode(currentNode);
+        if (ctx.useReporter()) {
+            ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
+        }
 
-		super.orchestration(new SuperOrchestrationContext(ictx));
+        stringBuffer.append(TEXT_2);
+        stringBuffer.append(TEXT_2);
+        return stringBuffer.toString();
+    }
 
-		if (ictx.useReporter()) {
-			Map<String, Object> parameterValues = new HashMap<String, Object>();
-			parameterValues.put("parameter", this.parameter);
-			String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
-			String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
-			ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
-		}
-		return null;
-	}
+    public String orchestration(PatternContext ctx) throws Exception {
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
 
-	protected org.polarsys.capella.core.data.capellacommon.StateMachine parameter = null;
+        super.orchestration(new SuperOrchestrationContext(ictx));
 
-	public void set_parameter(org.polarsys.capella.core.data.capellacommon.StateMachine object) {
-		this.parameter = object;
-	}
+        if (ictx.useReporter()) {
+            Map<String, Object> parameterValues = new HashMap<String, Object>();
+            parameterValues.put("parameter", this.parameter);
+            String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
+            String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
+            ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
+        }
+        return null;
+    }
 
-	public Map<String, Object> getParameters() {
-		final Map<String, Object> parameters = new HashMap<String, Object>();
-		parameters.put("parameter", this.parameter);
-		return parameters;
-	}
+    protected org.polarsys.capella.core.data.capellacommon.StateMachine parameter = null;
 
-	protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+    public void set_parameter(org.polarsys.capella.core.data.capellacommon.StateMachine object) {
+        this.parameter = object;
+    }
 
-		super.method_content(new StringBuffer(), ctx);
-		String projectName = ctx.getValue("projectName").toString();
-		String outputFolder = ctx.getValue("outputFolder").toString();
+    public Map<String, Object> getParameters() {
+        final Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("parameter", this.parameter);
+        return parameters;
+    }
 
-		Collection<String> regions = StateMachineHelper.getRegions(projectName, outputFolder, (StateMachine) element);
+    protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-		if (regions.size() > 0) {
+        super.method_content(new StringBuffer(), ctx);
+        String projectName = ctx.getValue("projectName").toString();
+        String outputFolder = ctx.getValue("outputFolder").toString();
 
-			stringBuffer.append(TEXT_1);
-			stringBuffer.append(TEXT_2);
-			stringBuffer.append(StringUtil.stringListToBulette(regions));
+        Collection<String> regions = StateMachineHelper.getRegions(projectName, outputFolder, (StateMachine) element);
 
-		}
+        if (regions.size() > 0) {
 
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
-	}
+            stringBuffer.append(TEXT_1);
+            stringBuffer.append(TEXT_2);
+            stringBuffer.append(StringUtil.stringListToBulette(regions));
 
-	protected void method_setCapellaContext(final StringBuffer stringBuffer, final PatternContext ctx)
-			throws Exception {
+        }
 
-		element = parameter;
-		String elementName = EscapeChars.forHTML(CapellaLabelProviderHelper.getText(element));
-		String elementType = EscapeChars.forHTML(element.eClass().getName());
-		title = "Capella - " + DocGenHtmlUtil.getModelName(element) + " - " + elementType + " " + elementName;
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
+    }
 
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "setCapellaContext", stringBuffer.toString());
-	}
+    protected void method_setCapellaContext(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+
+        element = parameter;
+        String elementName = EscapeChars.forHTML(CapellaLabelProviderHelper.getText(element));
+        String elementType = EscapeChars.forHTML(element.eClass().getName());
+        title = "Capella - " + DocGenHtmlUtil.getModelName(element) + " - " + elementType + " " + elementName;
+
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "setCapellaContext", stringBuffer.toString());
+    }
 }

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/packageDocGen.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/content/packageDocGen.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.1.201906060805
+//Generated with EGF 1.6.3.202110291409
 package org.polarsys.capella.docgen.content;
 
 import org.eclipse.egf.common.helper.*;
@@ -14,113 +14,113 @@ import org.polarsys.capella.docgen.util.StringUtil;
 import org.polarsys.capella.docgen.util.pattern.helper.PackageHelper;
 
 public class packageDocGen extends org.polarsys.capella.docgen.foundations.NamedElementDocGen {
-	protected static String nl;
+    protected static String nl;
 
-	public static synchronized packageDocGen create(String lineSeparator) {
-		nl = lineSeparator;
-		packageDocGen result = new packageDocGen();
-		nl = null;
-		return result;
-	}
+    public static synchronized packageDocGen create(String lineSeparator) {
+        nl = lineSeparator;
+        packageDocGen result = new packageDocGen();
+        nl = null;
+        return result;
+    }
 
-	public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
-	protected final String TEXT_1 = "<h2>Content</h2>";
-	protected final String TEXT_2 = NL;
+    public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
 
-	public packageDocGen() {
-		//Here is the constructor
-		StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_1 = "<h2>Content</h2>";
 
-		// add initialisation of the pattern variables (declaration has been already done).
+    protected final String TEXT_2 = NL;
 
-	}
+    public packageDocGen() {
+        //Here is the constructor
+        StringBuffer stringBuffer = new StringBuffer();
 
-	public String generate(Object argument) throws Exception {
-		final StringBuffer stringBuffer = new StringBuffer();
+        // add initialisation of the pattern variables (declaration has been already done).
 
-		InternalPatternContext ctx = (InternalPatternContext) argument;
-		Map<String, String> queryCtx = null;
-		IQuery.ParameterDescription paramDesc = null;
-		Node.Container currentNode = ctx.getNode();
+    }
 
-		List<Object> parameterList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
+    public String generate(Object argument) throws Exception {
+        final StringBuffer stringBuffer = new StringBuffer();
 
-		for (Object parameterParameter : parameterList) {
+        InternalPatternContext ctx = (InternalPatternContext) argument;
+        Map<String, String> queryCtx = null;
+        IQuery.ParameterDescription paramDesc = null;
+        Node.Container currentNode = ctx.getNode();
 
-			this.parameter = (org.polarsys.capella.core.data.capellacore.Structure) parameterParameter;
+        List<Object> parameterList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
 
-			if (preCondition(ctx)) {
-				ctx.setNode(new Node.Container(currentNode, getClass()));
-				orchestration(ctx);
-			}
+        for (Object parameterParameter : parameterList) {
 
-		}
-		ctx.setNode(currentNode);
-		if (ctx.useReporter()) {
-			ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
-		}
+            this.parameter = (org.polarsys.capella.core.data.capellacore.Structure) parameterParameter;
 
-		stringBuffer.append(TEXT_2);
-		stringBuffer.append(TEXT_2);
-		return stringBuffer.toString();
-	}
+            if (preCondition(ctx)) {
+                ctx.setNode(new Node.Container(currentNode, getClass()));
+                orchestration(ctx);
+            }
 
-	public String orchestration(PatternContext ctx) throws Exception {
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
+        }
+        ctx.setNode(currentNode);
+        if (ctx.useReporter()) {
+            ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
+        }
 
-		super.orchestration(new SuperOrchestrationContext(ictx));
+        stringBuffer.append(TEXT_2);
+        stringBuffer.append(TEXT_2);
+        return stringBuffer.toString();
+    }
 
-		if (ictx.useReporter()) {
-			Map<String, Object> parameterValues = new HashMap<String, Object>();
-			parameterValues.put("parameter", this.parameter);
-			String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
-			String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
-			ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
-		}
-		return null;
-	}
+    public String orchestration(PatternContext ctx) throws Exception {
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
 
-	protected org.polarsys.capella.core.data.capellacore.Structure parameter = null;
+        super.orchestration(new SuperOrchestrationContext(ictx));
 
-	public void set_parameter(org.polarsys.capella.core.data.capellacore.Structure object) {
-		this.parameter = object;
-	}
+        if (ictx.useReporter()) {
+            Map<String, Object> parameterValues = new HashMap<String, Object>();
+            parameterValues.put("parameter", this.parameter);
+            String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
+            String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
+            ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
+        }
+        return null;
+    }
 
-	public Map<String, Object> getParameters() {
-		final Map<String, Object> parameters = new HashMap<String, Object>();
-		parameters.put("parameter", this.parameter);
-		return parameters;
-	}
+    protected org.polarsys.capella.core.data.capellacore.Structure parameter = null;
 
-	protected void method_setCapellaContext(final StringBuffer stringBuffer, final PatternContext ctx)
-			throws Exception {
+    public void set_parameter(org.polarsys.capella.core.data.capellacore.Structure object) {
+        this.parameter = object;
+    }
 
-		element = parameter;
+    public Map<String, Object> getParameters() {
+        final Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("parameter", this.parameter);
+        return parameters;
+    }
 
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "setCapellaContext", stringBuffer.toString());
-	}
+    protected void method_setCapellaContext(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-	protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+        element = parameter;
 
-		super.method_content(new StringBuffer(), ctx);
-		String projectName = ctx.getValue("projectName").toString();
-		String outputFolder = ctx.getValue("outputFolder").toString();
-		Collection<String> content = PackageHelper.getContent((Structure) element, projectName, outputFolder);
-		if (content.size() > 0) {
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "setCapellaContext", stringBuffer.toString());
+    }
 
-			stringBuffer.append(TEXT_1);
-			stringBuffer.append(TEXT_2);
-			stringBuffer.append(StringUtil.stringListToBulette(content));
-		}
+    protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
-	}
+        super.method_content(new StringBuffer(), ctx);
+        String projectName = ctx.getValue("projectName").toString();
+        String outputFolder = ctx.getValue("outputFolder").toString();
+        Collection<String> content = PackageHelper.getContent((Structure) element, projectName, outputFolder);
+        if (content.size() > 0) {
 
-	public boolean preCondition(PatternContext ctx) throws Exception {
-		return !(parameter instanceof DataType
-				|| parameter instanceof org.polarsys.capella.core.data.information.Collection);
-	}
+            stringBuffer.append(TEXT_1);
+            stringBuffer.append(TEXT_2);
+            stringBuffer.append(StringUtil.stringListToBulette(content));
+        }
+
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
+    }
+
+    public boolean preCondition(PatternContext ctx) throws Exception {
+        return !(parameter instanceof DataType || parameter instanceof org.polarsys.capella.core.data.information.Collection);
+    }
 }

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/foundations/AbstractExchangeDocGen.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/foundations/AbstractExchangeDocGen.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.2.202001031546
+//Generated with EGF 1.6.3.202110291409
 package org.polarsys.capella.docgen.foundations;
 
 import org.eclipse.egf.common.helper.*;
@@ -13,172 +13,169 @@ import org.polarsys.capella.docgen.util.ExchangesServices;
 import org.polarsys.capella.core.data.cs.PhysicalLink;
 
 public class AbstractExchangeDocGen extends org.polarsys.capella.docgen.foundations.NamedElementDocGen {
-	protected static String nl;
+    protected static String nl;
 
-	public static synchronized AbstractExchangeDocGen create(String lineSeparator) {
-		nl = lineSeparator;
-		AbstractExchangeDocGen result = new AbstractExchangeDocGen();
-		nl = null;
-		return result;
-	}
+    public static synchronized AbstractExchangeDocGen create(String lineSeparator) {
+        nl = lineSeparator;
+        AbstractExchangeDocGen result = new AbstractExchangeDocGen();
+        nl = null;
+        return result;
+    }
 
-	public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
-	protected final String TEXT_1 = "<h2> Source </h2>";
-	protected final String TEXT_2 = NL;
-	protected final String TEXT_3 = NL + "<h2> Target </h2>";
-	protected final String TEXT_4 = NL + "\t<h2> Allocated Function Exchanges </h2>" + NL + "\t";
-	protected final String TEXT_5 = NL + "\t\t<h2> Allocated Exchanges Items </h2>" + NL + "\t\t";
-	protected final String TEXT_6 = NL + "\t<h2> Categories </h2>" + NL + "\t";
-	protected final String TEXT_7 = "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>" + NL
-			+ "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\"" + NL
-			+ "    \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">" + NL
-			+ "<html xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\" lang=\"en\">" + NL + "" + NL + "\t<head>"
-			+ NL + "\t\t<meta name=\"copyright\" content=\"";
-	protected final String TEXT_8 = "\" />" + NL
-			+ "\t\t<meta http-equiv=\"content-type\" content=\"text/html;charset=ISO-8859-1\" />" + NL
-			+ "\t\t<meta http-equiv=\"Content-Style-Type\" content=\"text/css\" />" + NL + "" + NL + "\t\t<title>";
-	protected final String TEXT_9 = "</title>" + NL
-			+ "\t\t<link rel=\"stylesheet\" href=\"../../scripts/jquery-treeview/jquery.treeview.css\" />" + NL
-			+ "  \t\t<script src=\"../../scripts/jquery-treeview/lib/jquery-1.11.1.js\" type=\"text/javascript\"></script>"
-			+ NL
-			+ "  \t\t<script src=\"../../scripts/jquery-treeview/jquery.treeview.js\" type=\"text/javascript\"></script>"
-			+ NL + "\t\t<link rel=\"stylesheet\" type=\"text/css\" href=\"../../css/simpletree.css\" />\t\t" + NL
-			+ "\t\t<link title=\"default\" rel=\"stylesheet\" type=\"text/css\" media=\"screen, projection\" href=\"../../css/content.css\"></link>"
-			+ NL + "\t\t<script type=\"text/javascript\">" + NL
-			+ "\t\t\tif(parent.location.href == self.location.href) {" + NL
-			+ "\t\t\t\twindow.location.href = 'index.html?";
-	protected final String TEXT_10 = "' + '#' + self.location.href.substring(self.location.href.lastIndexOf(\"#\")+1);"
-			+ NL + "\t\t\t}" + NL + "\t\t</script>" + NL + "\t\t" + NL + "\t\t<style>" + NL + "\t\t\tbody {" + NL
-			+ "\t\t\t\tbackground: white;" + NL + "\t\t\t\tfont-family: Arial;" + NL + "\t\t\t}" + NL
-			+ "\t\t\t.treeview {" + NL + "\t\t\t\tbackground-color: white ;" + NL + "\t\t\t}" + NL + "\t" + NL
-			+ "\t\t\t.treeview ul{ /*CSS for Simple Tree Menu*/" + NL + "\t\t\t\tbackground-color: white;" + NL
-			+ "\t\t\t\tfont-size: 12px;" + NL + "\t\t\t}" + NL + "\t" + NL
-			+ "\t\t\t.treeview li{ /*Style for LI elements in general (excludes an LI that contains sub lists)*/" + NL
-			+ "\t\t\t\tbackground-color: white;" + NL + "\t\t\t}" + NL + "\t\t</style>" + NL + "\t\t" + NL + "\t</head>"
-			+ NL + "\t" + NL + "\t<body>";
-	protected final String TEXT_11 = "\t<script type=\"text/javascript\">" + NL + "\t\t$(\"#";
-	protected final String TEXT_12 = "\").treeview({ collapsed: false, animated: \"fast\", unique: false, control: \"#treecontrol\"});"
-			+ NL + "\t\t$(\"#";
-	protected final String TEXT_13 = "\").treeview({ collapsed: false, animated: \"fast\", unique: false, control: \"#treecontrol\"});"
-			+ NL + "\t</script>" + NL + "   </body>" + NL + "</html>";
-	protected final String TEXT_14 = NL;
+    public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
 
-	public AbstractExchangeDocGen() {
-		//Here is the constructor
-		StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_1 = "<h2> Source </h2>";
 
-		// add initialisation of the pattern variables (declaration has been already done).
+    protected final String TEXT_2 = NL;
 
-	}
+    protected final String TEXT_3 = NL + "<h2> Target </h2>";
 
-	public String generate(Object argument) throws Exception {
-		final StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_4 = NL + "\t<h2> Allocated Function Exchanges </h2>" + NL + "\t";
 
-		InternalPatternContext ctx = (InternalPatternContext) argument;
-		Map<String, String> queryCtx = null;
-		IQuery.ParameterDescription paramDesc = null;
-		Node.Container currentNode = ctx.getNode();
+    protected final String TEXT_5 = NL + "\t\t<h2> Allocated Exchanges Items </h2>" + NL + "\t\t";
 
-		if (preCondition(ctx)) {
-			ctx.setNode(new Node.Container(currentNode, getClass()));
-			orchestration(ctx);
-		}
+    protected final String TEXT_6 = NL + "\t<h2> Categories </h2>" + NL + "\t";
 
-		ctx.setNode(currentNode);
-		if (ctx.useReporter()) {
-			ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
-		}
+    protected final String TEXT_7 = "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>" + NL + "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\"" + NL
+            + "    \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">" + NL + "<html xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\" lang=\"en\">" + NL + "" + NL + "\t<head>" + NL
+            + "\t\t<meta name=\"copyright\" content=\"";
 
-		stringBuffer.append(TEXT_14);
-		stringBuffer.append(TEXT_14);
-		return stringBuffer.toString();
-	}
+    protected final String TEXT_8 = "\" />" + NL + "\t\t<meta http-equiv=\"content-type\" content=\"text/html;charset=ISO-8859-1\" />" + NL
+            + "\t\t<meta http-equiv=\"Content-Style-Type\" content=\"text/css\" />" + NL + "" + NL + "\t\t<title>";
 
-	public String orchestration(PatternContext ctx) throws Exception {
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
+    protected final String TEXT_9 = "</title>" + NL + "\t\t<link rel=\"stylesheet\" href=\"../../scripts/jquery-treeview/jquery.treeview.css\" />" + NL
+            + "  \t\t<script src=\"../../scripts/jquery-treeview/lib/jquery-1.11.1.js\" type=\"text/javascript\"></script>" + NL
+            + "  \t\t<script src=\"../../scripts/jquery-treeview/jquery.treeview.js\" type=\"text/javascript\"></script>" + NL
+            + "\t\t<link rel=\"stylesheet\" type=\"text/css\" href=\"../../css/simpletree.css\" />\t\t" + NL
+            + "\t\t<link title=\"default\" rel=\"stylesheet\" type=\"text/css\" media=\"screen, projection\" href=\"../../css/content.css\"></link>" + NL + "\t\t<script type=\"text/javascript\">" + NL
+            + "\t\t\tif(parent.location.href == self.location.href) {" + NL + "\t\t\t\twindow.location.href = 'index.html?";
 
-		super.orchestration(new SuperOrchestrationContext(ictx));
+    protected final String TEXT_10 = "' + '#' + self.location.href.substring(self.location.href.lastIndexOf(\"#\")+1);" + NL + "\t\t\t}" + NL + "\t\t</script>" + NL + "\t\t" + NL + "\t\t<style>" + NL
+            + "\t\t\tbody {" + NL + "\t\t\t\tbackground: white;" + NL + "\t\t\t\tfont-family: Arial;" + NL + "\t\t\t}" + NL + "\t\t\t.treeview {" + NL + "\t\t\t\tbackground-color: white ;" + NL
+            + "\t\t\t}" + NL + "\t" + NL + "\t\t\t.treeview ul{ /*CSS for Simple Tree Menu*/" + NL + "\t\t\t\tbackground-color: white;" + NL + "\t\t\t\tfont-size: 12px;" + NL + "\t\t\t}" + NL + "\t"
+            + NL + "\t\t\t.treeview li{ /*Style for LI elements in general (excludes an LI that contains sub lists)*/" + NL + "\t\t\t\tbackground-color: white;" + NL + "\t\t\t}" + NL + "\t\t</style>"
+            + NL + "\t\t" + NL + "\t</head>" + NL + "\t" + NL + "\t<body>";
 
-		return null;
-	}
+    protected final String TEXT_11 = "\t<script type=\"text/javascript\">" + NL + "\t\t$(\"#";
 
-	public Map<String, Object> getParameters() {
-		final Map<String, Object> parameters = new HashMap<String, Object>();
-		return parameters;
-	}
+    protected final String TEXT_12 = "\").treeview({ collapsed: false, animated: \"fast\", unique: false, control: \"#treecontrol\"});" + NL + "\t\t$(\"#";
 
-	protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+    protected final String TEXT_13 = "\").treeview({ collapsed: false, animated: \"fast\", unique: false, control: \"#treecontrol\"});" + NL + "\t</script>" + NL + "   </body>" + NL + "</html>";
 
-		super.method_content(new StringBuffer(), ctx);
-		String projectName = ctx.getValue("projectName").toString();
-		String outputFolder = ctx.getValue("outputFolder").toString();
+    public AbstractExchangeDocGen() {
+        //Here is the constructor
+        StringBuffer stringBuffer = new StringBuffer();
 
-		String sourceContent = ExchangesServices.getSource(element, projectName, outputFolder);
-		String targetContent = ExchangesServices.getTarget(element, projectName, outputFolder);
+        // add initialisation of the pattern variables (declaration has been already done).
 
-		if (!sourceContent.equals("")) {
-			stringBuffer.append(TEXT_1);
-			stringBuffer.append(TEXT_2);
-			stringBuffer.append(sourceContent);
-		}
-		if (!targetContent.equals("")) {
-			stringBuffer.append(TEXT_3);
-			stringBuffer.append(TEXT_2);
-			stringBuffer.append(targetContent);
-		}
-		stringBuffer.append(TEXT_2);
-		if (ExchangesServices.genAllocatedFunctionExchanges(element)) {
-			if (element instanceof ComponentExchange) {
-				stringBuffer.append(TEXT_4);
-				stringBuffer.append(ExchangesServices.getAllocatedFunctionExchanges((ComponentExchange) element,
-						projectName, outputFolder));
-			}
-		}
-		stringBuffer.append(TEXT_2);
-		if (ExchangesServices.genAllocatedComponentExchanges(element)) {
-			if (element instanceof PhysicalLink) {
-				stringBuffer.append(TEXT_4);
-				stringBuffer.append(ExchangesServices.getAllocatedComponentExchanges((PhysicalLink) element,
-						projectName, outputFolder));
-			}
-		}
-		stringBuffer.append(TEXT_2);
-		if (ExchangesServices.genAllocatedExchangeItems(element)) {
-			if (element instanceof ComponentExchange || element instanceof FunctionalExchange) {
-				stringBuffer.append(TEXT_5);
-				stringBuffer.append(ExchangesServices.getAllocatedExchangeItems(element, projectName, outputFolder));
-			}
-		}
-		stringBuffer.append(TEXT_2);
-		if (ExchangesServices.genCategories(element)) {
-			stringBuffer.append(TEXT_6);
-			stringBuffer.append(ExchangesServices.getCategories(element, projectName, outputFolder));
-		}
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
-	}
+    }
 
-	protected void method_docHeader(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+    public String generate(Object argument) throws Exception {
+        final StringBuffer stringBuffer = new StringBuffer();
 
-		stringBuffer.append(TEXT_7);
-		stringBuffer.append(copyright);
-		stringBuffer.append(TEXT_8);
-		stringBuffer.append(title);
-		stringBuffer.append(TEXT_9);
-		stringBuffer.append(fileName);
-		stringBuffer.append(TEXT_10);
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "docHeader", stringBuffer.toString());
-	}
+        InternalPatternContext ctx = (InternalPatternContext) argument;
+        Map<String, String> queryCtx = null;
+        IQuery.ParameterDescription paramDesc = null;
+        Node.Container currentNode = ctx.getNode();
 
-	protected void method_docFooter(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+        if (preCondition(ctx)) {
+            ctx.setNode(new Node.Container(currentNode, getClass()));
+            orchestration(ctx);
+        }
 
-		stringBuffer.append(TEXT_11);
-		stringBuffer.append(ExchangesServices.SOURCE_PORT_TREE_ID);
-		stringBuffer.append(TEXT_12);
-		stringBuffer.append(ExchangesServices.TARGET_PORT_TREE_ID);
-		stringBuffer.append(TEXT_13);
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "docFooter", stringBuffer.toString());
-	}
+        ctx.setNode(currentNode);
+        if (ctx.useReporter()) {
+            ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
+        }
+
+        stringBuffer.append(TEXT_2);
+        stringBuffer.append(TEXT_2);
+        return stringBuffer.toString();
+    }
+
+    public String orchestration(PatternContext ctx) throws Exception {
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+
+        super.orchestration(new SuperOrchestrationContext(ictx));
+
+        return null;
+    }
+
+    public Map<String, Object> getParameters() {
+        final Map<String, Object> parameters = new HashMap<String, Object>();
+        return parameters;
+    }
+
+    protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+
+        super.method_content(new StringBuffer(), ctx);
+        String projectName = ctx.getValue("projectName").toString();
+        String outputFolder = ctx.getValue("outputFolder").toString();
+
+        String sourceContent = ExchangesServices.getSource(element, projectName, outputFolder);
+        String targetContent = ExchangesServices.getTarget(element, projectName, outputFolder);
+
+        if (!sourceContent.equals("")) {
+            stringBuffer.append(TEXT_1);
+            stringBuffer.append(TEXT_2);
+            stringBuffer.append(sourceContent);
+        }
+        if (!targetContent.equals("")) {
+            stringBuffer.append(TEXT_3);
+            stringBuffer.append(TEXT_2);
+            stringBuffer.append(targetContent);
+        }
+        stringBuffer.append(TEXT_2);
+        if (ExchangesServices.genAllocatedFunctionExchanges(element)) {
+            if (element instanceof ComponentExchange) {
+                stringBuffer.append(TEXT_4);
+                stringBuffer.append(ExchangesServices.getAllocatedFunctionExchanges((ComponentExchange) element, projectName, outputFolder));
+            }
+        }
+        stringBuffer.append(TEXT_2);
+        if (ExchangesServices.genAllocatedComponentExchanges(element)) {
+            if (element instanceof PhysicalLink) {
+                stringBuffer.append(TEXT_4);
+                stringBuffer.append(ExchangesServices.getAllocatedComponentExchanges((PhysicalLink) element, projectName, outputFolder));
+            }
+        }
+        stringBuffer.append(TEXT_2);
+        if (ExchangesServices.genAllocatedExchangeItems(element)) {
+            if (element instanceof ComponentExchange || element instanceof FunctionalExchange) {
+                stringBuffer.append(TEXT_5);
+                stringBuffer.append(ExchangesServices.getAllocatedExchangeItems(element, projectName, outputFolder));
+            }
+        }
+        stringBuffer.append(TEXT_2);
+        if (ExchangesServices.genCategories(element)) {
+            stringBuffer.append(TEXT_6);
+            stringBuffer.append(ExchangesServices.getCategories(element, projectName, outputFolder));
+        }
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
+    }
+
+    protected void method_docHeader(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+
+        stringBuffer.append(TEXT_7);
+        stringBuffer.append(copyright);
+        stringBuffer.append(TEXT_8);
+        stringBuffer.append(title);
+        stringBuffer.append(TEXT_9);
+        stringBuffer.append(fileName);
+        stringBuffer.append(TEXT_10);
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "docHeader", stringBuffer.toString());
+    }
+
+    protected void method_docFooter(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+
+        stringBuffer.append(TEXT_11);
+        stringBuffer.append(ExchangesServices.SOURCE_PORT_TREE_ID);
+        stringBuffer.append(TEXT_12);
+        stringBuffer.append(ExchangesServices.TARGET_PORT_TREE_ID);
+        stringBuffer.append(TEXT_13);
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "docFooter", stringBuffer.toString());
+    }
 }

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/foundations/AllConstraintsDocGen.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/foundations/AllConstraintsDocGen.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.2.202001031546
+//Generated with EGF 1.6.3.202110291409
 package org.polarsys.capella.docgen.foundations;
 
 import java.util.*;
@@ -9,142 +9,142 @@ import org.polarsys.capella.docgen.util.ConstraintsService;
 import org.polarsys.capella.common.data.modellingcore.AbstractConstraint;
 
 public class AllConstraintsDocGen {
-	protected static String nl;
+    protected static String nl;
 
-	public static synchronized AllConstraintsDocGen create(String lineSeparator) {
-		nl = lineSeparator;
-		AllConstraintsDocGen result = new AllConstraintsDocGen();
-		nl = null;
-		return result;
-	}
+    public static synchronized AllConstraintsDocGen create(String lineSeparator) {
+        nl = lineSeparator;
+        AllConstraintsDocGen result = new AllConstraintsDocGen();
+        nl = null;
+        return result;
+    }
 
-	public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
-	protected final String TEXT_1 = "";
-	protected final String TEXT_2 = NL;
+    public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
 
-	public AllConstraintsDocGen() {
-		//Here is the constructor
-		StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_1 = "";
 
-		// add initialisation of the pattern variables (declaration has been already done).
+    protected final String TEXT_2 = NL;
 
-	}
+    public AllConstraintsDocGen() {
+        //Here is the constructor
+        StringBuffer stringBuffer = new StringBuffer();
 
-	public String generate(Object argument) throws Exception {
-		final StringBuffer stringBuffer = new StringBuffer();
+        // add initialisation of the pattern variables (declaration has been already done).
 
-		InternalPatternContext ctx = (InternalPatternContext) argument;
-		Map<String, String> queryCtx = null;
-		IQuery.ParameterDescription paramDesc = null;
-		Node.Container currentNode = ctx.getNode();
+    }
 
-		List<Object> parameterList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
+    public String generate(Object argument) throws Exception {
+        final StringBuffer stringBuffer = new StringBuffer();
 
-		for (Object parameterParameter : parameterList) {
+        InternalPatternContext ctx = (InternalPatternContext) argument;
+        Map<String, String> queryCtx = null;
+        IQuery.ParameterDescription paramDesc = null;
+        Node.Container currentNode = ctx.getNode();
 
-			this.parameter = (org.polarsys.capella.core.data.capellacore.CapellaElement) parameterParameter;
+        List<Object> parameterList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
 
-			if (preCondition(ctx)) {
-				ctx.setNode(new Node.Container(currentNode, getClass()));
-				orchestration(ctx);
-			}
+        for (Object parameterParameter : parameterList) {
 
-		}
-		ctx.setNode(currentNode);
-		if (ctx.useReporter()) {
-			ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
-		}
+            this.parameter = (org.polarsys.capella.core.data.capellacore.CapellaElement) parameterParameter;
 
-		stringBuffer.append(TEXT_2);
-		stringBuffer.append(TEXT_2);
-		return stringBuffer.toString();
-	}
+            if (preCondition(ctx)) {
+                ctx.setNode(new Node.Container(currentNode, getClass()));
+                orchestration(ctx);
+            }
 
-	public String orchestration(PatternContext ctx) throws Exception {
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
+        }
+        ctx.setNode(currentNode);
+        if (ctx.useReporter()) {
+            ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
+        }
 
-		method_genConstraints(new StringBuffer(), ictx);
+        stringBuffer.append(TEXT_2);
+        stringBuffer.append(TEXT_2);
+        return stringBuffer.toString();
+    }
 
-		if (ictx.useReporter()) {
-			Map<String, Object> parameterValues = new HashMap<String, Object>();
-			parameterValues.put("parameter", this.parameter);
-			String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
-			String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
-			ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
-		}
-		return null;
-	}
+    public String orchestration(PatternContext ctx) throws Exception {
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
 
-	protected org.polarsys.capella.core.data.capellacore.CapellaElement parameter = null;
+        method_genConstraints(new StringBuffer(), ictx);
 
-	public void set_parameter(org.polarsys.capella.core.data.capellacore.CapellaElement object) {
-		this.parameter = object;
-	}
+        if (ictx.useReporter()) {
+            Map<String, Object> parameterValues = new HashMap<String, Object>();
+            parameterValues.put("parameter", this.parameter);
+            String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
+            String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
+            ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
+        }
+        return null;
+    }
 
-	public Map<String, Object> getParameters() {
-		final Map<String, Object> parameters = new HashMap<String, Object>();
-		parameters.put("parameter", this.parameter);
-		return parameters;
-	}
+    protected org.polarsys.capella.core.data.capellacore.CapellaElement parameter = null;
 
-	protected void method_genConstraints(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+    public void set_parameter(org.polarsys.capella.core.data.capellacore.CapellaElement object) {
+        this.parameter = object;
+    }
 
-		List<AbstractConstraint> ownedConstraintsList = parameter.getOwnedConstraints();
-		if (!ownedConstraintsList.isEmpty()) {
-			String title = "Owned Constraints";
+    public Map<String, Object> getParameters() {
+        final Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("parameter", this.parameter);
+        return parameters;
+    }
 
-			stringBuffer.append(TEXT_1);
-			{
-				//<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#LogicalName=org.polarsys.capella.docgen.foundations.ConstraintsDocGen" args="parameter:parameter, ownedConstraintsList:constraintsList, title:constraintSectionTitle"%>
+    protected void method_genConstraints(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-				InternalPatternContext ictx = (InternalPatternContext) ctx;
-				new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
-				stringBuffer.setLength(0);
+        List<AbstractConstraint> ownedConstraintsList = parameter.getOwnedConstraints();
+        if (!ownedConstraintsList.isEmpty()) {
+            String title = "Owned Constraints";
 
-				final Map<String, Object> callParameters = new HashMap<String, Object>();
-				callParameters.put("parameter", parameter);
-				callParameters.put("constraintsList", ownedConstraintsList);
-				callParameters.put("constraintSectionTitle", title);
-				CallHelper.executeWithParameterInjection(
-						"platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#_F9HPoVcEEeWXKstRBeKifA",
-						new ExecutionContext((InternalPatternContext) ctx), callParameters);
-				stringBuffer.setLength(0);
-			}
+            stringBuffer.append(TEXT_1);
+            {
+                //<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#LogicalName=org.polarsys.capella.docgen.foundations.ConstraintsDocGen" args="parameter:parameter, ownedConstraintsList:constraintsList, title:constraintSectionTitle"%>
 
-		}
+                InternalPatternContext ictx = (InternalPatternContext) ctx;
+                new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
+                stringBuffer.setLength(0);
 
-		stringBuffer.append(TEXT_2);
+                final Map<String, Object> callParameters = new HashMap<String, Object>();
+                callParameters.put("parameter", parameter);
+                callParameters.put("constraintsList", ownedConstraintsList);
+                callParameters.put("constraintSectionTitle", title);
+                CallHelper.executeWithParameterInjection("platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#_F9HPoVcEEeWXKstRBeKifA",
+                        new ExecutionContext((InternalPatternContext) ctx), callParameters);
+                stringBuffer.setLength(0);
+            }
 
-		List<AbstractConstraint> appledConstraintsList = ConstraintsService.getAppliedAndNotOwnedConstraints(parameter);
-		if (!appledConstraintsList.isEmpty()) {
-			String title = "Applied Constraints";
+        }
 
-			stringBuffer.append(TEXT_2);
-			{
-				//<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#LogicalName=org.polarsys.capella.docgen.foundations.ConstraintsDocGen" args="parameter:parameter, appledConstraintsList:constraintsList, title:constraintSectionTitle"%>
+        stringBuffer.append(TEXT_2);
 
-				InternalPatternContext ictx = (InternalPatternContext) ctx;
-				new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
-				stringBuffer.setLength(0);
+        List<AbstractConstraint> appledConstraintsList = ConstraintsService.getAppliedAndNotOwnedConstraints(parameter);
+        if (!appledConstraintsList.isEmpty()) {
+            String title = "Applied Constraints";
 
-				final Map<String, Object> callParameters = new HashMap<String, Object>();
-				callParameters.put("parameter", parameter);
-				callParameters.put("constraintsList", appledConstraintsList);
-				callParameters.put("constraintSectionTitle", title);
-				CallHelper.executeWithParameterInjection(
-						"platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#_F9HPoVcEEeWXKstRBeKifA",
-						new ExecutionContext((InternalPatternContext) ctx), callParameters);
-				stringBuffer.setLength(0);
-			}
+            stringBuffer.append(TEXT_2);
+            {
+                //<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#LogicalName=org.polarsys.capella.docgen.foundations.ConstraintsDocGen" args="parameter:parameter, appledConstraintsList:constraintsList, title:constraintSectionTitle"%>
 
-		}
+                InternalPatternContext ictx = (InternalPatternContext) ctx;
+                new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
+                stringBuffer.setLength(0);
 
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "genConstraints", stringBuffer.toString());
-	}
+                final Map<String, Object> callParameters = new HashMap<String, Object>();
+                callParameters.put("parameter", parameter);
+                callParameters.put("constraintsList", appledConstraintsList);
+                callParameters.put("constraintSectionTitle", title);
+                CallHelper.executeWithParameterInjection("platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#_F9HPoVcEEeWXKstRBeKifA",
+                        new ExecutionContext((InternalPatternContext) ctx), callParameters);
+                stringBuffer.setLength(0);
+            }
 
-	public boolean preCondition(PatternContext ctx) throws Exception {
-		return true;
-	}
+        }
+
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "genConstraints", stringBuffer.toString());
+    }
+
+    public boolean preCondition(PatternContext ctx) throws Exception {
+        return true;
+    }
 }

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/foundations/CapellaElementContentDocGen.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/foundations/CapellaElementContentDocGen.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.2.202001031546
+//Generated with EGF 1.6.3.202110291409
 package org.polarsys.capella.docgen.foundations;
 
 import java.util.*;
@@ -13,232 +13,237 @@ import org.polarsys.capella.core.data.requirement.Requirement;
 import org.polarsys.capella.docgen.util.TreeServices;
 
 public class CapellaElementContentDocGen {
-	protected static String nl;
+    protected static String nl;
 
-	public static synchronized CapellaElementContentDocGen create(String lineSeparator) {
-		nl = lineSeparator;
-		CapellaElementContentDocGen result = new CapellaElementContentDocGen();
-		nl = null;
-		return result;
-	}
+    public static synchronized CapellaElementContentDocGen create(String lineSeparator) {
+        nl = lineSeparator;
+        CapellaElementContentDocGen result = new CapellaElementContentDocGen();
+        nl = null;
+        return result;
+    }
 
-	public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
-	protected final String TEXT_1 = "<img src=\"../icon/";
-	protected final String TEXT_2 = "\" alt=\"";
-	protected final String TEXT_3 = "\" style=\"float:left; margin-right:10px\" /><h1>";
-	protected final String TEXT_4 = "</h1>" + NL
-			+ "<p style=\"margin-top:3px; margin-bottom:3px\"><span class=\"elementMetaClass\">";
-	protected final String TEXT_5 = "</span></p>" + NL + "<em class=\"elementPath\">";
-	protected final String TEXT_6 = "</em>";
-	protected final String TEXT_7 = NL;
-	protected final String TEXT_8 = NL + NL + NL + NL;
-	protected final String TEXT_9 = NL + "\t<h2>" + NL + "\tRequirements" + NL + "\t</h2>" + NL + "\t" + NL + "\t";
-	protected final String TEXT_10 = NL + "\t<br>" + NL + "\t" + NL + "\t";
-	protected final String TEXT_11 = NL + "\t" + NL + "\t";
-	protected final String TEXT_12 = NL + "\t";
+    public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
 
-	public CapellaElementContentDocGen() {
-		//Here is the constructor
-		StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_1 = "<img src=\"../icon/";
 
-		// add initialisation of the pattern variables (declaration has been already done).
+    protected final String TEXT_2 = "\" alt=\"";
 
-	}
+    protected final String TEXT_3 = "\" style=\"float:left; margin-right:10px\" /><h1>";
 
-	public String generate(Object argument) throws Exception {
-		final StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_4 = "</h1>" + NL + "<p style=\"margin-top:3px; margin-bottom:3px\"><span class=\"elementMetaClass\">";
 
-		InternalPatternContext ctx = (InternalPatternContext) argument;
-		Map<String, String> queryCtx = null;
-		IQuery.ParameterDescription paramDesc = null;
-		Node.Container currentNode = ctx.getNode();
+    protected final String TEXT_5 = "</span></p>" + NL + "<em class=\"elementPath\">";
 
-		List<Object> elementList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
-		List<Object> documentTitleList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
+    protected final String TEXT_6 = "</em>";
 
-		for (Object elementParameter : elementList) {
-			for (Object documentTitleParameter : documentTitleList) {
+    protected final String TEXT_7 = NL;
 
-				this.element = (org.polarsys.capella.core.data.capellacore.CapellaElement) elementParameter;
-				this.documentTitle = (java.lang.String) documentTitleParameter;
+    protected final String TEXT_8 = NL + NL + NL + NL;
 
-				if (preCondition(ctx)) {
-					ctx.setNode(new Node.Container(currentNode, getClass()));
-					orchestration(ctx);
-				}
+    protected final String TEXT_9 = NL + "\t<h2>" + NL + "\tRequirements" + NL + "\t</h2>" + NL + "\t" + NL + "\t";
 
-			}
-		}
-		ctx.setNode(currentNode);
-		if (ctx.useReporter()) {
-			ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
-		}
+    protected final String TEXT_10 = NL + "\t<br>" + NL + "\t" + NL + "\t";
 
-		stringBuffer.append(TEXT_7);
-		stringBuffer.append(TEXT_7);
-		return stringBuffer.toString();
-	}
+    protected final String TEXT_11 = NL + "\t" + NL + "\t";
 
-	public String orchestration(PatternContext ctx) throws Exception {
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
+    protected final String TEXT_12 = NL + "\t";
 
-		method_body(new StringBuffer(), ictx);
+    public CapellaElementContentDocGen() {
+        //Here is the constructor
+        StringBuffer stringBuffer = new StringBuffer();
 
-		method_postBody(new StringBuffer(), ictx);
+        // add initialisation of the pattern variables (declaration has been already done).
 
-		if (ictx.useReporter()) {
-			Map<String, Object> parameterValues = new HashMap<String, Object>();
-			parameterValues.put("element", this.element);
-			parameterValues.put("documentTitle", this.documentTitle);
-			String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
-			String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
-			ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
-		}
-		return null;
-	}
+    }
 
-	protected org.polarsys.capella.core.data.capellacore.CapellaElement element = null;
+    public String generate(Object argument) throws Exception {
+        final StringBuffer stringBuffer = new StringBuffer();
 
-	public void set_element(org.polarsys.capella.core.data.capellacore.CapellaElement object) {
-		this.element = object;
-	}
+        InternalPatternContext ctx = (InternalPatternContext) argument;
+        Map<String, String> queryCtx = null;
+        IQuery.ParameterDescription paramDesc = null;
+        Node.Container currentNode = ctx.getNode();
 
-	protected java.lang.String documentTitle = null;
+        List<Object> elementList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
+        List<Object> documentTitleList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
 
-	public void set_documentTitle(java.lang.String object) {
-		this.documentTitle = object;
-	}
+        for (Object elementParameter : elementList) {
+            for (Object documentTitleParameter : documentTitleList) {
 
-	public Map<String, Object> getParameters() {
-		final Map<String, Object> parameters = new HashMap<String, Object>();
-		parameters.put("element", this.element);
-		parameters.put("documentTitle", this.documentTitle);
-		return parameters;
-	}
+                this.element = (org.polarsys.capella.core.data.capellacore.CapellaElement) elementParameter;
+                this.documentTitle = (java.lang.String) documentTitleParameter;
 
-	protected void method_body(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+                if (preCondition(ctx)) {
+                    ctx.setNode(new Node.Container(currentNode, getClass()));
+                    orchestration(ctx);
+                }
 
-		String projectName = ctx.getValue("projectName").toString();
-		String outputFolder = ctx.getValue("outputFolder").toString();
-		String elementPath = CapellaServices.getElementPath(element);
-		String elementName = CapellaServices.getHyperlinkFromElement(element);
-		String elementType = EscapeChars.forHTML(element.eClass().getName());
-		String logo = ImageHelper.getTypePng(element, projectName, outputFolder);
+            }
+        }
+        ctx.setNode(currentNode);
+        if (ctx.useReporter()) {
+            ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
+        }
 
-		stringBuffer.append(TEXT_1);
-		stringBuffer.append(logo);
-		stringBuffer.append(TEXT_2);
-		stringBuffer.append(elementType);
-		stringBuffer.append(TEXT_3);
-		stringBuffer.append(documentTitle);
-		stringBuffer.append(TEXT_4);
-		stringBuffer.append(elementType);
-		stringBuffer.append(TEXT_5);
-		stringBuffer.append(elementPath);
-		stringBuffer.append(TEXT_6);
-		// Summary and description generation
-		stringBuffer.append(TEXT_7);
-		{
-			//<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#LogicalName=org.polarsys.capella.docgen.foundations.SummaryAndDescriptionGeneration" args="element:element"%>
+        stringBuffer.append(TEXT_7);
+        stringBuffer.append(TEXT_7);
+        return stringBuffer.toString();
+    }
 
-			InternalPatternContext ictx = (InternalPatternContext) ctx;
-			new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
-			stringBuffer.setLength(0);
+    public String orchestration(PatternContext ctx) throws Exception {
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
 
-			final Map<String, Object> callParameters = new HashMap<String, Object>();
-			callParameters.put("element", element);
-			CallHelper.executeWithParameterInjection(
-					"platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#_fiM9sOZdEd-YVt45ZEg4_w",
-					new ExecutionContext((InternalPatternContext) ctx), callParameters);
-			stringBuffer.setLength(0);
-		}
+        method_body(new StringBuffer(), ictx);
 
-		stringBuffer.append(TEXT_7);
-		// Generating status and review information 
-		stringBuffer.append(TEXT_7);
-		{
-			//<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#LogicalName=org.polarsys.capella.docgen.foundations.StatusAndReviewGeneration" args="element:element"%>
+        method_postBody(new StringBuffer(), ictx);
 
-			InternalPatternContext ictx = (InternalPatternContext) ctx;
-			new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
-			stringBuffer.setLength(0);
+        if (ictx.useReporter()) {
+            Map<String, Object> parameterValues = new HashMap<String, Object>();
+            parameterValues.put("element", this.element);
+            parameterValues.put("documentTitle", this.documentTitle);
+            String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
+            String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
+            ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
+        }
+        return null;
+    }
 
-			final Map<String, Object> callParameters = new HashMap<String, Object>();
-			callParameters.put("element", element);
-			CallHelper.executeWithParameterInjection(
-					"platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#_2sAHwHWMEemiHtSfRhpXIQ",
-					new ExecutionContext((InternalPatternContext) ctx), callParameters);
-			stringBuffer.setLength(0);
-		}
+    protected org.polarsys.capella.core.data.capellacore.CapellaElement element = null;
 
-		stringBuffer.append(TEXT_8);
+    public void set_element(org.polarsys.capella.core.data.capellacore.CapellaElement object) {
+        this.element = object;
+    }
 
-		org.polarsys.kitalpha.doc.gen.business.core.extension.intf.DocGenExtensionFactory.newDocGenExtensionEngine()
-				.apply("CAPELLA_REQUIREMENTS_EXTENSION", ctx, getParameters(), stringBuffer);
+    protected java.lang.String documentTitle = null;
 
-		org.polarsys.kitalpha.doc.gen.business.core.extension.intf.DocGenExtensionFactory.newDocGenExtensionEngine()
-				.apply("CAPELLA_ELEMENT_EXTENSION", ctx, getParameters(), stringBuffer);
+    public void set_documentTitle(java.lang.String object) {
+        this.documentTitle = object;
+    }
 
-		stringBuffer.append(TEXT_7);
-		// requirements
+    public Map<String, Object> getParameters() {
+        final Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("element", this.element);
+        parameters.put("documentTitle", this.documentTitle);
+        return parameters;
+    }
 
-		EList<Requirement> appliedReq = element.getAppliedRequirements();
-		if (appliedReq.size() > 0) {
+    protected void method_body(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-			stringBuffer.append(TEXT_9);
-			{
-				//<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#LogicalName=org.polarsys.kitalpha.doc.gen.business.core.doccontent.treeview.TreeViewControlHeader" args="element:parameter, TreeServices.REQUIREMENT_TREE_ID:treeID"%>
+        String projectName = ctx.getValue("projectName").toString();
+        String outputFolder = ctx.getValue("outputFolder").toString();
+        String elementPath = CapellaServices.getElementPath(element);
+        String elementName = CapellaServices.getHyperlinkFromElement(element);
+        String elementType = EscapeChars.forHTML(element.eClass().getName());
+        String logo = ImageHelper.getTypePng(element, projectName, outputFolder);
 
-				InternalPatternContext ictx = (InternalPatternContext) ctx;
-				new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
-				stringBuffer.setLength(0);
+        stringBuffer.append(TEXT_1);
+        stringBuffer.append(logo);
+        stringBuffer.append(TEXT_2);
+        stringBuffer.append(elementType);
+        stringBuffer.append(TEXT_3);
+        stringBuffer.append(documentTitle);
+        stringBuffer.append(TEXT_4);
+        stringBuffer.append(elementType);
+        stringBuffer.append(TEXT_5);
+        stringBuffer.append(elementPath);
+        stringBuffer.append(TEXT_6);
+        // Summary and description generation
+        stringBuffer.append(TEXT_7);
+        {
+            //<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#LogicalName=org.polarsys.capella.docgen.foundations.SummaryAndDescriptionGeneration" args="element:element"%>
 
-				final Map<String, Object> callParameters = new HashMap<String, Object>();
-				callParameters.put("parameter", element);
-				callParameters.put("treeID", TreeServices.REQUIREMENT_TREE_ID);
-				CallHelper.executeWithParameterInjection(
-						"platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#_V6ybEJ52EemYav3Xat9ApA",
-						new ExecutionContext((InternalPatternContext) ctx), callParameters);
-				stringBuffer.setLength(0);
-			}
+            InternalPatternContext ictx = (InternalPatternContext) ctx;
+            new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
+            stringBuffer.setLength(0);
 
-			stringBuffer.append(TEXT_10);
-			stringBuffer.append(TreeServices.getRequirementsTree(appliedReq, projectName, outputFolder));
-			stringBuffer.append(TEXT_11);
-			{
-				//<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#LogicalName=org.polarsys.kitalpha.doc.gen.business.core.doccontent.treeview.TreeViewControlFooter" args="element:parameter, TreeServices.REQUIREMENT_TREE_ID:treeID, true:collapsed"%>
+            final Map<String, Object> callParameters = new HashMap<String, Object>();
+            callParameters.put("element", element);
+            CallHelper.executeWithParameterInjection("platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#_fiM9sOZdEd-YVt45ZEg4_w",
+                    new ExecutionContext((InternalPatternContext) ctx), callParameters);
+            stringBuffer.setLength(0);
+        }
 
-				InternalPatternContext ictx = (InternalPatternContext) ctx;
-				new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
-				stringBuffer.setLength(0);
+        stringBuffer.append(TEXT_7);
+        // Generating status and review information 
+        stringBuffer.append(TEXT_7);
+        {
+            //<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#LogicalName=org.polarsys.capella.docgen.foundations.StatusAndReviewGeneration" args="element:element"%>
 
-				final Map<String, Object> callParameters = new HashMap<String, Object>();
-				callParameters.put("parameter", element);
-				callParameters.put("treeID", TreeServices.REQUIREMENT_TREE_ID);
-				callParameters.put("collapsed", true);
-				CallHelper.executeWithParameterInjection(
-						"platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#_-tPnEJ8dEemYav3Xat9ApA",
-						new ExecutionContext((InternalPatternContext) ctx), callParameters);
-				stringBuffer.setLength(0);
-			}
+            InternalPatternContext ictx = (InternalPatternContext) ctx;
+            new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
+            stringBuffer.setLength(0);
 
-			stringBuffer.append(TEXT_12);
+            final Map<String, Object> callParameters = new HashMap<String, Object>();
+            callParameters.put("element", element);
+            CallHelper.executeWithParameterInjection("platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#_2sAHwHWMEemiHtSfRhpXIQ",
+                    new ExecutionContext((InternalPatternContext) ctx), callParameters);
+            stringBuffer.setLength(0);
+        }
 
-		}
+        stringBuffer.append(TEXT_8);
 
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "body", stringBuffer.toString());
-	}
+        org.polarsys.kitalpha.doc.gen.business.core.extension.intf.DocGenExtensionFactory.newDocGenExtensionEngine().apply("CAPELLA_REQUIREMENTS_EXTENSION", ctx, getParameters(), stringBuffer);
 
-	protected void method_postBody(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+        org.polarsys.kitalpha.doc.gen.business.core.extension.intf.DocGenExtensionFactory.newDocGenExtensionEngine().apply("CAPELLA_ELEMENT_EXTENSION", ctx, getParameters(), stringBuffer);
 
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "postBody", stringBuffer.toString());
-	}
+        stringBuffer.append(TEXT_7);
+        // requirements
 
-	public boolean preCondition(PatternContext ctx) throws Exception {
-		return true;
-	}
+        EList<Requirement> appliedReq = element.getAppliedRequirements();
+        if (appliedReq.size() > 0) {
+
+            stringBuffer.append(TEXT_9);
+            {
+                //<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#LogicalName=org.polarsys.kitalpha.doc.gen.business.core.doccontent.treeview.TreeViewControlHeader" args="element:parameter, TreeServices.REQUIREMENT_TREE_ID:treeID"%>
+
+                InternalPatternContext ictx = (InternalPatternContext) ctx;
+                new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
+                stringBuffer.setLength(0);
+
+                final Map<String, Object> callParameters = new HashMap<String, Object>();
+                callParameters.put("parameter", element);
+                callParameters.put("treeID", TreeServices.REQUIREMENT_TREE_ID);
+                CallHelper.executeWithParameterInjection("platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#_V6ybEJ52EemYav3Xat9ApA",
+                        new ExecutionContext((InternalPatternContext) ctx), callParameters);
+                stringBuffer.setLength(0);
+            }
+
+            stringBuffer.append(TEXT_10);
+            stringBuffer.append(TreeServices.getRequirementsTree(appliedReq, projectName, outputFolder));
+            stringBuffer.append(TEXT_11);
+            {
+                //<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#LogicalName=org.polarsys.kitalpha.doc.gen.business.core.doccontent.treeview.TreeViewControlFooter" args="element:parameter, TreeServices.REQUIREMENT_TREE_ID:treeID, true:collapsed"%>
+
+                InternalPatternContext ictx = (InternalPatternContext) ctx;
+                new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
+                stringBuffer.setLength(0);
+
+                final Map<String, Object> callParameters = new HashMap<String, Object>();
+                callParameters.put("parameter", element);
+                callParameters.put("treeID", TreeServices.REQUIREMENT_TREE_ID);
+                callParameters.put("collapsed", true);
+                CallHelper.executeWithParameterInjection("platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#_-tPnEJ8dEemYav3Xat9ApA",
+                        new ExecutionContext((InternalPatternContext) ctx), callParameters);
+                stringBuffer.setLength(0);
+            }
+
+            stringBuffer.append(TEXT_12);
+
+        }
+
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "body", stringBuffer.toString());
+    }
+
+    protected void method_postBody(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "postBody", stringBuffer.toString());
+    }
+
+    public boolean preCondition(PatternContext ctx) throws Exception {
+        return true;
+    }
 }

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/foundations/CapellaElementDocGen.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/foundations/CapellaElementDocGen.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.2.202001031546
+//Generated with EGF 1.6.3.202110291409
 package org.polarsys.capella.docgen.foundations;
 
 import org.eclipse.egf.common.helper.*;
@@ -14,214 +14,204 @@ import org.polarsys.capella.core.data.cs.BlockArchitecture;
 import org.polarsys.capella.docgen.diagram.CapellaHelper;
 
 public class CapellaElementDocGen extends org.polarsys.kitalpha.doc.gen.business.core.doccontent.ElementDocContent {
-	protected static String nl;
+    protected static String nl;
 
-	public static synchronized CapellaElementDocGen create(String lineSeparator) {
-		nl = lineSeparator;
-		CapellaElementDocGen result = new CapellaElementDocGen();
-		nl = null;
-		return result;
-	}
+    public static synchronized CapellaElementDocGen create(String lineSeparator) {
+        nl = lineSeparator;
+        CapellaElementDocGen result = new CapellaElementDocGen();
+        nl = null;
+        return result;
+    }
 
-	public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
-	protected final String TEXT_1 = "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>" + NL
-			+ "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\"" + NL
-			+ "    \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">" + NL
-			+ "<html xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\" lang=\"en\">" + NL + "" + NL + "\t<head>"
-			+ NL + "\t\t<meta name=\"copyright\" content=\"";
-	protected final String TEXT_2 = "\" />" + NL
-			+ "\t\t<meta http-equiv=\"content-type\" content=\"text/html;charset=ISO-8859-1\" />" + NL
-			+ "\t\t<meta http-equiv=\"Content-Style-Type\" content=\"text/css\" />" + NL + "" + NL + "\t\t<title>";
-	protected final String TEXT_3 = "</title>" + NL
-			+ "\t\t<link rel=\"stylesheet\" href=\"../../scripts/jquery-treeview/jquery.treeview.css\" />" + NL
-			+ "  \t\t<script src=\"../../scripts/jquery-treeview/lib/jquery-1.11.1.js\" type=\"text/javascript\"></script>"
-			+ NL
-			+ "  \t\t<script src=\"../../scripts/jquery-treeview/jquery.treeview.js\" type=\"text/javascript\"></script>"
-			+ NL + "\t\t<link rel=\"stylesheet\" type=\"text/css\" href=\"../../css/simpletree.css\" />\t\t" + NL
-			+ "\t\t<link title=\"default\" rel=\"stylesheet\" type=\"text/css\" media=\"screen, projection\" href=\"../../css/content.css\"></link>"
-			+ NL + "\t\t<script type=\"text/javascript\">" + NL
-			+ "\t\t\tif(parent.location.href == self.location.href) {" + NL
-			+ "\t\t\t\twindow.location.href = 'index.html?";
-	protected final String TEXT_4 = "' + '#' + self.location.href.substring(self.location.href.lastIndexOf(\"#\")+1);"
-			+ NL + "\t\t\t}" + NL + "\t\t</script>" + NL + "\t\t" + NL + "\t\t<style>" + NL + "\t\t\tbody {" + NL
-			+ "\t\t\t\tbackground: white;" + NL + "\t\t\t\tfont-family: Arial;" + NL + "\t\t\t}" + NL
-			+ "\t\t\t.treeview {" + NL + "\t\t\t\tbackground-color: white ;" + NL + "\t\t\t}" + NL + "\t" + NL
-			+ "\t\t\t.treeview ul{ /*CSS for Simple Tree Menu*/" + NL + "\t\t\t\tbackground-color: white;" + NL
-			+ "\t\t\t\tfont-size: 12px;" + NL + "\t\t\t}" + NL + "\t" + NL
-			+ "\t\t\t.treeview li{ /*Style for LI elements in general (excludes an LI that contains sub lists)*/" + NL
-			+ "\t\t\t\tbackground-color: white;" + NL + "\t\t\t}" + NL + "\t\t</style>" + NL + "\t\t" + NL + "\t</head>"
-			+ NL + "\t" + NL + "\t<body>\t";
-	protected final String TEXT_5 = NL;
+    public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
 
-	public CapellaElementDocGen() {
-		//Here is the constructor
-		StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_1 = "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>" + NL + "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\"" + NL
+            + "    \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">" + NL + "<html xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\" lang=\"en\">" + NL + "" + NL + "\t<head>" + NL
+            + "\t\t<meta name=\"copyright\" content=\"";
 
-		// add initialisation of the pattern variables (declaration has been already done).
+    protected final String TEXT_2 = "\" />" + NL + "\t\t<meta http-equiv=\"content-type\" content=\"text/html;charset=ISO-8859-1\" />" + NL
+            + "\t\t<meta http-equiv=\"Content-Style-Type\" content=\"text/css\" />" + NL + "" + NL + "\t\t<title>";
 
-	}
+    protected final String TEXT_3 = "</title>" + NL + "\t\t<link rel=\"stylesheet\" href=\"../../scripts/jquery-treeview/jquery.treeview.css\" />" + NL
+            + "  \t\t<script src=\"../../scripts/jquery-treeview/lib/jquery-1.11.1.js\" type=\"text/javascript\"></script>" + NL
+            + "  \t\t<script src=\"../../scripts/jquery-treeview/jquery.treeview.js\" type=\"text/javascript\"></script>" + NL
+            + "\t\t<link rel=\"stylesheet\" type=\"text/css\" href=\"../../css/simpletree.css\" />\t\t" + NL
+            + "\t\t<link title=\"default\" rel=\"stylesheet\" type=\"text/css\" media=\"screen, projection\" href=\"../../css/content.css\"></link>" + NL + "\t\t<script type=\"text/javascript\">" + NL
+            + "\t\t\tif(parent.location.href == self.location.href) {" + NL + "\t\t\t\twindow.location.href = 'index.html?";
 
-	public String generate(Object argument) throws Exception {
-		final StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_4 = "' + '#' + self.location.href.substring(self.location.href.lastIndexOf(\"#\")+1);" + NL + "\t\t\t}" + NL + "\t\t</script>" + NL + "\t\t" + NL + "\t\t<style>" + NL
+            + "\t\t\tbody {" + NL + "\t\t\t\tbackground: white;" + NL + "\t\t\t\tfont-family: Arial;" + NL + "\t\t\t}" + NL + "\t\t\t.treeview {" + NL + "\t\t\t\tbackground-color: white ;" + NL
+            + "\t\t\t}" + NL + "\t" + NL + "\t\t\t.treeview ul{ /*CSS for Simple Tree Menu*/" + NL + "\t\t\t\tbackground-color: white;" + NL + "\t\t\t\tfont-size: 12px;" + NL + "\t\t\t}" + NL + "\t"
+            + NL + "\t\t\t.treeview li{ /*Style for LI elements in general (excludes an LI that contains sub lists)*/" + NL + "\t\t\t\tbackground-color: white;" + NL + "\t\t\t}" + NL + "\t\t</style>"
+            + NL + "\t\t" + NL + "\t</head>" + NL + "\t" + NL + "\t<body>\t";
 
-		InternalPatternContext ctx = (InternalPatternContext) argument;
-		Map<String, String> queryCtx = null;
-		IQuery.ParameterDescription paramDesc = null;
-		Node.Container currentNode = ctx.getNode();
+    protected final String TEXT_5 = NL;
 
-		if (preCondition(ctx)) {
-			ctx.setNode(new Node.Container(currentNode, getClass()));
-			orchestration(ctx);
-		}
+    public CapellaElementDocGen() {
+        //Here is the constructor
+        StringBuffer stringBuffer = new StringBuffer();
 
-		ctx.setNode(currentNode);
-		if (ctx.useReporter()) {
-			ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
-		}
+        // add initialisation of the pattern variables (declaration has been already done).
 
-		stringBuffer.append(TEXT_5);
-		stringBuffer.append(TEXT_5);
-		return stringBuffer.toString();
-	}
+    }
 
-	public String orchestration(PatternContext ctx) throws Exception {
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
+    public String generate(Object argument) throws Exception {
+        final StringBuffer stringBuffer = new StringBuffer();
 
-		method_setCapellaContext(new StringBuffer(), ictx);
+        InternalPatternContext ctx = (InternalPatternContext) argument;
+        Map<String, String> queryCtx = null;
+        IQuery.ParameterDescription paramDesc = null;
+        Node.Container currentNode = ctx.getNode();
 
-		method_setTitle(new StringBuffer(), ictx);
+        if (preCondition(ctx)) {
+            ctx.setNode(new Node.Container(currentNode, getClass()));
+            orchestration(ctx);
+        }
 
-		method_setPath(new StringBuffer(), ictx);
+        ctx.setNode(currentNode);
+        if (ctx.useReporter()) {
+            ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
+        }
 
-		method_setFileName(new StringBuffer(), ictx);
-		super.orchestration(new SuperOrchestrationContext(ictx));
+        stringBuffer.append(TEXT_5);
+        stringBuffer.append(TEXT_5);
+        return stringBuffer.toString();
+    }
 
-		return null;
-	}
+    public String orchestration(PatternContext ctx) throws Exception {
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
 
-	protected org.polarsys.capella.core.data.capellacore.CapellaElement element = null;
+        method_setCapellaContext(new StringBuffer(), ictx);
 
-	public void set_element(org.polarsys.capella.core.data.capellacore.CapellaElement object) {
-		this.element = object;
-	}
+        method_setTitle(new StringBuffer(), ictx);
 
-	protected java.lang.String documentTitle = null;
+        method_setPath(new StringBuffer(), ictx);
 
-	public void set_documentTitle(java.lang.String object) {
-		this.documentTitle = object;
-	}
+        method_setFileName(new StringBuffer(), ictx);
+        super.orchestration(new SuperOrchestrationContext(ictx));
 
-	protected java.lang.String elementPath = null;
+        return null;
+    }
 
-	public void set_elementPath(java.lang.String object) {
-		this.elementPath = object;
-	}
+    protected org.polarsys.capella.core.data.capellacore.CapellaElement element = null;
 
-	public Map<String, Object> getParameters() {
-		final Map<String, Object> parameters = new HashMap<String, Object>();
-		return parameters;
-	}
+    public void set_element(org.polarsys.capella.core.data.capellacore.CapellaElement object) {
+        this.element = object;
+    }
 
-	protected void method_setCapellaContext(final StringBuffer stringBuffer, final PatternContext ctx)
-			throws Exception {
+    protected java.lang.String documentTitle = null;
 
-		element = null;
+    public void set_documentTitle(java.lang.String object) {
+        this.documentTitle = object;
+    }
 
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "setCapellaContext", stringBuffer.toString());
-	}
+    protected java.lang.String elementPath = null;
 
-	protected void method_setTitle(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+    public void set_elementPath(java.lang.String object) {
+        this.elementPath = object;
+    }
 
-		String elementName = CapellaServices.getHyperlinkFromElement(element);
-		/*
-		String elementType = EscapeChars.forHTML(element.eClass().getName());
-		String projectName= ctx.getValue("projectName").toString();
-		*/
-		documentTitle = elementName;
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "setTitle", stringBuffer.toString());
-	}
+    public Map<String, Object> getParameters() {
+        final Map<String, Object> parameters = new HashMap<String, Object>();
+        return parameters;
+    }
 
-	protected void method_setPath(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+    protected void method_setCapellaContext(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-		elementPath = CapellaServices.getElementPath(element);
+        element = null;
 
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "setPath", stringBuffer.toString());
-	}
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "setCapellaContext", stringBuffer.toString());
+    }
 
-	protected void method_setFileName(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+    protected void method_setTitle(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-		fileName = DocGenHtmlCapellaUtil.getCapellaElementRootFileName(element);
+        String elementName = CapellaServices.getHyperlinkFromElement(element);
+        /*
+        String elementType = EscapeChars.forHTML(element.eClass().getName());
+        String projectName= ctx.getValue("projectName").toString();
+        */
+        documentTitle = elementName;
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "setTitle", stringBuffer.toString());
+    }
 
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "setFileName", stringBuffer.toString());
-	}
+    protected void method_setPath(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-	protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+        elementPath = CapellaServices.getElementPath(element);
 
-		{
-			//<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#LogicalName=org.polarsys.capella.docgen.foundations.CapellaElementContentDocGen" args="element:element, documentTitle:documentTitle"%>
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "setPath", stringBuffer.toString());
+    }
 
-			InternalPatternContext ictx = (InternalPatternContext) ctx;
-			new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
-			stringBuffer.setLength(0);
+    protected void method_setFileName(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-			final Map<String, Object> callParameters = new HashMap<String, Object>();
-			callParameters.put("element", element);
-			callParameters.put("documentTitle", documentTitle);
-			CallHelper.executeWithParameterInjection(
-					"platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#_2twVYKu9EeCWrf9pgx3zjA",
-					new ExecutionContext((InternalPatternContext) ctx), callParameters);
-			stringBuffer.setLength(0);
-		}
+        fileName = DocGenHtmlCapellaUtil.getCapellaElementRootFileName(element);
 
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
-	}
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "setFileName", stringBuffer.toString());
+    }
 
-	protected void method_setFileNameService(final StringBuffer stringBuffer, final PatternContext ctx)
-			throws Exception {
+    protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-		fileNameService = DocGenHtmlCapellaUtil.SERVICE;
+        {
+            //<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#LogicalName=org.polarsys.capella.docgen.foundations.CapellaElementContentDocGen" args="element:element, documentTitle:documentTitle"%>
 
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "setFileNameService", stringBuffer.toString());
-	}
+            InternalPatternContext ictx = (InternalPatternContext) ctx;
+            new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
+            stringBuffer.setLength(0);
 
-	protected void method_endContent(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+            final Map<String, Object> callParameters = new HashMap<String, Object>();
+            callParameters.put("element", element);
+            callParameters.put("documentTitle", documentTitle);
+            CallHelper.executeWithParameterInjection("platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#_2twVYKu9EeCWrf9pgx3zjA",
+                    new ExecutionContext((InternalPatternContext) ctx), callParameters);
+            stringBuffer.setLength(0);
+        }
 
-		{
-			//<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#LogicalName=org.polarsys.capella.docgen.foundations.CapellaElementEndContentDocGen" args="element:element"%>
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
+    }
 
-			InternalPatternContext ictx = (InternalPatternContext) ctx;
-			new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
-			stringBuffer.setLength(0);
+    protected void method_setFileNameService(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-			final Map<String, Object> callParameters = new HashMap<String, Object>();
-			callParameters.put("element", element);
-			CallHelper.executeWithParameterInjection(
-					"platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#_H6iekavLEeCas-LHcur3rg",
-					new ExecutionContext((InternalPatternContext) ctx), callParameters);
-			stringBuffer.setLength(0);
-		}
+        fileNameService = DocGenHtmlCapellaUtil.SERVICE;
 
-		super.method_endContent(new StringBuffer(), ctx);
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "endContent", stringBuffer.toString());
-	}
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "setFileNameService", stringBuffer.toString());
+    }
 
-	protected void method_docHeader(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+    protected void method_endContent(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-		stringBuffer.append(TEXT_1);
-		stringBuffer.append(copyright);
-		stringBuffer.append(TEXT_2);
-		stringBuffer.append(title);
-		stringBuffer.append(TEXT_3);
-		stringBuffer.append(fileName);
-		stringBuffer.append(TEXT_4);
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "docHeader", stringBuffer.toString());
-	}
+        {
+            //<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#LogicalName=org.polarsys.capella.docgen.foundations.CapellaElementEndContentDocGen" args="element:element"%>
+
+            InternalPatternContext ictx = (InternalPatternContext) ctx;
+            new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
+            stringBuffer.setLength(0);
+
+            final Map<String, Object> callParameters = new HashMap<String, Object>();
+            callParameters.put("element", element);
+            CallHelper.executeWithParameterInjection("platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#_H6iekavLEeCas-LHcur3rg",
+                    new ExecutionContext((InternalPatternContext) ctx), callParameters);
+            stringBuffer.setLength(0);
+        }
+
+        super.method_endContent(new StringBuffer(), ctx);
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "endContent", stringBuffer.toString());
+    }
+
+    protected void method_docHeader(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+
+        stringBuffer.append(TEXT_1);
+        stringBuffer.append(copyright);
+        stringBuffer.append(TEXT_2);
+        stringBuffer.append(title);
+        stringBuffer.append(TEXT_3);
+        stringBuffer.append(fileName);
+        stringBuffer.append(TEXT_4);
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "docHeader", stringBuffer.toString());
+    }
 }

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/foundations/CapellaElementEndContentDocGen.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/foundations/CapellaElementEndContentDocGen.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.2.202001031546
+//Generated with EGF 1.6.3.202110291409
 package org.polarsys.capella.docgen.foundations;
 
 import org.eclipse.egf.common.helper.*;
@@ -11,233 +11,229 @@ import org.polarsys.capella.docgen.util.CapellaElementService;
 import org.polarsys.capella.docgen.util.StringUtil;
 
 public class CapellaElementEndContentDocGen {
-	protected static String nl;
+    protected static String nl;
 
-	public static synchronized CapellaElementEndContentDocGen create(String lineSeparator) {
-		nl = lineSeparator;
-		CapellaElementEndContentDocGen result = new CapellaElementEndContentDocGen();
-		nl = null;
-		return result;
-	}
+    public static synchronized CapellaElementEndContentDocGen create(String lineSeparator) {
+        nl = lineSeparator;
+        CapellaElementEndContentDocGen result = new CapellaElementEndContentDocGen();
+        nl = null;
+        return result;
+    }
 
-	public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
-	protected final String TEXT_1 = "";
-	protected final String TEXT_2 = NL + "<h2>Realized Elements</h2>" + NL;
-	protected final String TEXT_3 = NL;
-	protected final String TEXT_4 = NL + "<h2>Realizing Elements </h2>" + NL;
+    public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
 
-	public CapellaElementEndContentDocGen() {
-		//Here is the constructor
-		StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_1 = "";
 
-		// add initialisation of the pattern variables (declaration has been already done).
+    protected final String TEXT_2 = NL + "<h2>Realized Elements</h2>" + NL;
 
-	}
+    protected final String TEXT_3 = NL;
 
-	public String generate(Object argument) throws Exception {
-		final StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_4 = NL + "<h2>Realizing Elements </h2>" + NL;
 
-		InternalPatternContext ctx = (InternalPatternContext) argument;
-		Map<String, String> queryCtx = null;
-		IQuery.ParameterDescription paramDesc = null;
-		Node.Container currentNode = ctx.getNode();
+    public CapellaElementEndContentDocGen() {
+        //Here is the constructor
+        StringBuffer stringBuffer = new StringBuffer();
 
-		List<Object> elementList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
+        // add initialisation of the pattern variables (declaration has been already done).
 
-		for (Object elementParameter : elementList) {
+    }
 
-			this.element = (org.polarsys.capella.core.data.capellacore.CapellaElement) elementParameter;
+    public String generate(Object argument) throws Exception {
+        final StringBuffer stringBuffer = new StringBuffer();
 
-			if (preCondition(ctx)) {
-				ctx.setNode(new Node.Container(currentNode, getClass()));
-				orchestration(ctx);
-			}
+        InternalPatternContext ctx = (InternalPatternContext) argument;
+        Map<String, String> queryCtx = null;
+        IQuery.ParameterDescription paramDesc = null;
+        Node.Container currentNode = ctx.getNode();
 
-		}
-		ctx.setNode(currentNode);
-		if (ctx.useReporter()) {
-			ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
-		}
+        List<Object> elementList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
 
-		stringBuffer.append(TEXT_3);
-		stringBuffer.append(TEXT_3);
-		return stringBuffer.toString();
-	}
+        for (Object elementParameter : elementList) {
 
-	public String orchestration(PatternContext ctx) throws Exception {
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
+            this.element = (org.polarsys.capella.core.data.capellacore.CapellaElement) elementParameter;
 
-		method_body(new StringBuffer(), ictx);
+            if (preCondition(ctx)) {
+                ctx.setNode(new Node.Container(currentNode, getClass()));
+                orchestration(ctx);
+            }
 
-		if (ictx.useReporter()) {
-			Map<String, Object> parameterValues = new HashMap<String, Object>();
-			parameterValues.put("element", this.element);
-			String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
-			String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
-			ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
-		}
-		return null;
-	}
+        }
+        ctx.setNode(currentNode);
+        if (ctx.useReporter()) {
+            ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
+        }
 
-	protected org.polarsys.capella.core.data.capellacore.CapellaElement element = null;
+        stringBuffer.append(TEXT_3);
+        stringBuffer.append(TEXT_3);
+        return stringBuffer.toString();
+    }
 
-	public void set_element(org.polarsys.capella.core.data.capellacore.CapellaElement object) {
-		this.element = object;
-	}
+    public String orchestration(PatternContext ctx) throws Exception {
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
 
-	public Map<String, Object> getParameters() {
-		final Map<String, Object> parameters = new HashMap<String, Object>();
-		parameters.put("element", this.element);
-		return parameters;
-	}
+        method_body(new StringBuffer(), ictx);
 
-	protected void method_body(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+        if (ictx.useReporter()) {
+            Map<String, Object> parameterValues = new HashMap<String, Object>();
+            parameterValues.put("element", this.element);
+            String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
+            String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
+            ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
+        }
+        return null;
+    }
 
-		// Realized Elements 
-		stringBuffer.append(TEXT_1);
+    protected org.polarsys.capella.core.data.capellacore.CapellaElement element = null;
 
-		String outputFolder = ctx.getValue("outputFolder").toString();
-		String projectName = ctx.getValue("projectName").toString();
-		Collection<String> allocations = CapellaElementService.getOutGoingAllocation(element, projectName,
-				outputFolder);
-		if (allocations.size() > 0) {
-			stringBuffer.append(TEXT_2);
-			stringBuffer.append(TEXT_3);
-			stringBuffer.append(StringUtil.stringListToBulette(allocations));
-			stringBuffer.append(TEXT_3);
-		}
-		stringBuffer.append(TEXT_3);
-		// Realizing Elements 
+    public void set_element(org.polarsys.capella.core.data.capellacore.CapellaElement object) {
+        this.element = object;
+    }
 
-		//String outputFolder = ctx.getValue("outputFolder").toString();
-		//String projectName = ctx.getValue("projectName").toString();
-		Collection<String> allocations2 = CapellaElementService.getIncomingAllocation(element, projectName,
-				outputFolder);
-		if (allocations2.size() > 0) {
-			stringBuffer.append(TEXT_4);
-			stringBuffer.append(TEXT_3);
-			stringBuffer.append(StringUtil.stringListToBulette(allocations2));
-			stringBuffer.append(TEXT_3);
-		}
-		stringBuffer.append(TEXT_3);
-		// All constraints
-		stringBuffer.append(TEXT_3);
-		{
-			//<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#LogicalName=org.polarsys.capella.docgen.foundations.AllConstraintsDocGen" args="element:parameter"%>
+    public Map<String, Object> getParameters() {
+        final Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("element", this.element);
+        return parameters;
+    }
 
-			InternalPatternContext ictx = (InternalPatternContext) ctx;
-			new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
-			stringBuffer.setLength(0);
+    protected void method_body(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-			final Map<String, Object> callParameters = new HashMap<String, Object>();
-			callParameters.put("parameter", element);
-			CallHelper.executeWithParameterInjection(
-					"platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#_MribAMILEeu7XfnfLZ0e8g",
-					new ExecutionContext((InternalPatternContext) ctx), callParameters);
-			stringBuffer.setLength(0);
-		}
+        // Realized Elements 
+        stringBuffer.append(TEXT_1);
 
-		stringBuffer.append(TEXT_3);
-		// Property values
-		stringBuffer.append(TEXT_3);
-		{
-			//<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#LogicalName=org.polarsys.capella.docgen.foundations.PropertyValueGen" args="element:element, outputFolder:outputFolder, projectName:projectName"%>
+        String outputFolder = ctx.getValue("outputFolder").toString();
+        String projectName = ctx.getValue("projectName").toString();
+        Collection<String> allocations = CapellaElementService.getOutGoingAllocation(element, projectName, outputFolder);
+        if (allocations.size() > 0) {
+            stringBuffer.append(TEXT_2);
+            stringBuffer.append(TEXT_3);
+            stringBuffer.append(StringUtil.stringListToBulette(allocations));
+            stringBuffer.append(TEXT_3);
+        }
+        stringBuffer.append(TEXT_3);
+        // Realizing Elements 
 
-			InternalPatternContext ictx = (InternalPatternContext) ctx;
-			new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
-			stringBuffer.setLength(0);
+        //String outputFolder = ctx.getValue("outputFolder").toString();
+        //String projectName = ctx.getValue("projectName").toString();
+        Collection<String> allocations2 = CapellaElementService.getIncomingAllocation(element, projectName, outputFolder);
+        if (allocations2.size() > 0) {
+            stringBuffer.append(TEXT_4);
+            stringBuffer.append(TEXT_3);
+            stringBuffer.append(StringUtil.stringListToBulette(allocations2));
+            stringBuffer.append(TEXT_3);
+        }
+        stringBuffer.append(TEXT_3);
+        // All constraints
+        stringBuffer.append(TEXT_3);
+        {
+            //<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#LogicalName=org.polarsys.capella.docgen.foundations.AllConstraintsDocGen" args="element:parameter"%>
 
-			final Map<String, Object> callParameters = new HashMap<String, Object>();
-			callParameters.put("element", element);
-			callParameters.put("outputFolder", outputFolder);
-			callParameters.put("projectName", projectName);
-			CallHelper.executeWithParameterInjection(
-					"platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#_UT85gDr2EeK9AZkoGpWdMw",
-					new ExecutionContext((InternalPatternContext) ctx), callParameters);
-			stringBuffer.setLength(0);
-		}
+            InternalPatternContext ictx = (InternalPatternContext) ctx;
+            new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
+            stringBuffer.setLength(0);
 
-		stringBuffer.append(TEXT_3);
-		// owned diagrams
-		stringBuffer.append(TEXT_3);
-		{
-			//<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#LogicalName=org.polarsys.capella.docgen.foundations.DiagramsGeneration" args="element:element"%>
+            final Map<String, Object> callParameters = new HashMap<String, Object>();
+            callParameters.put("parameter", element);
+            CallHelper.executeWithParameterInjection("platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#_MribAMILEeu7XfnfLZ0e8g",
+                    new ExecutionContext((InternalPatternContext) ctx), callParameters);
+            stringBuffer.setLength(0);
+        }
 
-			InternalPatternContext ictx = (InternalPatternContext) ctx;
-			new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
-			stringBuffer.setLength(0);
+        stringBuffer.append(TEXT_3);
+        // Property values
+        stringBuffer.append(TEXT_3);
+        {
+            //<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#LogicalName=org.polarsys.capella.docgen.foundations.PropertyValueGen" args="element:element, outputFolder:outputFolder, projectName:projectName"%>
 
-			final Map<String, Object> callParameters = new HashMap<String, Object>();
-			callParameters.put("element", element);
-			CallHelper.executeWithParameterInjection(
-					"platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#_PVePETXrEeCNvtb1bUM2fQ",
-					new ExecutionContext((InternalPatternContext) ctx), callParameters);
-			stringBuffer.setLength(0);
-		}
+            InternalPatternContext ictx = (InternalPatternContext) ctx;
+            new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
+            stringBuffer.setLength(0);
 
-		stringBuffer.append(TEXT_3);
-		// Presented in diagrams generation
-		stringBuffer.append(TEXT_3);
-		{
-			//<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#LogicalName=org.polarsys.capella.docgen.foundations.PresentedDiagrmsGeneration" args="element:element"%>
+            final Map<String, Object> callParameters = new HashMap<String, Object>();
+            callParameters.put("element", element);
+            callParameters.put("outputFolder", outputFolder);
+            callParameters.put("projectName", projectName);
+            CallHelper.executeWithParameterInjection("platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#_UT85gDr2EeK9AZkoGpWdMw",
+                    new ExecutionContext((InternalPatternContext) ctx), callParameters);
+            stringBuffer.setLength(0);
+        }
 
-			InternalPatternContext ictx = (InternalPatternContext) ctx;
-			new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
-			stringBuffer.setLength(0);
+        stringBuffer.append(TEXT_3);
+        // owned diagrams
+        stringBuffer.append(TEXT_3);
+        {
+            //<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#LogicalName=org.polarsys.capella.docgen.foundations.DiagramsGeneration" args="element:element"%>
 
-			final Map<String, Object> callParameters = new HashMap<String, Object>();
-			callParameters.put("element", element);
-			CallHelper.executeWithParameterInjection(
-					"platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#_wWwgkErlEeCvqtVx_IKrqA",
-					new ExecutionContext((InternalPatternContext) ctx), callParameters);
-			stringBuffer.setLength(0);
-		}
+            InternalPatternContext ictx = (InternalPatternContext) ctx;
+            new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
+            stringBuffer.setLength(0);
 
-		stringBuffer.append(TEXT_3);
-		// Interested diagram in this model element 
-		stringBuffer.append(TEXT_3);
-		{
-			//<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#LogicalName=org.polarsys.capella.docgen.foundations.InterestedDiagrmsGeneration" args="element:element"%>
+            final Map<String, Object> callParameters = new HashMap<String, Object>();
+            callParameters.put("element", element);
+            CallHelper.executeWithParameterInjection("platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#_PVePETXrEeCNvtb1bUM2fQ",
+                    new ExecutionContext((InternalPatternContext) ctx), callParameters);
+            stringBuffer.setLength(0);
+        }
 
-			InternalPatternContext ictx = (InternalPatternContext) ctx;
-			new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
-			stringBuffer.setLength(0);
+        stringBuffer.append(TEXT_3);
+        // Presented in diagrams generation
+        stringBuffer.append(TEXT_3);
+        {
+            //<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#LogicalName=org.polarsys.capella.docgen.foundations.PresentedDiagrmsGeneration" args="element:element"%>
 
-			final Map<String, Object> callParameters = new HashMap<String, Object>();
-			callParameters.put("element", element);
-			CallHelper.executeWithParameterInjection(
-					"platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#_mGFhcAHoEemzNsJkc2kajg",
-					new ExecutionContext((InternalPatternContext) ctx), callParameters);
-			stringBuffer.setLength(0);
-		}
+            InternalPatternContext ictx = (InternalPatternContext) ctx;
+            new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
+            stringBuffer.setLength(0);
 
-		stringBuffer.append(TEXT_3);
-		// Diagrams navigation tree
-		stringBuffer.append(TEXT_3);
-		{
-			//<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#LogicalName=org.polarsys.capella.docgen.foundations.DiagramNavigationTree" args="element:element, outputFolder:outputFolder, projectName:projectName"%>
+            final Map<String, Object> callParameters = new HashMap<String, Object>();
+            callParameters.put("element", element);
+            CallHelper.executeWithParameterInjection("platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#_wWwgkErlEeCvqtVx_IKrqA",
+                    new ExecutionContext((InternalPatternContext) ctx), callParameters);
+            stringBuffer.setLength(0);
+        }
 
-			InternalPatternContext ictx = (InternalPatternContext) ctx;
-			new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
-			stringBuffer.setLength(0);
+        stringBuffer.append(TEXT_3);
+        // Interested diagram in this model element 
+        stringBuffer.append(TEXT_3);
+        {
+            //<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#LogicalName=org.polarsys.capella.docgen.foundations.InterestedDiagrmsGeneration" args="element:element"%>
 
-			final Map<String, Object> callParameters = new HashMap<String, Object>();
-			callParameters.put("element", element);
-			callParameters.put("outputFolder", outputFolder);
-			callParameters.put("projectName", projectName);
-			CallHelper.executeWithParameterInjection(
-					"platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#_mpoLIKGQEemXudi5U_Uo0A",
-					new ExecutionContext((InternalPatternContext) ctx), callParameters);
-			stringBuffer.setLength(0);
-		}
+            InternalPatternContext ictx = (InternalPatternContext) ctx;
+            new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
+            stringBuffer.setLength(0);
 
-		stringBuffer.append(TEXT_3);
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "body", stringBuffer.toString());
-	}
+            final Map<String, Object> callParameters = new HashMap<String, Object>();
+            callParameters.put("element", element);
+            CallHelper.executeWithParameterInjection("platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#_mGFhcAHoEemzNsJkc2kajg",
+                    new ExecutionContext((InternalPatternContext) ctx), callParameters);
+            stringBuffer.setLength(0);
+        }
 
-	public boolean preCondition(PatternContext ctx) throws Exception {
-		return true;
-	}
+        stringBuffer.append(TEXT_3);
+        // Diagrams navigation tree
+        stringBuffer.append(TEXT_3);
+        {
+            //<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#LogicalName=org.polarsys.capella.docgen.foundations.DiagramNavigationTree" args="element:element, outputFolder:outputFolder, projectName:projectName"%>
+
+            InternalPatternContext ictx = (InternalPatternContext) ctx;
+            new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
+            stringBuffer.setLength(0);
+
+            final Map<String, Object> callParameters = new HashMap<String, Object>();
+            callParameters.put("element", element);
+            callParameters.put("outputFolder", outputFolder);
+            callParameters.put("projectName", projectName);
+            CallHelper.executeWithParameterInjection("platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#_mpoLIKGQEemXudi5U_Uo0A",
+                    new ExecutionContext((InternalPatternContext) ctx), callParameters);
+            stringBuffer.setLength(0);
+        }
+
+        stringBuffer.append(TEXT_3);
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "body", stringBuffer.toString());
+    }
+
+    public boolean preCondition(PatternContext ctx) throws Exception {
+        return true;
+    }
 }

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/foundations/ConstraintsDocGen.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/foundations/ConstraintsDocGen.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.2.202001031546
+//Generated with EGF 1.6.3.202110291409
 package org.polarsys.capella.docgen.foundations;
 
 import java.util.*;
@@ -10,243 +10,250 @@ import org.polarsys.capella.docgen.util.ConstraintsService;
 import org.polarsys.capella.docgen.util.pattern.helper.PropertyValueHelper;
 
 public class ConstraintsDocGen {
-	protected static String nl;
+    protected static String nl;
 
-	public static synchronized ConstraintsDocGen create(String lineSeparator) {
-		nl = lineSeparator;
-		ConstraintsDocGen result = new ConstraintsDocGen();
-		nl = null;
-		return result;
-	}
+    public static synchronized ConstraintsDocGen create(String lineSeparator) {
+        nl = lineSeparator;
+        ConstraintsDocGen result = new ConstraintsDocGen();
+        nl = null;
+        return result;
+    }
 
-	public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
-	protected final String TEXT_1 = "";
-	protected final String TEXT_2 = NL + NL + "<table style=\"width: 100%\" border=\"1\">" + NL + "\t<tbody>" + NL
-			+ "        <tr>" + NL
-			+ "\t\t\t<td style=\"font-weight: bold; text-align: center; width: 15%\"> Name and Description</td>" + NL
-			+ "\t\t\t<td style=\"font-weight: bold; text-align: center; width: 55%\"> Owned specification</td>" + NL
-			+ "\t\t\t<td style=\"font-weight: bold; text-align: center; width: 15%\"> Constrained elements<br /></td>"
-			+ NL + "\t\t\t" + NL + "        </tr>";
-	protected final String TEXT_3 = NL;
-	protected final String TEXT_4 = NL + "        <tr>";
-	protected final String TEXT_5 = "\t\t\t<td rowspan=\"3\">";
-	protected final String TEXT_6 = "        \t<td>";
-	protected final String TEXT_7 = NL + "<b>";
-	protected final String TEXT_8 = " </b>";
-	protected final String TEXT_9 = NL + "\t\t\t</td>" + NL + "\t\t\t<td>";
-	protected final String TEXT_10 = "\t\t\t\t" + NL + "\t\t\t</td>" + NL + "\t\t\t<td>  ";
-	protected final String TEXT_11 = "\t\t\t" + NL + "\t\t\t</td>" + NL + "        </tr>";
-	protected final String TEXT_12 = NL + "\t\t<tr>" + NL + "\t\t\t<th colspan=\"2\">" + NL
-			+ "\t\t\tApplied and Contained Property Values" + NL + "\t\t\t</th>" + NL + "\t\t</tr>" + NL + "\t\t<tr>"
-			+ NL + "\t\t\t<td colspan=\"2\">";
-	protected final String TEXT_13 = NL + "\t\t\t</td>" + NL + "\t\t</tr>";
-	protected final String TEXT_14 = NL + "\t</tbody>" + NL + "</table>" + NL;
+    public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
 
-	public ConstraintsDocGen() {
-		//Here is the constructor
-		StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_1 = "";
 
-		// add initialisation of the pattern variables (declaration has been already done).
+    protected final String TEXT_2 = NL + NL + "<table style=\"width: 100%\" border=\"1\">" + NL + "\t<tbody>" + NL + "        <tr>" + NL
+            + "\t\t\t<td style=\"font-weight: bold; text-align: center; width: 15%\"> Name and Description</td>" + NL
+            + "\t\t\t<td style=\"font-weight: bold; text-align: center; width: 55%\"> Owned specification</td>" + NL
+            + "\t\t\t<td style=\"font-weight: bold; text-align: center; width: 15%\"> Constrained elements<br /></td>" + NL + "\t\t\t" + NL + "        </tr>";
 
-	}
+    protected final String TEXT_3 = NL;
 
-	public String generate(Object argument) throws Exception {
-		final StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_4 = NL + "        <tr>";
 
-		InternalPatternContext ctx = (InternalPatternContext) argument;
-		Map<String, String> queryCtx = null;
-		IQuery.ParameterDescription paramDesc = null;
-		Node.Container currentNode = ctx.getNode();
+    protected final String TEXT_5 = "\t\t\t<td rowspan=\"3\">";
 
-		List<Object> parameterList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
-		List<Object> constraintsListList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
-		List<Object> constraintSectionTitleList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
+    protected final String TEXT_6 = "        \t<td>";
 
-		for (Object parameterParameter : parameterList) {
-			for (Object constraintsListParameter : constraintsListList) {
-				for (Object constraintSectionTitleParameter : constraintSectionTitleList) {
+    protected final String TEXT_7 = NL + "<b>";
 
-					this.parameter = (org.polarsys.capella.core.data.capellacore.CapellaElement) parameterParameter;
-					this.constraintsList = (java.util.List) constraintsListParameter;
-					this.constraintSectionTitle = (java.lang.String) constraintSectionTitleParameter;
+    protected final String TEXT_8 = " </b>";
 
-					if (preCondition(ctx)) {
-						ctx.setNode(new Node.Container(currentNode, getClass()));
-						orchestration(ctx);
-					}
+    protected final String TEXT_9 = NL + "\t\t\t</td>" + NL + "\t\t\t<td>";
 
-				}
-			}
-		}
-		ctx.setNode(currentNode);
-		if (ctx.useReporter()) {
-			ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
-		}
+    protected final String TEXT_10 = "\t\t\t\t" + NL + "\t\t\t</td>" + NL + "\t\t\t<td>  ";
 
-		stringBuffer.append(TEXT_3);
-		stringBuffer.append(TEXT_3);
-		return stringBuffer.toString();
-	}
+    protected final String TEXT_11 = "\t\t\t" + NL + "\t\t\t</td>" + NL + "        </tr>";
 
-	public String orchestration(PatternContext ctx) throws Exception {
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
+    protected final String TEXT_12 = NL + "\t\t<tr>" + NL + "\t\t\t<th colspan=\"2\">" + NL + "\t\t\tApplied and Contained Property Values" + NL + "\t\t\t</th>" + NL + "\t\t</tr>" + NL + "\t\t<tr>"
+            + NL + "\t\t\t<td colspan=\"2\">";
 
-		method_genConstraints(new StringBuffer(), ictx);
+    protected final String TEXT_13 = NL + "\t\t\t</td>" + NL + "\t\t</tr>";
 
-		if (ictx.useReporter()) {
-			Map<String, Object> parameterValues = new HashMap<String, Object>();
-			parameterValues.put("parameter", this.parameter);
-			parameterValues.put("constraintsList", this.constraintsList);
-			parameterValues.put("constraintSectionTitle", this.constraintSectionTitle);
-			String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
-			String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
-			ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
-		}
-		return null;
-	}
+    protected final String TEXT_14 = NL + "\t</tbody>" + NL + "</table>" + NL;
 
-	protected org.polarsys.capella.core.data.capellacore.CapellaElement parameter = null;
+    public ConstraintsDocGen() {
+        //Here is the constructor
+        StringBuffer stringBuffer = new StringBuffer();
 
-	public void set_parameter(org.polarsys.capella.core.data.capellacore.CapellaElement object) {
-		this.parameter = object;
-	}
+        // add initialisation of the pattern variables (declaration has been already done).
 
-	protected java.util.List constraintsList = null;
+    }
 
-	public void set_constraintsList(java.util.List object) {
-		this.constraintsList = object;
-	}
+    public String generate(Object argument) throws Exception {
+        final StringBuffer stringBuffer = new StringBuffer();
 
-	protected java.lang.String constraintSectionTitle = null;
+        InternalPatternContext ctx = (InternalPatternContext) argument;
+        Map<String, String> queryCtx = null;
+        IQuery.ParameterDescription paramDesc = null;
+        Node.Container currentNode = ctx.getNode();
 
-	public void set_constraintSectionTitle(java.lang.String object) {
-		this.constraintSectionTitle = object;
-	}
+        List<Object> parameterList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
+        List<Object> constraintsListList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
+        List<Object> constraintSectionTitleList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
 
-	public Map<String, Object> getParameters() {
-		final Map<String, Object> parameters = new HashMap<String, Object>();
-		parameters.put("parameter", this.parameter);
-		parameters.put("constraintsList", this.constraintsList);
-		parameters.put("constraintSectionTitle", this.constraintSectionTitle);
-		return parameters;
-	}
+        for (Object parameterParameter : parameterList) {
+            for (Object constraintsListParameter : constraintsListList) {
+                for (Object constraintSectionTitleParameter : constraintSectionTitleList) {
 
-	protected void method_genConstraints(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+                    this.parameter = (org.polarsys.capella.core.data.capellacore.CapellaElement) parameterParameter;
+                    this.constraintsList = (java.util.List) constraintsListParameter;
+                    this.constraintSectionTitle = (java.lang.String) constraintSectionTitleParameter;
 
-		// Fallback to default behavior
-		if (constraintSectionTitle == null || constraintSectionTitle.trim().equals("")) {
-			constraintSectionTitle = "Constraints";
-		}
-		if (constraintsList == null || constraintsList.isEmpty()) {
-			constraintsList = parameter.getOwnedConstraints();
-		}
+                    if (preCondition(ctx)) {
+                        ctx.setNode(new Node.Container(currentNode, getClass()));
+                        orchestration(ctx);
+                    }
 
-		stringBuffer.append(TEXT_1);
-		{
-			//<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#LogicalName=org.polarsys.kitalpha.doc.gen.business.core.generic.ElementGenerateByPropterty" args="parameter:eObject,constraintSectionTitle:property"%>
+                }
+            }
+        }
+        ctx.setNode(currentNode);
+        if (ctx.useReporter()) {
+            ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
+        }
 
-			InternalPatternContext ictx = (InternalPatternContext) ctx;
-			new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
-			stringBuffer.setLength(0);
+        stringBuffer.append(TEXT_3);
+        stringBuffer.append(TEXT_3);
+        return stringBuffer.toString();
+    }
 
-			final Map<String, Object> callParameters = new HashMap<String, Object>();
-			callParameters.put("eObject", parameter);
-			callParameters.put("property", constraintSectionTitle);
-			CallHelper.executeWithParameterInjection(
-					"platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#_cWGxMONUEd-euK0PeLuaMA",
-					new ExecutionContext((InternalPatternContext) ctx), callParameters);
-			stringBuffer.setLength(0);
-		}
+    public String orchestration(PatternContext ctx) throws Exception {
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
 
-		stringBuffer.append(TEXT_2);
-		String projectName = (String) ctx.getValue("projectName");
-		String outputFolder = (String) ctx.getValue("outputFolder");
-		stringBuffer.append(TEXT_3);
+        method_genConstraints(new StringBuffer(), ictx);
 
-		List<?> constraints = constraintsList;
-		constraints.stream().filter(Constraint.class::isInstance).forEach(c -> {
-			Constraint constraint = (Constraint) c;
-			String constraintName = ConstraintsService.getConstraintName(constraint);
+        if (ictx.useReporter()) {
+            Map<String, Object> parameterValues = new HashMap<String, Object>();
+            parameterValues.put("parameter", this.parameter);
+            parameterValues.put("constraintsList", this.constraintsList);
+            parameterValues.put("constraintSectionTitle", this.constraintSectionTitle);
+            String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
+            String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
+            ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
+        }
+        return null;
+    }
 
-			stringBuffer.append(TEXT_4);
+    protected org.polarsys.capella.core.data.capellacore.CapellaElement parameter = null;
 
-			Boolean hasAppliedPVorPVGs = PropertyValueHelper.hasAppliedOrOwnedPropertyValues(constraint);
-			if (hasAppliedPVorPVGs) {
+    public void set_parameter(org.polarsys.capella.core.data.capellacore.CapellaElement object) {
+        this.parameter = object;
+    }
 
-				stringBuffer.append(TEXT_5);
-			} else {
+    protected java.util.List constraintsList = null;
 
-				stringBuffer.append(TEXT_6);
-			}
+    public void set_constraintsList(java.util.List object) {
+        this.constraintsList = object;
+    }
 
-			stringBuffer.append(TEXT_7);
-			stringBuffer.append(constraintName);
-			stringBuffer.append(TEXT_8);
-			// Summary and description generation
-			stringBuffer.append(TEXT_3);
-			{
-				//<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#LogicalName=org.polarsys.capella.docgen.foundations.SummaryAndDescriptionGeneration" args="constraint:element"%>
+    protected java.lang.String constraintSectionTitle = null;
 
-				InternalPatternContext ictx = (InternalPatternContext) ctx;
-				new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
-				stringBuffer.setLength(0);
+    public void set_constraintSectionTitle(java.lang.String object) {
+        this.constraintSectionTitle = object;
+    }
 
-				final Map<String, Object> callParameters = new HashMap<String, Object>();
-				callParameters.put("element", constraint);
-				CallHelper.executeWithParameterInjection(
-						"platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#_fiM9sOZdEd-YVt45ZEg4_w",
-						new ExecutionContext((InternalPatternContext) ctx), callParameters);
-				stringBuffer.setLength(0);
-			}
+    public Map<String, Object> getParameters() {
+        final Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("parameter", this.parameter);
+        parameters.put("constraintsList", this.constraintsList);
+        parameters.put("constraintSectionTitle", this.constraintSectionTitle);
+        return parameters;
+    }
 
-			stringBuffer.append(TEXT_9);
-			stringBuffer.append(TEXT_3);
-			stringBuffer.append(ConstraintsService.getValueSpecification(constraint.getOwnedSpecification(),
-					projectName, outputFolder));
-			stringBuffer.append(TEXT_10);
-			stringBuffer.append(TEXT_3);
-			stringBuffer.append(ConstraintsService.getConstrainedElement(constraint, projectName, outputFolder));
-			stringBuffer.append(TEXT_11);
+    protected void method_genConstraints(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-			if (hasAppliedPVorPVGs) {
-				int sectionLevel = 4;
-				boolean displayAsRowParameter = true;
+        // Fallback to default behavior
+        if (constraintSectionTitle == null || constraintSectionTitle.trim().equals("")) {
+            constraintSectionTitle = "Constraints";
+        }
+        if (constraintsList == null || constraintsList.isEmpty()) {
+            constraintsList = parameter.getOwnedConstraints();
+        }
 
-				stringBuffer.append(TEXT_12);
-				stringBuffer.append(TEXT_3);
-				{
-					//<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#LogicalName=org.polarsys.capella.docgen.foundations.PropertyValueGen" args="constraint:element,outputFolder:outputFolder,projectName:projectName,sectionLevel:sectionLevelParameter,displayAsRowParameter:displayAsRowParameter"%>
+        stringBuffer.append(TEXT_1);
+        {
+            //<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#LogicalName=org.polarsys.kitalpha.doc.gen.business.core.generic.ElementGenerateByPropterty" args="parameter:eObject,constraintSectionTitle:property"%>
 
-					InternalPatternContext ictx = (InternalPatternContext) ctx;
-					new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
-					stringBuffer.setLength(0);
+            InternalPatternContext ictx = (InternalPatternContext) ctx;
+            new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
+            stringBuffer.setLength(0);
 
-					final Map<String, Object> callParameters = new HashMap<String, Object>();
-					callParameters.put("element", constraint);
-					callParameters.put("outputFolder", outputFolder);
-					callParameters.put("projectName", projectName);
-					callParameters.put("sectionLevelParameter", sectionLevel);
-					callParameters.put("displayAsRowParameter", displayAsRowParameter);
-					CallHelper.executeWithParameterInjection(
-							"platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#_UT85gDr2EeK9AZkoGpWdMw",
-							new ExecutionContext((InternalPatternContext) ctx), callParameters);
-					stringBuffer.setLength(0);
-				}
+            final Map<String, Object> callParameters = new HashMap<String, Object>();
+            callParameters.put("eObject", parameter);
+            callParameters.put("property", constraintSectionTitle);
+            CallHelper.executeWithParameterInjection("platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#_cWGxMONUEd-euK0PeLuaMA",
+                    new ExecutionContext((InternalPatternContext) ctx), callParameters);
+            stringBuffer.setLength(0);
+        }
 
-				stringBuffer.append(TEXT_13);
+        stringBuffer.append(TEXT_2);
+        String projectName = (String) ctx.getValue("projectName");
+        String outputFolder = (String) ctx.getValue("outputFolder");
+        stringBuffer.append(TEXT_3);
 
-			}
-		});
+        List<?> constraints = constraintsList;
+        constraints.stream().filter(Constraint.class::isInstance).forEach(c -> {
+            Constraint constraint = (Constraint) c;
+            String constraintName = ConstraintsService.getConstraintName(constraint);
 
-		stringBuffer.append(TEXT_14);
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "genConstraints", stringBuffer.toString());
-	}
+            stringBuffer.append(TEXT_4);
 
-	public boolean preCondition(PatternContext ctx) throws Exception {
-		return true;
-	}
+            Boolean hasAppliedPVorPVGs = PropertyValueHelper.hasAppliedOrOwnedPropertyValues(constraint);
+            if (hasAppliedPVorPVGs) {
+
+                stringBuffer.append(TEXT_5);
+            } else {
+
+                stringBuffer.append(TEXT_6);
+            }
+
+            stringBuffer.append(TEXT_7);
+            stringBuffer.append(constraintName);
+            stringBuffer.append(TEXT_8);
+            // Summary and description generation
+            stringBuffer.append(TEXT_3);
+            {
+                //<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#LogicalName=org.polarsys.capella.docgen.foundations.SummaryAndDescriptionGeneration" args="constraint:element"%>
+
+                InternalPatternContext ictx = (InternalPatternContext) ctx;
+                new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
+                stringBuffer.setLength(0);
+
+                final Map<String, Object> callParameters = new HashMap<String, Object>();
+                callParameters.put("element", constraint);
+                CallHelper.executeWithParameterInjection("platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#_fiM9sOZdEd-YVt45ZEg4_w",
+                        new ExecutionContext((InternalPatternContext) ctx), callParameters);
+                stringBuffer.setLength(0);
+            }
+
+            stringBuffer.append(TEXT_9);
+            stringBuffer.append(TEXT_3);
+            stringBuffer.append(ConstraintsService.getValueSpecification(constraint.getOwnedSpecification(), projectName, outputFolder));
+            stringBuffer.append(TEXT_10);
+            stringBuffer.append(TEXT_3);
+            stringBuffer.append(ConstraintsService.getConstrainedElement(constraint, projectName, outputFolder));
+            stringBuffer.append(TEXT_11);
+
+            if (hasAppliedPVorPVGs) {
+                int sectionLevel = 4;
+                boolean displayAsRowParameter = true;
+
+                stringBuffer.append(TEXT_12);
+                stringBuffer.append(TEXT_3);
+                {
+                    //<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#LogicalName=org.polarsys.capella.docgen.foundations.PropertyValueGen" args="constraint:element,outputFolder:outputFolder,projectName:projectName,sectionLevel:sectionLevelParameter,displayAsRowParameter:displayAsRowParameter"%>
+
+                    InternalPatternContext ictx = (InternalPatternContext) ctx;
+                    new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
+                    stringBuffer.setLength(0);
+
+                    final Map<String, Object> callParameters = new HashMap<String, Object>();
+                    callParameters.put("element", constraint);
+                    callParameters.put("outputFolder", outputFolder);
+                    callParameters.put("projectName", projectName);
+                    callParameters.put("sectionLevelParameter", sectionLevel);
+                    callParameters.put("displayAsRowParameter", displayAsRowParameter);
+                    CallHelper.executeWithParameterInjection("platform:/plugin/org.polarsys.capella.docgen/egf/HTMLDocGenCapella.fcore#_UT85gDr2EeK9AZkoGpWdMw",
+                            new ExecutionContext((InternalPatternContext) ctx), callParameters);
+                    stringBuffer.setLength(0);
+                }
+
+                stringBuffer.append(TEXT_13);
+
+            }
+        });
+
+        stringBuffer.append(TEXT_14);
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "genConstraints", stringBuffer.toString());
+    }
+
+    public boolean preCondition(PatternContext ctx) throws Exception {
+        return true;
+    }
 }

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/foundations/DiagramNavigationTree.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/foundations/DiagramNavigationTree.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.2.202001031546
+//Generated with EGF 1.6.3.202110291409
 package org.polarsys.capella.docgen.foundations;
 
 import java.util.*;
@@ -11,170 +11,171 @@ import org.polarsys.capella.docgen.diagram.CapellaHelper;
 import org.polarsys.capella.docgen.preference.CapellaDocgenPreferenceHelper;
 
 public class DiagramNavigationTree {
-	protected static String nl;
+    protected static String nl;
 
-	public static synchronized DiagramNavigationTree create(String lineSeparator) {
-		nl = lineSeparator;
-		DiagramNavigationTree result = new DiagramNavigationTree();
-		nl = null;
-		return result;
-	}
+    public static synchronized DiagramNavigationTree create(String lineSeparator) {
+        nl = lineSeparator;
+        DiagramNavigationTree result = new DiagramNavigationTree();
+        nl = null;
+        return result;
+    }
 
-	public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
-	protected final String TEXT_1 = "\t<h2>Diagrams</h2>" + NL + "\t";
-	protected final String TEXT_2 = NL + "\t<br>" + NL + "\t" + NL + "\t";
-	protected final String TEXT_3 = NL + "\t";
-	protected final String TEXT_4 = NL;
+    public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
 
-	public DiagramNavigationTree() {
-		//Here is the constructor
-		StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_1 = "\t<h2>Diagrams</h2>" + NL + "\t";
 
-		// add initialisation of the pattern variables (declaration has been already done).
+    protected final String TEXT_2 = NL + "\t<br>" + NL + "\t" + NL + "\t";
 
-	}
+    protected final String TEXT_3 = NL + "\t";
 
-	public String generate(Object argument) throws Exception {
-		final StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_4 = NL;
 
-		InternalPatternContext ctx = (InternalPatternContext) argument;
-		Map<String, String> queryCtx = null;
-		IQuery.ParameterDescription paramDesc = null;
-		Node.Container currentNode = ctx.getNode();
+    public DiagramNavigationTree() {
+        //Here is the constructor
+        StringBuffer stringBuffer = new StringBuffer();
 
-		List<Object> elementList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
-		List<Object> outputFolderList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
-		List<Object> projectNameList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
+        // add initialisation of the pattern variables (declaration has been already done).
 
-		for (Object elementParameter : elementList) {
-			for (Object outputFolderParameter : outputFolderList) {
-				for (Object projectNameParameter : projectNameList) {
+    }
 
-					this.element = (org.polarsys.capella.core.data.capellacore.CapellaElement) elementParameter;
-					this.outputFolder = (java.lang.String) outputFolderParameter;
-					this.projectName = (java.lang.String) projectNameParameter;
+    public String generate(Object argument) throws Exception {
+        final StringBuffer stringBuffer = new StringBuffer();
 
-					if (preCondition(ctx)) {
-						ctx.setNode(new Node.Container(currentNode, getClass()));
-						orchestration(ctx);
-					}
+        InternalPatternContext ctx = (InternalPatternContext) argument;
+        Map<String, String> queryCtx = null;
+        IQuery.ParameterDescription paramDesc = null;
+        Node.Container currentNode = ctx.getNode();
 
-				}
-			}
-		}
-		ctx.setNode(currentNode);
-		if (ctx.useReporter()) {
-			ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
-		}
+        List<Object> elementList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
+        List<Object> outputFolderList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
+        List<Object> projectNameList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
 
-		stringBuffer.append(TEXT_4);
-		stringBuffer.append(TEXT_4);
-		return stringBuffer.toString();
-	}
+        for (Object elementParameter : elementList) {
+            for (Object outputFolderParameter : outputFolderList) {
+                for (Object projectNameParameter : projectNameList) {
 
-	public String orchestration(PatternContext ctx) throws Exception {
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
+                    this.element = (org.polarsys.capella.core.data.capellacore.CapellaElement) elementParameter;
+                    this.outputFolder = (java.lang.String) outputFolderParameter;
+                    this.projectName = (java.lang.String) projectNameParameter;
 
-		method_body(new StringBuffer(), ictx);
+                    if (preCondition(ctx)) {
+                        ctx.setNode(new Node.Container(currentNode, getClass()));
+                        orchestration(ctx);
+                    }
 
-		if (ictx.useReporter()) {
-			Map<String, Object> parameterValues = new HashMap<String, Object>();
-			parameterValues.put("element", this.element);
-			parameterValues.put("outputFolder", this.outputFolder);
-			parameterValues.put("projectName", this.projectName);
-			String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
-			String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
-			ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
-		}
-		return null;
-	}
+                }
+            }
+        }
+        ctx.setNode(currentNode);
+        if (ctx.useReporter()) {
+            ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
+        }
 
-	protected org.polarsys.capella.core.data.capellacore.CapellaElement element = null;
+        stringBuffer.append(TEXT_4);
+        stringBuffer.append(TEXT_4);
+        return stringBuffer.toString();
+    }
 
-	public void set_element(org.polarsys.capella.core.data.capellacore.CapellaElement object) {
-		this.element = object;
-	}
+    public String orchestration(PatternContext ctx) throws Exception {
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
 
-	protected java.lang.String outputFolder = null;
+        method_body(new StringBuffer(), ictx);
 
-	public void set_outputFolder(java.lang.String object) {
-		this.outputFolder = object;
-	}
+        if (ictx.useReporter()) {
+            Map<String, Object> parameterValues = new HashMap<String, Object>();
+            parameterValues.put("element", this.element);
+            parameterValues.put("outputFolder", this.outputFolder);
+            parameterValues.put("projectName", this.projectName);
+            String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
+            String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
+            ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
+        }
+        return null;
+    }
 
-	protected java.lang.String projectName = null;
+    protected org.polarsys.capella.core.data.capellacore.CapellaElement element = null;
 
-	public void set_projectName(java.lang.String object) {
-		this.projectName = object;
-	}
+    public void set_element(org.polarsys.capella.core.data.capellacore.CapellaElement object) {
+        this.element = object;
+    }
 
-	public Map<String, Object> getParameters() {
-		final Map<String, Object> parameters = new HashMap<String, Object>();
-		parameters.put("element", this.element);
-		parameters.put("outputFolder", this.outputFolder);
-		parameters.put("projectName", this.projectName);
-		return parameters;
-	}
+    protected java.lang.String outputFolder = null;
 
-	protected void method_body(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+    public void set_outputFolder(java.lang.String object) {
+        this.outputFolder = object;
+    }
 
-		String projectName = ctx.getValue("projectName").toString();
-		String outputFolder = ctx.getValue("outputFolder").toString();
-		String treeID = TreeServices.DIAGRAMS_TREE_ID;
+    protected java.lang.String projectName = null;
 
-		if (element instanceof BlockArchitecture) {
-			if (CapellaHelper.hostDiagrams((BlockArchitecture) element)) {
+    public void set_projectName(java.lang.String object) {
+        this.projectName = object;
+    }
 
-				stringBuffer.append(TEXT_1);
-				{
-					//<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#LogicalName=org.polarsys.kitalpha.doc.gen.business.core.doccontent.treeview.TreeViewControlHeader" args="element:parameter, treeID:treeID"%>
+    public Map<String, Object> getParameters() {
+        final Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("element", this.element);
+        parameters.put("outputFolder", this.outputFolder);
+        parameters.put("projectName", this.projectName);
+        return parameters;
+    }
 
-					InternalPatternContext ictx = (InternalPatternContext) ctx;
-					new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
-					stringBuffer.setLength(0);
+    protected void method_body(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-					final Map<String, Object> callParameters = new HashMap<String, Object>();
-					callParameters.put("parameter", element);
-					callParameters.put("treeID", treeID);
-					CallHelper.executeWithParameterInjection(
-							"platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#_V6ybEJ52EemYav3Xat9ApA",
-							new ExecutionContext((InternalPatternContext) ctx), callParameters);
-					stringBuffer.setLength(0);
-				}
+        String projectName = ctx.getValue("projectName").toString();
+        String outputFolder = ctx.getValue("outputFolder").toString();
+        String treeID = TreeServices.DIAGRAMS_TREE_ID;
 
-				stringBuffer.append(TEXT_2);
-				stringBuffer
-						.append(TreeServices.getDiagramsTree((BlockArchitecture) element, projectName, outputFolder));
-				stringBuffer.append(TEXT_3);
-				{
-					//<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#LogicalName=org.polarsys.kitalpha.doc.gen.business.core.doccontent.treeview.TreeViewControlFooter" args="element:parameter, treeID:treeID, false:collapsed"%>
+        if (element instanceof BlockArchitecture) {
+            if (CapellaHelper.hostDiagrams((BlockArchitecture) element)) {
 
-					InternalPatternContext ictx = (InternalPatternContext) ctx;
-					new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
-					stringBuffer.setLength(0);
+                stringBuffer.append(TEXT_1);
+                {
+                    //<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#LogicalName=org.polarsys.kitalpha.doc.gen.business.core.doccontent.treeview.TreeViewControlHeader" args="element:parameter, treeID:treeID"%>
 
-					final Map<String, Object> callParameters = new HashMap<String, Object>();
-					callParameters.put("parameter", element);
-					callParameters.put("treeID", treeID);
-					callParameters.put("collapsed", false);
-					CallHelper.executeWithParameterInjection(
-							"platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#_-tPnEJ8dEemYav3Xat9ApA",
-							new ExecutionContext((InternalPatternContext) ctx), callParameters);
-					stringBuffer.setLength(0);
-				}
+                    InternalPatternContext ictx = (InternalPatternContext) ctx;
+                    new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
+                    stringBuffer.setLength(0);
 
-				stringBuffer.append(TEXT_3);
+                    final Map<String, Object> callParameters = new HashMap<String, Object>();
+                    callParameters.put("parameter", element);
+                    callParameters.put("treeID", treeID);
+                    CallHelper.executeWithParameterInjection("platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#_V6ybEJ52EemYav3Xat9ApA",
+                            new ExecutionContext((InternalPatternContext) ctx), callParameters);
+                    stringBuffer.setLength(0);
+                }
 
-			}
-		}
+                stringBuffer.append(TEXT_2);
+                stringBuffer.append(TreeServices.getDiagramsTree((BlockArchitecture) element, projectName, outputFolder));
+                stringBuffer.append(TEXT_3);
+                {
+                    //<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#LogicalName=org.polarsys.kitalpha.doc.gen.business.core.doccontent.treeview.TreeViewControlFooter" args="element:parameter, treeID:treeID, false:collapsed"%>
 
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "body", stringBuffer.toString());
-	}
+                    InternalPatternContext ictx = (InternalPatternContext) ctx;
+                    new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
+                    stringBuffer.setLength(0);
 
-	public boolean preCondition(PatternContext ctx) throws Exception {
-		return element instanceof BlockArchitecture && CapellaDocgenPreferenceHelper.isExportDiagramTree();
-	}
+                    final Map<String, Object> callParameters = new HashMap<String, Object>();
+                    callParameters.put("parameter", element);
+                    callParameters.put("treeID", treeID);
+                    callParameters.put("collapsed", false);
+                    CallHelper.executeWithParameterInjection("platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#_-tPnEJ8dEemYav3Xat9ApA",
+                            new ExecutionContext((InternalPatternContext) ctx), callParameters);
+                    stringBuffer.setLength(0);
+                }
+
+                stringBuffer.append(TEXT_3);
+
+            }
+        }
+
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "body", stringBuffer.toString());
+    }
+
+    public boolean preCondition(PatternContext ctx) throws Exception {
+        return element instanceof BlockArchitecture && CapellaDocgenPreferenceHelper.isExportDiagramTree();
+    }
 }

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/foundations/DiagramsGeneration.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/foundations/DiagramsGeneration.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.1.201906060805
+//Generated with EGF 1.6.3.202110291409
 package org.polarsys.capella.docgen.foundations;
 
 import org.eclipse.egf.common.helper.*;
@@ -13,149 +13,150 @@ import org.polarsys.capella.docgen.diagram.CapellaHelper;
 import org.polarsys.capella.docgen.util.*;
 
 public class DiagramsGeneration {
-	protected static String nl;
+    protected static String nl;
 
-	public static synchronized DiagramsGeneration create(String lineSeparator) {
-		nl = lineSeparator;
-		DiagramsGeneration result = new DiagramsGeneration();
-		nl = null;
-		return result;
-	}
+    public static synchronized DiagramsGeneration create(String lineSeparator) {
+        nl = lineSeparator;
+        DiagramsGeneration result = new DiagramsGeneration();
+        nl = null;
+        return result;
+    }
 
-	public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
-	protected final String TEXT_1 = "<h2>Owned diagrams</h2>";
-	protected final String TEXT_2 = NL;
+    public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
 
-	public DiagramsGeneration() {
-		//Here is the constructor
-		StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_1 = "<h2>Owned diagrams</h2>";
 
-		// add initialisation of the pattern variables (declaration has been already done).
+    protected final String TEXT_2 = NL;
 
-	}
+    public DiagramsGeneration() {
+        //Here is the constructor
+        StringBuffer stringBuffer = new StringBuffer();
 
-	public String generate(Object argument) throws Exception {
-		final StringBuffer stringBuffer = new StringBuffer();
+        // add initialisation of the pattern variables (declaration has been already done).
 
-		InternalPatternContext ctx = (InternalPatternContext) argument;
-		Map<String, String> queryCtx = null;
-		IQuery.ParameterDescription paramDesc = null;
-		Node.Container currentNode = ctx.getNode();
+    }
 
-		List<Object> elementList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
+    public String generate(Object argument) throws Exception {
+        final StringBuffer stringBuffer = new StringBuffer();
 
-		for (Object elementParameter : elementList) {
+        InternalPatternContext ctx = (InternalPatternContext) argument;
+        Map<String, String> queryCtx = null;
+        IQuery.ParameterDescription paramDesc = null;
+        Node.Container currentNode = ctx.getNode();
 
-			this.element = (org.polarsys.capella.core.data.capellacore.CapellaElement) elementParameter;
+        List<Object> elementList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
 
-			if (preCondition(ctx)) {
-				ctx.setNode(new Node.Container(currentNode, getClass()));
-				orchestration(ctx);
-			}
+        for (Object elementParameter : elementList) {
 
-		}
-		ctx.setNode(currentNode);
-		if (ctx.useReporter()) {
-			ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
-		}
+            this.element = (org.polarsys.capella.core.data.capellacore.CapellaElement) elementParameter;
 
-		stringBuffer.append(TEXT_2);
-		stringBuffer.append(TEXT_2);
-		return stringBuffer.toString();
-	}
+            if (preCondition(ctx)) {
+                ctx.setNode(new Node.Container(currentNode, getClass()));
+                orchestration(ctx);
+            }
 
-	public String orchestration(PatternContext ctx) throws Exception {
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
+        }
+        ctx.setNode(currentNode);
+        if (ctx.useReporter()) {
+            ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
+        }
 
-		method_setContext(new StringBuffer(), ictx);
+        stringBuffer.append(TEXT_2);
+        stringBuffer.append(TEXT_2);
+        return stringBuffer.toString();
+    }
 
-		method_body(new StringBuffer(), ictx);
+    public String orchestration(PatternContext ctx) throws Exception {
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
 
-		if (ictx.useReporter()) {
-			Map<String, Object> parameterValues = new HashMap<String, Object>();
-			parameterValues.put("element", this.element);
-			String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
-			String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
-			ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
-		}
-		return null;
-	}
+        method_setContext(new StringBuffer(), ictx);
 
-	protected org.polarsys.kitalpha.doc.gen.business.core.util.IFileNameService fileNameService = null;
+        method_body(new StringBuffer(), ictx);
 
-	public void set_fileNameService(org.polarsys.kitalpha.doc.gen.business.core.util.IFileNameService object) {
-		this.fileNameService = object;
-	}
+        if (ictx.useReporter()) {
+            Map<String, Object> parameterValues = new HashMap<String, Object>();
+            parameterValues.put("element", this.element);
+            String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
+            String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
+            ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
+        }
+        return null;
+    }
 
-	protected org.polarsys.kitalpha.doc.gen.business.core.util.IDiagramHelper helper = null;
+    protected org.polarsys.kitalpha.doc.gen.business.core.util.IFileNameService fileNameService = null;
 
-	public void set_helper(org.polarsys.kitalpha.doc.gen.business.core.util.IDiagramHelper object) {
-		this.helper = object;
-	}
+    public void set_fileNameService(org.polarsys.kitalpha.doc.gen.business.core.util.IFileNameService object) {
+        this.fileNameService = object;
+    }
 
-	protected org.polarsys.capella.core.data.capellacore.CapellaElement element = null;
+    protected org.polarsys.kitalpha.doc.gen.business.core.util.IDiagramHelper helper = null;
 
-	public void set_element(org.polarsys.capella.core.data.capellacore.CapellaElement object) {
-		this.element = object;
-	}
+    public void set_helper(org.polarsys.kitalpha.doc.gen.business.core.util.IDiagramHelper object) {
+        this.helper = object;
+    }
 
-	public Map<String, Object> getParameters() {
-		final Map<String, Object> parameters = new HashMap<String, Object>();
-		parameters.put("element", this.element);
-		return parameters;
-	}
+    protected org.polarsys.capella.core.data.capellacore.CapellaElement element = null;
 
-	protected void method_setContext(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+    public void set_element(org.polarsys.capella.core.data.capellacore.CapellaElement object) {
+        this.element = object;
+    }
 
-		fileNameService = DocGenHtmlCapellaUtil.SERVICE;
-		helper = new CapellaDiagramHelper();
+    public Map<String, Object> getParameters() {
+        final Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("element", this.element);
+        return parameters;
+    }
 
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "setContext", stringBuffer.toString());
-	}
+    protected void method_setContext(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-	protected void method_body(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+        fileNameService = DocGenHtmlCapellaUtil.SERVICE;
+        helper = new CapellaDiagramHelper();
 
-		Collection<DRepresentation> diagramList = CapellaHelper.getDiagramForObject(element);
-		if (diagramList.size() >= 1) {
-			stringBuffer.append(TEXT_1);
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "setContext", stringBuffer.toString());
+    }
 
-			// Diagram generation
-			String outputFolder = ctx.getValue("outputFolder").toString();
-			String projectName = ctx.getValue("projectName").toString();
-			for (DRepresentation diagram : diagramList) {
-				if (diagram instanceof DSemanticDiagram) {
-					String generatedFolder = fileNameService.getFileName(((DSemanticDiagram) diagram).getTarget());
-					stringBuffer.append(TEXT_2);
-					{
-						//<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#LogicalName=org.polarsys.kitalpha.doc.gen.business.core.sirius.DiagramGenerator" args="diagram:diagram, outputFolder:outputFolder, projectName:projectName, generatedFolder:generatedFolder, fileNameService:fileNameService, helper:helper"%>
+    protected void method_body(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-						InternalPatternContext ictx = (InternalPatternContext) ctx;
-						new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
-						stringBuffer.setLength(0);
+        Collection<DRepresentation> diagramList = CapellaHelper.getDiagramForObject(element);
+        if (diagramList.size() >= 1) {
+            stringBuffer.append(TEXT_1);
 
-						final Map<String, Object> callParameters = new HashMap<String, Object>();
-						callParameters.put("diagram", diagram);
-						callParameters.put("outputFolder", outputFolder);
-						callParameters.put("projectName", projectName);
-						callParameters.put("generatedFolder", generatedFolder);
-						callParameters.put("fileNameService", fileNameService);
-						callParameters.put("helper", helper);
-						CallHelper.executeWithParameterInjection(
-								"platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#_yyU7IvYiEd-jis7N5RhttA",
-								new ExecutionContext((InternalPatternContext) ctx), callParameters);
-						stringBuffer.setLength(0);
-					}
+            // Diagram generation
+            String outputFolder = ctx.getValue("outputFolder").toString();
+            String projectName = ctx.getValue("projectName").toString();
+            for (DRepresentation diagram : diagramList) {
+                if (diagram instanceof DSemanticDiagram) {
+                    String generatedFolder = fileNameService.getFileName(((DSemanticDiagram) diagram).getTarget());
+                    stringBuffer.append(TEXT_2);
+                    {
+                        //<%@ egf:patternCall patternId="platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#LogicalName=org.polarsys.kitalpha.doc.gen.business.core.sirius.DiagramGenerator" args="diagram:diagram, outputFolder:outputFolder, projectName:projectName, generatedFolder:generatedFolder, fileNameService:fileNameService, helper:helper"%>
 
-				}
-			}
-		}
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "body", stringBuffer.toString());
-	}
+                        InternalPatternContext ictx = (InternalPatternContext) ctx;
+                        new Node.DataLeaf(ictx.getNode(), getClass(), null, stringBuffer.toString());
+                        stringBuffer.setLength(0);
 
-	public boolean preCondition(PatternContext ctx) throws Exception {
-		return true;
-	}
+                        final Map<String, Object> callParameters = new HashMap<String, Object>();
+                        callParameters.put("diagram", diagram);
+                        callParameters.put("outputFolder", outputFolder);
+                        callParameters.put("projectName", projectName);
+                        callParameters.put("generatedFolder", generatedFolder);
+                        callParameters.put("fileNameService", fileNameService);
+                        callParameters.put("helper", helper);
+                        CallHelper.executeWithParameterInjection("platform:/plugin/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore#_yyU7IvYiEd-jis7N5RhttA",
+                                new ExecutionContext((InternalPatternContext) ctx), callParameters);
+                        stringBuffer.setLength(0);
+                    }
+
+                }
+            }
+        }
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "body", stringBuffer.toString());
+    }
+
+    public boolean preCondition(PatternContext ctx) throws Exception {
+        return true;
+    }
 }

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/foundations/InterestedDiagrmsGeneration.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/foundations/InterestedDiagrmsGeneration.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.2.202001031546
+//Generated with EGF 1.6.3.202110291409
 package org.polarsys.capella.docgen.foundations;
 
 import org.eclipse.sirius.viewpoint.DRepresentationDescriptor;
@@ -33,153 +33,160 @@ import org.polarsys.capella.docgen.util.CapellaLabelProviderHelper;
 import org.polarsys.kitalpha.doc.gen.business.core.preference.helper.DocgenDiagramPreferencesHelper;
 
 public class InterestedDiagrmsGeneration {
-	protected static String nl;
+    protected static String nl;
 
-	public static synchronized InterestedDiagrmsGeneration create(String lineSeparator) {
-		nl = lineSeparator;
-		InterestedDiagrmsGeneration result = new InterestedDiagrmsGeneration();
-		nl = null;
-		return result;
-	}
+    public static synchronized InterestedDiagrmsGeneration create(String lineSeparator) {
+        nl = lineSeparator;
+        InterestedDiagrmsGeneration result = new InterestedDiagrmsGeneration();
+        nl = null;
+        return result;
+    }
 
-	public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
-	protected final String TEXT_1 = "";
-	protected final String TEXT_2 = NL;
-	protected final String TEXT_3 = NL + "\t<h2>Diagrams interesting for \"";
-	protected final String TEXT_4 = "\"</h2>" + NL + "\t";
-	protected final String TEXT_5 = NL + "\t\t<div>" + NL + "\t\t\t";
-	protected final String TEXT_6 = NL + "\t\t\t<p class=\"diagram-name\" id=\"";
-	protected final String TEXT_7 = "\">";
-	protected final String TEXT_8 = "</p>" + NL + "\t\t\t<p class=\"diagram\">" + NL + "\t\t\t\t";
-	protected final String TEXT_9 = NL + "\t\t\t\t";
-	protected final String TEXT_10 = NL + "\t\t\t\t<br/>" + NL + "\t\t\t\t<br/>" + NL + "\t\t\t</p>" + NL + "\t\t</div>"
-			+ NL + "\t";
+    public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
 
-	public InterestedDiagrmsGeneration() {
-		//Here is the constructor
-		StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_1 = "";
 
-		// add initialisation of the pattern variables (declaration has been already done).
+    protected final String TEXT_2 = NL;
 
-	}
+    protected final String TEXT_3 = NL + "\t<h2>Diagrams interesting for \"";
 
-	public String generate(Object argument) throws Exception {
-		final StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_4 = "\"</h2>" + NL + "\t";
 
-		InternalPatternContext ctx = (InternalPatternContext) argument;
-		Map<String, String> queryCtx = null;
-		IQuery.ParameterDescription paramDesc = null;
-		Node.Container currentNode = ctx.getNode();
+    protected final String TEXT_5 = NL + "\t\t<div>" + NL + "\t\t\t";
 
-		List<Object> elementList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
+    protected final String TEXT_6 = NL + "\t\t\t<p class=\"diagram-name\" id=\"";
 
-		for (Object elementParameter : elementList) {
+    protected final String TEXT_7 = "\">";
 
-			this.element = (org.polarsys.capella.core.data.capellacore.CapellaElement) elementParameter;
+    protected final String TEXT_8 = "</p>" + NL + "\t\t\t<p class=\"diagram\">" + NL + "\t\t\t\t";
 
-			if (preCondition(ctx)) {
-				ctx.setNode(new Node.Container(currentNode, getClass()));
-				orchestration(ctx);
-			}
+    protected final String TEXT_9 = NL + "\t\t\t\t";
 
-		}
-		ctx.setNode(currentNode);
-		if (ctx.useReporter()) {
-			ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
-		}
+    protected final String TEXT_10 = NL + "\t\t\t\t<br/>" + NL + "\t\t\t\t<br/>" + NL + "\t\t\t</p>" + NL + "\t\t</div>" + NL + "\t";
 
-		stringBuffer.append(TEXT_2);
-		stringBuffer.append(TEXT_2);
-		return stringBuffer.toString();
-	}
+    public InterestedDiagrmsGeneration() {
+        //Here is the constructor
+        StringBuffer stringBuffer = new StringBuffer();
 
-	public String orchestration(PatternContext ctx) throws Exception {
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
+        // add initialisation of the pattern variables (declaration has been already done).
 
-		method_setContext(new StringBuffer(), ictx);
+    }
 
-		method_body(new StringBuffer(), ictx);
+    public String generate(Object argument) throws Exception {
+        final StringBuffer stringBuffer = new StringBuffer();
 
-		if (ictx.useReporter()) {
-			Map<String, Object> parameterValues = new HashMap<String, Object>();
-			parameterValues.put("element", this.element);
-			String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
-			String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
-			ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
-		}
-		return null;
-	}
+        InternalPatternContext ctx = (InternalPatternContext) argument;
+        Map<String, String> queryCtx = null;
+        IQuery.ParameterDescription paramDesc = null;
+        Node.Container currentNode = ctx.getNode();
 
-	protected org.polarsys.kitalpha.doc.gen.business.core.util.IFileNameService fileNameService = null;
+        List<Object> elementList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
 
-	public void set_fileNameService(org.polarsys.kitalpha.doc.gen.business.core.util.IFileNameService object) {
-		this.fileNameService = object;
-	}
+        for (Object elementParameter : elementList) {
 
-	protected org.polarsys.kitalpha.doc.gen.business.core.util.IDiagramHelper helper = null;
+            this.element = (org.polarsys.capella.core.data.capellacore.CapellaElement) elementParameter;
 
-	public void set_helper(org.polarsys.kitalpha.doc.gen.business.core.util.IDiagramHelper object) {
-		this.helper = object;
-	}
+            if (preCondition(ctx)) {
+                ctx.setNode(new Node.Container(currentNode, getClass()));
+                orchestration(ctx);
+            }
 
-	protected org.polarsys.capella.core.data.capellacore.CapellaElement element = null;
+        }
+        ctx.setNode(currentNode);
+        if (ctx.useReporter()) {
+            ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
+        }
 
-	public void set_element(org.polarsys.capella.core.data.capellacore.CapellaElement object) {
-		this.element = object;
-	}
+        stringBuffer.append(TEXT_2);
+        stringBuffer.append(TEXT_2);
+        return stringBuffer.toString();
+    }
 
-	public Map<String, Object> getParameters() {
-		final Map<String, Object> parameters = new HashMap<String, Object>();
-		parameters.put("element", this.element);
-		return parameters;
-	}
+    public String orchestration(PatternContext ctx) throws Exception {
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
 
-	protected void method_setContext(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+        method_setContext(new StringBuffer(), ictx);
 
-		fileNameService = DocGenHtmlCapellaUtil.SERVICE;
-		helper = new CapellaDiagramHelper();
+        method_body(new StringBuffer(), ictx);
 
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "setContext", stringBuffer.toString());
-	}
+        if (ictx.useReporter()) {
+            Map<String, Object> parameterValues = new HashMap<String, Object>();
+            parameterValues.put("element", this.element);
+            String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
+            String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
+            ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
+        }
+        return null;
+    }
 
-	protected void method_body(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+    protected org.polarsys.kitalpha.doc.gen.business.core.util.IFileNameService fileNameService = null;
 
-		Collection<DDiagram> interestedDiagrams = CapellaHelper.getAllInterestedRepresentationsFor(element);
-		stringBuffer.append(TEXT_1);
-		List<DSemanticDiagram> exportableDiagrams = interestedDiagrams.parallelStream()
-				.filter(diagram -> diagram instanceof DSemanticDiagram).map(diagram -> (DSemanticDiagram) diagram)
-				.filter(diagram -> GenerationGlobalScope.getInstance().isCopyInScope(diagram.getTarget()))
-				.collect(Collectors.toList());
-		stringBuffer.append(TEXT_2);
-		if (!exportableDiagrams.isEmpty()) {
-			stringBuffer.append(TEXT_3);
-			stringBuffer.append(CapellaLabelProviderHelper.getText(element));
-			stringBuffer.append(TEXT_4);
-			exportableDiagrams.forEach(diagram -> {
-				stringBuffer.append(TEXT_5);
-				String id = DiagramSessionHelper.getID(diagram);
-				DRepresentationQuery rep2descQuery = new DRepresentationQuery(diagram);
-				DRepresentationDescriptor result = rep2descQuery.getRepresentationDescriptor();
-				String name = (result == null) ? id : result.getName();
+    public void set_fileNameService(org.polarsys.kitalpha.doc.gen.business.core.util.IFileNameService object) {
+        this.fileNameService = object;
+    }
 
-				stringBuffer.append(TEXT_6);
-				stringBuffer.append(id);
-				stringBuffer.append(TEXT_7);
-				stringBuffer.append(EscapeChars.forHTML(name));
-				stringBuffer.append(TEXT_8);
-				String generatedFolder = fileNameService.getFileName(diagram.getTarget());
-				stringBuffer.append(TEXT_9);
-				stringBuffer.append(CapellaServices.getImageLinkForDiagram(generatedFolder, diagram));
-				stringBuffer.append(TEXT_10);
-			});
-		}
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "body", stringBuffer.toString());
-	}
+    protected org.polarsys.kitalpha.doc.gen.business.core.util.IDiagramHelper helper = null;
 
-	public boolean preCondition(PatternContext ctx) throws Exception {
-		return true;
-	}
+    public void set_helper(org.polarsys.kitalpha.doc.gen.business.core.util.IDiagramHelper object) {
+        this.helper = object;
+    }
+
+    protected org.polarsys.capella.core.data.capellacore.CapellaElement element = null;
+
+    public void set_element(org.polarsys.capella.core.data.capellacore.CapellaElement object) {
+        this.element = object;
+    }
+
+    public Map<String, Object> getParameters() {
+        final Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("element", this.element);
+        return parameters;
+    }
+
+    protected void method_setContext(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+
+        fileNameService = DocGenHtmlCapellaUtil.SERVICE;
+        helper = new CapellaDiagramHelper();
+
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "setContext", stringBuffer.toString());
+    }
+
+    protected void method_body(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+
+        Collection<DDiagram> interestedDiagrams = CapellaHelper.getAllInterestedRepresentationsFor(element);
+        stringBuffer.append(TEXT_1);
+        List<DSemanticDiagram> exportableDiagrams = interestedDiagrams.parallelStream().filter(diagram -> diagram instanceof DSemanticDiagram).map(diagram -> (DSemanticDiagram) diagram)
+                .filter(diagram -> GenerationGlobalScope.getInstance().isCopyInScope(diagram.getTarget())).collect(Collectors.toList());
+        stringBuffer.append(TEXT_2);
+        if (!exportableDiagrams.isEmpty()) {
+            stringBuffer.append(TEXT_3);
+            stringBuffer.append(CapellaLabelProviderHelper.getText(element));
+            stringBuffer.append(TEXT_4);
+            exportableDiagrams.forEach(diagram -> {
+                stringBuffer.append(TEXT_5);
+                String id = DiagramSessionHelper.getID(diagram);
+                DRepresentationQuery rep2descQuery = new DRepresentationQuery(diagram);
+                DRepresentationDescriptor result = rep2descQuery.getRepresentationDescriptor();
+                String name = (result == null) ? id : result.getName();
+
+                stringBuffer.append(TEXT_6);
+                stringBuffer.append(id);
+                stringBuffer.append(TEXT_7);
+                stringBuffer.append(EscapeChars.forHTML(name));
+                stringBuffer.append(TEXT_8);
+                String generatedFolder = fileNameService.getFileName(diagram.getTarget());
+                stringBuffer.append(TEXT_9);
+                stringBuffer.append(CapellaServices.getImageLinkForDiagram(generatedFolder, diagram));
+                stringBuffer.append(TEXT_10);
+            });
+        }
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "body", stringBuffer.toString());
+    }
+
+    public boolean preCondition(PatternContext ctx) throws Exception {
+        return true;
+    }
 }

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/foundations/NamedElementDocGen.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/foundations/NamedElementDocGen.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.2.202001031546
+//Generated with EGF 1.6.3.202110291409
 package org.polarsys.capella.docgen.foundations;
 
 import org.eclipse.egf.common.helper.*;
@@ -13,95 +13,97 @@ import org.polarsys.capella.docgen.util.CapellaLabelProviderHelper;
 import org.polarsys.kitalpha.doc.gen.business.core.util.EscapeChars;
 
 public class NamedElementDocGen extends org.polarsys.capella.docgen.foundations.CapellaElementDocGen {
-	protected static String nl;
+    protected static String nl;
 
-	public static synchronized NamedElementDocGen create(String lineSeparator) {
-		nl = lineSeparator;
-		NamedElementDocGen result = new NamedElementDocGen();
-		nl = null;
-		return result;
-	}
+    public static synchronized NamedElementDocGen create(String lineSeparator) {
+        nl = lineSeparator;
+        NamedElementDocGen result = new NamedElementDocGen();
+        nl = null;
+        return result;
+    }
 
-	public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
-	protected final String TEXT_1 = NL;
-	protected final String TEXT_2 = NL;
+    public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
 
-	public NamedElementDocGen() {
-		//Here is the constructor
-		StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_1 = NL;
 
-		// add initialisation of the pattern variables (declaration has been already done).
+    protected final String TEXT_2 = NL;
 
-	}
+    public NamedElementDocGen() {
+        //Here is the constructor
+        StringBuffer stringBuffer = new StringBuffer();
 
-	public String generate(Object argument) throws Exception {
-		final StringBuffer stringBuffer = new StringBuffer();
+        // add initialisation of the pattern variables (declaration has been already done).
 
-		InternalPatternContext ctx = (InternalPatternContext) argument;
-		Map<String, String> queryCtx = null;
-		IQuery.ParameterDescription paramDesc = null;
-		Node.Container currentNode = ctx.getNode();
+    }
 
-		if (preCondition(ctx)) {
-			ctx.setNode(new Node.Container(currentNode, getClass()));
-			orchestration(ctx);
-		}
+    public String generate(Object argument) throws Exception {
+        final StringBuffer stringBuffer = new StringBuffer();
 
-		ctx.setNode(currentNode);
-		if (ctx.useReporter()) {
-			ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
-		}
+        InternalPatternContext ctx = (InternalPatternContext) argument;
+        Map<String, String> queryCtx = null;
+        IQuery.ParameterDescription paramDesc = null;
+        Node.Container currentNode = ctx.getNode();
 
-		stringBuffer.append(TEXT_2);
-		stringBuffer.append(TEXT_2);
-		return stringBuffer.toString();
-	}
+        if (preCondition(ctx)) {
+            ctx.setNode(new Node.Container(currentNode, getClass()));
+            orchestration(ctx);
+        }
 
-	public String orchestration(PatternContext ctx) throws Exception {
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
+        ctx.setNode(currentNode);
+        if (ctx.useReporter()) {
+            ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
+        }
 
-		super.orchestration(new SuperOrchestrationContext(ictx));
+        stringBuffer.append(TEXT_2);
+        stringBuffer.append(TEXT_2);
+        return stringBuffer.toString();
+    }
 
-		return null;
-	}
+    public String orchestration(PatternContext ctx) throws Exception {
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
 
-	public Map<String, Object> getParameters() {
-		final Map<String, Object> parameters = new HashMap<String, Object>();
-		return parameters;
-	}
+        super.orchestration(new SuperOrchestrationContext(ictx));
 
-	protected void method_setContext(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+        return null;
+    }
 
-		String elementName = EscapeChars.forHTML(CapellaLabelProviderHelper.getText(element));
-		String elementType = EscapeChars.forHTML(element.eClass().getName());
-		/*NamedElement namedElement = ((NamedElement) element);
-		
-		StringBuffer buffer = new StringBuffer (namedElement.getName());
-		
-		buffer
-			.append (" [")
-			.append (namedElement.eClass().getName())
-			.append ("]");
-		*/
-		title = "Capella - " + DocGenHtmlUtil.getModelName(element) + " - " + elementType + " " + elementName;
+    public Map<String, Object> getParameters() {
+        final Map<String, Object> parameters = new HashMap<String, Object>();
+        return parameters;
+    }
 
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "setContext", stringBuffer.toString());
-	}
+    protected void method_setContext(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-	protected void method_setFileName(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+        String elementName = EscapeChars.forHTML(CapellaLabelProviderHelper.getText(element));
+        String elementType = EscapeChars.forHTML(element.eClass().getName());
+        /*NamedElement namedElement = ((NamedElement) element);
+        
+        StringBuffer buffer = new StringBuffer (namedElement.getName());
+        
+        buffer
+        	.append (" [")
+        	.append (namedElement.eClass().getName())
+        	.append ("]");
+        */
+        title = "Capella - " + DocGenHtmlUtil.getModelName(element) + " - " + elementType + " " + elementName;
 
-		fileName = DocGenHtmlCapellaUtil.getNamedElementRootFileName(element);
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "setContext", stringBuffer.toString());
+    }
 
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "setFileName", stringBuffer.toString());
-	}
+    protected void method_setFileName(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-	protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+        fileName = DocGenHtmlCapellaUtil.getNamedElementRootFileName(element);
 
-		super.method_content(new StringBuffer(), ctx);
-		stringBuffer.append(TEXT_1);
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
-	}
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "setFileName", stringBuffer.toString());
+    }
+
+    protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+
+        super.method_content(new StringBuffer(), ctx);
+        stringBuffer.append(TEXT_1);
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
+    }
 }

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/foundations/PresentedDiagrmsGeneration.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/foundations/PresentedDiagrmsGeneration.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.2.202001031546
+//Generated with EGF 1.6.3.202110291409
 package org.polarsys.capella.docgen.foundations;
 
 import org.eclipse.egf.common.helper.*;
@@ -19,147 +19,153 @@ import org.polarsys.capella.docgen.util.CapellaLabelProviderHelper;
 import org.polarsys.kitalpha.doc.gen.business.core.preference.helper.DocgenDiagramPreferencesHelper;
 
 public class PresentedDiagrmsGeneration {
-	protected static String nl;
+    protected static String nl;
 
-	public static synchronized PresentedDiagrmsGeneration create(String lineSeparator) {
-		nl = lineSeparator;
-		PresentedDiagrmsGeneration result = new PresentedDiagrmsGeneration();
-		nl = null;
-		return result;
-	}
+    public static synchronized PresentedDiagrmsGeneration create(String lineSeparator) {
+        nl = lineSeparator;
+        PresentedDiagrmsGeneration result = new PresentedDiagrmsGeneration();
+        nl = null;
+        return result;
+    }
 
-	public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
-	protected final String TEXT_1 = "<h2>Diagrams displaying \"";
-	protected final String TEXT_2 = "\"</h2>" + NL + "<ul>";
-	protected final String TEXT_3 = NL + "<li>";
-	protected final String TEXT_4 = NL;
-	protected final String TEXT_5 = " ";
-	protected final String TEXT_6 = NL + "</li>";
-	protected final String TEXT_7 = NL + "</ul>";
+    public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
 
-	public PresentedDiagrmsGeneration() {
-		//Here is the constructor
-		StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_1 = "<h2>Diagrams displaying \"";
 
-		// add initialisation of the pattern variables (declaration has been already done).
+    protected final String TEXT_2 = "\"</h2>" + NL + "<ul>";
 
-	}
+    protected final String TEXT_3 = NL + "<li>";
 
-	public String generate(Object argument) throws Exception {
-		final StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_4 = NL;
 
-		InternalPatternContext ctx = (InternalPatternContext) argument;
-		Map<String, String> queryCtx = null;
-		IQuery.ParameterDescription paramDesc = null;
-		Node.Container currentNode = ctx.getNode();
+    protected final String TEXT_5 = " ";
 
-		List<Object> elementList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
+    protected final String TEXT_6 = NL + "</li>";
 
-		for (Object elementParameter : elementList) {
+    protected final String TEXT_7 = NL + "</ul>";
 
-			this.element = (org.polarsys.capella.core.data.capellacore.CapellaElement) elementParameter;
+    public PresentedDiagrmsGeneration() {
+        //Here is the constructor
+        StringBuffer stringBuffer = new StringBuffer();
 
-			if (preCondition(ctx)) {
-				ctx.setNode(new Node.Container(currentNode, getClass()));
-				orchestration(ctx);
-			}
+        // add initialisation of the pattern variables (declaration has been already done).
 
-		}
-		ctx.setNode(currentNode);
-		if (ctx.useReporter()) {
-			ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
-		}
+    }
 
-		stringBuffer.append(TEXT_4);
-		stringBuffer.append(TEXT_4);
-		return stringBuffer.toString();
-	}
+    public String generate(Object argument) throws Exception {
+        final StringBuffer stringBuffer = new StringBuffer();
 
-	public String orchestration(PatternContext ctx) throws Exception {
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
+        InternalPatternContext ctx = (InternalPatternContext) argument;
+        Map<String, String> queryCtx = null;
+        IQuery.ParameterDescription paramDesc = null;
+        Node.Container currentNode = ctx.getNode();
 
-		method_setContext(new StringBuffer(), ictx);
+        List<Object> elementList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
 
-		method_body(new StringBuffer(), ictx);
+        for (Object elementParameter : elementList) {
 
-		if (ictx.useReporter()) {
-			Map<String, Object> parameterValues = new HashMap<String, Object>();
-			parameterValues.put("element", this.element);
-			String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
-			String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
-			ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
-		}
-		return null;
-	}
+            this.element = (org.polarsys.capella.core.data.capellacore.CapellaElement) elementParameter;
 
-	protected org.polarsys.kitalpha.doc.gen.business.core.util.IFileNameService fileNameService = null;
+            if (preCondition(ctx)) {
+                ctx.setNode(new Node.Container(currentNode, getClass()));
+                orchestration(ctx);
+            }
 
-	public void set_fileNameService(org.polarsys.kitalpha.doc.gen.business.core.util.IFileNameService object) {
-		this.fileNameService = object;
-	}
+        }
+        ctx.setNode(currentNode);
+        if (ctx.useReporter()) {
+            ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
+        }
 
-	protected org.polarsys.kitalpha.doc.gen.business.core.util.IDiagramHelper helper = null;
+        stringBuffer.append(TEXT_4);
+        stringBuffer.append(TEXT_4);
+        return stringBuffer.toString();
+    }
 
-	public void set_helper(org.polarsys.kitalpha.doc.gen.business.core.util.IDiagramHelper object) {
-		this.helper = object;
-	}
+    public String orchestration(PatternContext ctx) throws Exception {
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
 
-	protected org.polarsys.capella.core.data.capellacore.CapellaElement element = null;
+        method_setContext(new StringBuffer(), ictx);
 
-	public void set_element(org.polarsys.capella.core.data.capellacore.CapellaElement object) {
-		this.element = object;
-	}
+        method_body(new StringBuffer(), ictx);
 
-	public Map<String, Object> getParameters() {
-		final Map<String, Object> parameters = new HashMap<String, Object>();
-		parameters.put("element", this.element);
-		return parameters;
-	}
+        if (ictx.useReporter()) {
+            Map<String, Object> parameterValues = new HashMap<String, Object>();
+            parameterValues.put("element", this.element);
+            String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
+            String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
+            ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
+        }
+        return null;
+    }
 
-	protected void method_setContext(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+    protected org.polarsys.kitalpha.doc.gen.business.core.util.IFileNameService fileNameService = null;
 
-		fileNameService = DocGenHtmlCapellaUtil.SERVICE;
-		helper = new CapellaDiagramHelper();
+    public void set_fileNameService(org.polarsys.kitalpha.doc.gen.business.core.util.IFileNameService object) {
+        this.fileNameService = object;
+    }
 
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "setContext", stringBuffer.toString());
-	}
+    protected org.polarsys.kitalpha.doc.gen.business.core.util.IDiagramHelper helper = null;
 
-	protected void method_body(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+    public void set_helper(org.polarsys.kitalpha.doc.gen.business.core.util.IDiagramHelper object) {
+        this.helper = object;
+    }
 
-		Set<DSemanticDiagram> diagramSet = CapellaHelper.getDiagramContainingObject(element);
-		if (diagramSet.size() >= 1) {
-			stringBuffer.append(TEXT_1);
-			stringBuffer.append(CapellaLabelProviderHelper.getText(element));
-			stringBuffer.append(TEXT_2);
-			for (DSemanticDiagram diagram : diagramSet) {
-				EObject eObject = diagram.getTarget();
-				if (eObject == null) {
-					//The diagram could not be exported
-					continue;
-				}
-				String generatedFolder = fileNameService.getFileName(eObject);
-				stringBuffer.append(TEXT_3);
-				if (eObject instanceof NamedElement
-						&& DocGenHtmlCapellaControl.isPageCandidate((CapellaElement) eObject)) {
-					stringBuffer.append(TEXT_4);
-					stringBuffer.append(CapellaServices.getHyperlinkFromElement(diagram));
-					stringBuffer.append(TEXT_5);
-				} else {
-					stringBuffer.append(TEXT_4);
-					stringBuffer.append(CapellaLabelProviderHelper.getText(eObject));
-				}
-				stringBuffer.append(TEXT_6);
+    protected org.polarsys.capella.core.data.capellacore.CapellaElement element = null;
 
-			}
-			stringBuffer.append(TEXT_7);
-		}
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "body", stringBuffer.toString());
-	}
+    public void set_element(org.polarsys.capella.core.data.capellacore.CapellaElement object) {
+        this.element = object;
+    }
 
-	public boolean preCondition(PatternContext ctx) throws Exception {
-		return DocgenDiagramPreferencesHelper.getExportDiagram();
-	}
+    public Map<String, Object> getParameters() {
+        final Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("element", this.element);
+        return parameters;
+    }
+
+    protected void method_setContext(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+
+        fileNameService = DocGenHtmlCapellaUtil.SERVICE;
+        helper = new CapellaDiagramHelper();
+
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "setContext", stringBuffer.toString());
+    }
+
+    protected void method_body(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+
+        Set<DSemanticDiagram> diagramSet = CapellaHelper.getDiagramContainingObject(element);
+        if (diagramSet.size() >= 1) {
+            stringBuffer.append(TEXT_1);
+            stringBuffer.append(CapellaLabelProviderHelper.getText(element));
+            stringBuffer.append(TEXT_2);
+            for (DSemanticDiagram diagram : diagramSet) {
+                EObject eObject = diagram.getTarget();
+                if (eObject == null) {
+                    //The diagram could not be exported
+                    continue;
+                }
+                String generatedFolder = fileNameService.getFileName(eObject);
+                stringBuffer.append(TEXT_3);
+                if (eObject instanceof NamedElement && DocGenHtmlCapellaControl.isPageCandidate((CapellaElement) eObject)) {
+                    stringBuffer.append(TEXT_4);
+                    stringBuffer.append(CapellaServices.getHyperlinkFromElement(diagram));
+                    stringBuffer.append(TEXT_5);
+                } else {
+                    stringBuffer.append(TEXT_4);
+                    stringBuffer.append(CapellaLabelProviderHelper.getText(eObject));
+                }
+                stringBuffer.append(TEXT_6);
+
+            }
+            stringBuffer.append(TEXT_7);
+        }
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "body", stringBuffer.toString());
+    }
+
+    public boolean preCondition(PatternContext ctx) throws Exception {
+        return DocgenDiagramPreferencesHelper.getExportDiagram();
+    }
 }

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/foundations/PropertyValueGen.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/foundations/PropertyValueGen.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.2.202001031546
+//Generated with EGF 1.6.3.202110291409
 package org.polarsys.capella.docgen.foundations;
 
 import java.util.*;
@@ -11,220 +11,225 @@ import org.polarsys.capella.core.data.capellacore.PropertyValueGroup;
 import org.polarsys.capella.docgen.util.pattern.helper.PropertyValueHelper;
 
 public class PropertyValueGen {
-	protected static String nl;
+    protected static String nl;
 
-	public static synchronized PropertyValueGen create(String lineSeparator) {
-		nl = lineSeparator;
-		PropertyValueGen result = new PropertyValueGen();
-		nl = null;
-		return result;
-	}
+    public static synchronized PropertyValueGen create(String lineSeparator) {
+        nl = lineSeparator;
+        PropertyValueGen result = new PropertyValueGen();
+        nl = null;
+        return result;
+    }
 
-	public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
-	protected final String TEXT_1 = "\t<table style=\"border:none\">" + NL + "\t\t<tr style=\"border:none\">" + NL
-			+ "\t\t\t<td style=\"border:none; vertical-align:top\">" + NL + "\t";
-	protected final String TEXT_2 = NL + "\t<h";
-	protected final String TEXT_3 = ">Property Values</h";
-	protected final String TEXT_4 = ">" + NL + "\t<table max-width=screen.width>" + NL + "\t   <thead> " + NL
-			+ "\t       <tr>" + NL + "\t       \t   <th>Relation</th>\t" + NL + "\t           <th>Name</th>" + NL
-			+ "\t           <th>Value</th>" + NL + "\t           <th>Description</th>" + NL + "\t       </tr>" + NL
-			+ "\t   </thead>" + NL + "\t   <tbody>" + NL + "\t";
-	protected final String TEXT_5 = NL + "\t";
-	protected final String TEXT_6 = NL + "\t</tbody>" + NL + "\t</table>" + NL + "\t";
-	protected final String TEXT_7 = NL + "\t\t\t</td>" + NL + "\t\t\t<td style=\"border:none; vertical-align:top\">"
-			+ NL + "\t";
-	protected final String TEXT_8 = ">Property Value Groups</h";
-	protected final String TEXT_9 = NL + "\t\t\t</td>" + NL + "\t\t</tr>" + NL + "\t</table>" + NL + "\t";
-	protected final String TEXT_10 = NL;
+    public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
 
-	public PropertyValueGen() {
-		//Here is the constructor
-		StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_1 = "\t<table style=\"border:none\">" + NL + "\t\t<tr style=\"border:none\">" + NL + "\t\t\t<td style=\"border:none; vertical-align:top\">" + NL + "\t";
 
-		// add initialisation of the pattern variables (declaration has been already done).
+    protected final String TEXT_2 = NL + "\t<h";
 
-	}
+    protected final String TEXT_3 = ">Property Values</h";
 
-	public String generate(Object argument) throws Exception {
-		final StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_4 = ">" + NL + "\t<table max-width=screen.width>" + NL + "\t   <thead> " + NL + "\t       <tr>" + NL + "\t       \t   <th>Relation</th>\t" + NL
+            + "\t           <th>Name</th>" + NL + "\t           <th>Value</th>" + NL + "\t           <th>Description</th>" + NL + "\t       </tr>" + NL + "\t   </thead>" + NL + "\t   <tbody>" + NL
+            + "\t";
 
-		InternalPatternContext ctx = (InternalPatternContext) argument;
-		Map<String, String> queryCtx = null;
-		IQuery.ParameterDescription paramDesc = null;
-		Node.Container currentNode = ctx.getNode();
+    protected final String TEXT_5 = NL + "\t";
 
-		List<Object> elementList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
-		List<Object> outputFolderList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
-		List<Object> projectNameList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
-		List<Object> sectionLevelParameterList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
-		List<Object> displayAsRowParameterList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
+    protected final String TEXT_6 = NL + "\t</tbody>" + NL + "\t</table>" + NL + "\t";
 
-		for (Object elementParameter : elementList) {
-			for (Object outputFolderParameter : outputFolderList) {
-				for (Object projectNameParameter : projectNameList) {
-					for (Object sectionLevelParameterParameter : sectionLevelParameterList) {
-						for (Object displayAsRowParameterParameter : displayAsRowParameterList) {
+    protected final String TEXT_7 = NL + "\t\t\t</td>" + NL + "\t\t\t<td style=\"border:none; vertical-align:top\">" + NL + "\t";
 
-							this.element = (org.polarsys.capella.core.data.capellacore.CapellaElement) elementParameter;
-							this.outputFolder = (java.lang.String) outputFolderParameter;
-							this.projectName = (java.lang.String) projectNameParameter;
-							this.sectionLevelParameter = (java.lang.Integer) sectionLevelParameterParameter;
-							this.displayAsRowParameter = (java.lang.Boolean) displayAsRowParameterParameter;
+    protected final String TEXT_8 = ">Property Value Groups</h";
 
-							if (preCondition(ctx)) {
-								ctx.setNode(new Node.Container(currentNode, getClass()));
-								orchestration(ctx);
-							}
+    protected final String TEXT_9 = NL + "\t\t\t</td>" + NL + "\t\t</tr>" + NL + "\t</table>" + NL + "\t";
 
-						}
-					}
-				}
-			}
-		}
-		ctx.setNode(currentNode);
-		if (ctx.useReporter()) {
-			ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
-		}
+    protected final String TEXT_10 = NL;
 
-		stringBuffer.append(TEXT_10);
-		stringBuffer.append(TEXT_10);
-		return stringBuffer.toString();
-	}
+    public PropertyValueGen() {
+        //Here is the constructor
+        StringBuffer stringBuffer = new StringBuffer();
 
-	public String orchestration(PatternContext ctx) throws Exception {
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
+        // add initialisation of the pattern variables (declaration has been already done).
 
-		method_body(new StringBuffer(), ictx);
+    }
 
-		if (ictx.useReporter()) {
-			Map<String, Object> parameterValues = new HashMap<String, Object>();
-			parameterValues.put("element", this.element);
-			parameterValues.put("outputFolder", this.outputFolder);
-			parameterValues.put("projectName", this.projectName);
-			parameterValues.put("sectionLevelParameter", this.sectionLevelParameter);
-			parameterValues.put("displayAsRowParameter", this.displayAsRowParameter);
-			String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
-			String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
-			ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
-		}
-		return null;
-	}
+    public String generate(Object argument) throws Exception {
+        final StringBuffer stringBuffer = new StringBuffer();
 
-	protected org.polarsys.capella.core.data.capellacore.CapellaElement element = null;
+        InternalPatternContext ctx = (InternalPatternContext) argument;
+        Map<String, String> queryCtx = null;
+        IQuery.ParameterDescription paramDesc = null;
+        Node.Container currentNode = ctx.getNode();
 
-	public void set_element(org.polarsys.capella.core.data.capellacore.CapellaElement object) {
-		this.element = object;
-	}
+        List<Object> elementList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
+        List<Object> outputFolderList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
+        List<Object> projectNameList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
+        List<Object> sectionLevelParameterList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
+        List<Object> displayAsRowParameterList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
 
-	protected java.lang.String outputFolder = null;
+        for (Object elementParameter : elementList) {
+            for (Object outputFolderParameter : outputFolderList) {
+                for (Object projectNameParameter : projectNameList) {
+                    for (Object sectionLevelParameterParameter : sectionLevelParameterList) {
+                        for (Object displayAsRowParameterParameter : displayAsRowParameterList) {
 
-	public void set_outputFolder(java.lang.String object) {
-		this.outputFolder = object;
-	}
+                            this.element = (org.polarsys.capella.core.data.capellacore.CapellaElement) elementParameter;
+                            this.outputFolder = (java.lang.String) outputFolderParameter;
+                            this.projectName = (java.lang.String) projectNameParameter;
+                            this.sectionLevelParameter = (java.lang.Integer) sectionLevelParameterParameter;
+                            this.displayAsRowParameter = (java.lang.Boolean) displayAsRowParameterParameter;
 
-	protected java.lang.String projectName = null;
+                            if (preCondition(ctx)) {
+                                ctx.setNode(new Node.Container(currentNode, getClass()));
+                                orchestration(ctx);
+                            }
 
-	public void set_projectName(java.lang.String object) {
-		this.projectName = object;
-	}
+                        }
+                    }
+                }
+            }
+        }
+        ctx.setNode(currentNode);
+        if (ctx.useReporter()) {
+            ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
+        }
 
-	protected java.lang.Integer sectionLevelParameter = null;
+        stringBuffer.append(TEXT_10);
+        stringBuffer.append(TEXT_10);
+        return stringBuffer.toString();
+    }
 
-	public void set_sectionLevelParameter(java.lang.Integer object) {
-		this.sectionLevelParameter = object;
-	}
+    public String orchestration(PatternContext ctx) throws Exception {
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
 
-	protected java.lang.Boolean displayAsRowParameter = null;
+        method_body(new StringBuffer(), ictx);
 
-	public void set_displayAsRowParameter(java.lang.Boolean object) {
-		this.displayAsRowParameter = object;
-	}
+        if (ictx.useReporter()) {
+            Map<String, Object> parameterValues = new HashMap<String, Object>();
+            parameterValues.put("element", this.element);
+            parameterValues.put("outputFolder", this.outputFolder);
+            parameterValues.put("projectName", this.projectName);
+            parameterValues.put("sectionLevelParameter", this.sectionLevelParameter);
+            parameterValues.put("displayAsRowParameter", this.displayAsRowParameter);
+            String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
+            String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
+            ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
+        }
+        return null;
+    }
 
-	public Map<String, Object> getParameters() {
-		final Map<String, Object> parameters = new HashMap<String, Object>();
-		parameters.put("element", this.element);
-		parameters.put("outputFolder", this.outputFolder);
-		parameters.put("projectName", this.projectName);
-		parameters.put("sectionLevelParameter", this.sectionLevelParameter);
-		parameters.put("displayAsRowParameter", this.displayAsRowParameter);
-		return parameters;
-	}
+    protected org.polarsys.capella.core.data.capellacore.CapellaElement element = null;
 
-	protected void method_body(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+    public void set_element(org.polarsys.capella.core.data.capellacore.CapellaElement object) {
+        this.element = object;
+    }
 
-		int sectionLevel = 2;
-		if (sectionLevelParameter != null) {
-			sectionLevel = sectionLevelParameter;
-		}
-		;
-		// We get the list of applied and owned PV
-		EList<AbstractPropertyValue> applied_list = element.getAppliedPropertyValues();
-		EList<AbstractPropertyValue> owned_list = element.getOwnedPropertyValues();
+    protected java.lang.String outputFolder = null;
 
-		// If we want to display both tables horizontally
-		if (displayAsRowParameter != null && displayAsRowParameter) {
+    public void set_outputFolder(java.lang.String object) {
+        this.outputFolder = object;
+    }
 
-			stringBuffer.append(TEXT_1);
+    protected java.lang.String projectName = null;
 
-		}
-		if ((applied_list != null && applied_list.size() > 0) || (owned_list != null && owned_list.size() > 0)) {
+    public void set_projectName(java.lang.String object) {
+        this.projectName = object;
+    }
 
-			stringBuffer.append(TEXT_2);
-			stringBuffer.append(sectionLevel);
-			stringBuffer.append(TEXT_3);
-			stringBuffer.append(sectionLevel);
-			stringBuffer.append(TEXT_4);
+    protected java.lang.Integer sectionLevelParameter = null;
 
-			String table = PropertyValueHelper.getPVTable(element, 0, projectName, outputFolder);
+    public void set_sectionLevelParameter(java.lang.Integer object) {
+        this.sectionLevelParameter = object;
+    }
 
-			stringBuffer.append(TEXT_5);
-			stringBuffer.append(table);
-			stringBuffer.append(TEXT_6);
+    protected java.lang.Boolean displayAsRowParameter = null;
 
-			if (displayAsRowParameter != null && displayAsRowParameter) {
+    public void set_displayAsRowParameter(java.lang.Boolean object) {
+        this.displayAsRowParameter = object;
+    }
 
-				stringBuffer.append(TEXT_7);
+    public Map<String, Object> getParameters() {
+        final Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("element", this.element);
+        parameters.put("outputFolder", this.outputFolder);
+        parameters.put("projectName", this.projectName);
+        parameters.put("sectionLevelParameter", this.sectionLevelParameter);
+        parameters.put("displayAsRowParameter", this.displayAsRowParameter);
+        return parameters;
+    }
 
-			}
-		}
+    protected void method_body(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-		// We get the list of applied and owned PVG
-		EList<PropertyValueGroup> appliedgroup_list = element.getAppliedPropertyValueGroups();
-		EList<PropertyValueGroup> ownedgroup_list = element.getOwnedPropertyValueGroups();
+        int sectionLevel = 2;
+        if (sectionLevelParameter != null) {
+            sectionLevel = sectionLevelParameter;
+        } ;
+        // We get the list of applied and owned PV
+        EList<AbstractPropertyValue> applied_list = element.getAppliedPropertyValues();
+        EList<AbstractPropertyValue> owned_list = element.getOwnedPropertyValues();
 
-		if ((appliedgroup_list != null && appliedgroup_list.size() > 0)
-				|| (ownedgroup_list != null && ownedgroup_list.size() > 0)) {
+        // If we want to display both tables horizontally
+        if (displayAsRowParameter != null && displayAsRowParameter) {
 
-			stringBuffer.append(TEXT_2);
-			stringBuffer.append(sectionLevel);
-			stringBuffer.append(TEXT_8);
-			stringBuffer.append(sectionLevel);
-			stringBuffer.append(TEXT_4);
+            stringBuffer.append(TEXT_1);
 
-			String table = PropertyValueHelper.getPVGTable(element, 0, projectName, outputFolder);
+        }
+        if ((applied_list != null && applied_list.size() > 0) || (owned_list != null && owned_list.size() > 0)) {
 
-			stringBuffer.append(TEXT_5);
-			stringBuffer.append(table);
-			stringBuffer.append(TEXT_6);
+            stringBuffer.append(TEXT_2);
+            stringBuffer.append(sectionLevel);
+            stringBuffer.append(TEXT_3);
+            stringBuffer.append(sectionLevel);
+            stringBuffer.append(TEXT_4);
 
-		}
-		if (displayAsRowParameter != null && displayAsRowParameter) {
+            String table = PropertyValueHelper.getPVTable(element, 0, projectName, outputFolder);
 
-			stringBuffer.append(TEXT_9);
+            stringBuffer.append(TEXT_5);
+            stringBuffer.append(table);
+            stringBuffer.append(TEXT_6);
 
-		}
+            if (displayAsRowParameter != null && displayAsRowParameter) {
 
-		stringBuffer.append(TEXT_10);
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "body", stringBuffer.toString());
-	}
+                stringBuffer.append(TEXT_7);
 
-	public boolean preCondition(PatternContext ctx) throws Exception {
-		return true;
-	}
+            }
+        }
+
+        // We get the list of applied and owned PVG
+        EList<PropertyValueGroup> appliedgroup_list = element.getAppliedPropertyValueGroups();
+        EList<PropertyValueGroup> ownedgroup_list = element.getOwnedPropertyValueGroups();
+
+        if ((appliedgroup_list != null && appliedgroup_list.size() > 0) || (ownedgroup_list != null && ownedgroup_list.size() > 0)) {
+
+            stringBuffer.append(TEXT_2);
+            stringBuffer.append(sectionLevel);
+            stringBuffer.append(TEXT_8);
+            stringBuffer.append(sectionLevel);
+            stringBuffer.append(TEXT_4);
+
+            String table = PropertyValueHelper.getPVGTable(element, 0, projectName, outputFolder);
+
+            stringBuffer.append(TEXT_5);
+            stringBuffer.append(table);
+            stringBuffer.append(TEXT_6);
+
+        }
+        if (displayAsRowParameter != null && displayAsRowParameter) {
+
+            stringBuffer.append(TEXT_9);
+
+        }
+
+        stringBuffer.append(TEXT_10);
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "body", stringBuffer.toString());
+    }
+
+    public boolean preCondition(PatternContext ctx) throws Exception {
+        return true;
+    }
 }

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/foundations/StatusAndReviewGeneration.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/foundations/StatusAndReviewGeneration.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.1.201906060805
+//Generated with EGF 1.6.3.202110291409
 package org.polarsys.capella.docgen.foundations;
 
 import org.eclipse.egf.common.helper.*;
@@ -15,143 +15,148 @@ import org.polarsys.capella.core.data.capellacore.EnumerationPropertyType;
 import org.polarsys.capella.core.model.handler.helpers.CapellaProjectHelper;
 
 public class StatusAndReviewGeneration {
-	protected static String nl;
+    protected static String nl;
 
-	public static synchronized StatusAndReviewGeneration create(String lineSeparator) {
-		nl = lineSeparator;
-		StatusAndReviewGeneration result = new StatusAndReviewGeneration();
-		nl = null;
-		return result;
-	}
+    public static synchronized StatusAndReviewGeneration create(String lineSeparator) {
+        nl = lineSeparator;
+        StatusAndReviewGeneration result = new StatusAndReviewGeneration();
+        nl = null;
+        return result;
+    }
 
-	public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
-	protected final String TEXT_1 = "\t<h2> Status and Review</h2>" + NL + "\t";
-	protected final String TEXT_2 = NL + "\t\t<p><b>Status:</b> ";
-	protected final String TEXT_3 = "</p>" + NL + "\t";
-	protected final String TEXT_4 = NL + "\t\t<p><b>Review:</b> </p>" + NL + "\t\t";
-	protected final String TEXT_5 = NL + "\t\t<p>";
-	protected final String TEXT_6 = NL;
-	protected final String TEXT_7 = NL + "<h2>Progress Overview</h2>";
-	protected final String TEXT_8 = NL + "No Progress information in this project";
+    public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
 
-	public StatusAndReviewGeneration() {
-		//Here is the constructor
-		StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_1 = "\t<h2> Status and Review</h2>" + NL + "\t";
 
-		// add initialisation of the pattern variables (declaration has been already done).
+    protected final String TEXT_2 = NL + "\t\t<p><b>Status:</b> ";
 
-	}
+    protected final String TEXT_3 = "</p>" + NL + "\t";
 
-	public String generate(Object argument) throws Exception {
-		final StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_4 = NL + "\t\t<p><b>Review:</b> </p>" + NL + "\t\t";
 
-		InternalPatternContext ctx = (InternalPatternContext) argument;
-		Map<String, String> queryCtx = null;
-		IQuery.ParameterDescription paramDesc = null;
-		Node.Container currentNode = ctx.getNode();
+    protected final String TEXT_5 = NL + "\t\t<p>";
 
-		List<Object> elementList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
+    protected final String TEXT_6 = NL;
 
-		for (Object elementParameter : elementList) {
+    protected final String TEXT_7 = NL + "<h2>Progress Overview</h2>";
 
-			this.element = (org.polarsys.capella.core.data.capellacore.CapellaElement) elementParameter;
+    protected final String TEXT_8 = NL + "No Progress information in this project";
 
-			if (preCondition(ctx)) {
-				ctx.setNode(new Node.Container(currentNode, getClass()));
-				orchestration(ctx);
-			}
+    public StatusAndReviewGeneration() {
+        //Here is the constructor
+        StringBuffer stringBuffer = new StringBuffer();
 
-		}
-		ctx.setNode(currentNode);
-		if (ctx.useReporter()) {
-			ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
-		}
+        // add initialisation of the pattern variables (declaration has been already done).
 
-		stringBuffer.append(TEXT_6);
-		stringBuffer.append(TEXT_6);
-		return stringBuffer.toString();
-	}
+    }
 
-	public String orchestration(PatternContext ctx) throws Exception {
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
+    public String generate(Object argument) throws Exception {
+        final StringBuffer stringBuffer = new StringBuffer();
 
-		method_genStatusAndReview(new StringBuffer(), ictx);
+        InternalPatternContext ctx = (InternalPatternContext) argument;
+        Map<String, String> queryCtx = null;
+        IQuery.ParameterDescription paramDesc = null;
+        Node.Container currentNode = ctx.getNode();
 
-		method_genProgressOverview(new StringBuffer(), ictx);
+        List<Object> elementList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
 
-		if (ictx.useReporter()) {
-			Map<String, Object> parameterValues = new HashMap<String, Object>();
-			parameterValues.put("element", this.element);
-			String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
-			String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
-			ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
-		}
-		return null;
-	}
+        for (Object elementParameter : elementList) {
 
-	protected org.polarsys.capella.core.data.capellacore.CapellaElement element = null;
+            this.element = (org.polarsys.capella.core.data.capellacore.CapellaElement) elementParameter;
 
-	public void set_element(org.polarsys.capella.core.data.capellacore.CapellaElement object) {
-		this.element = object;
-	}
+            if (preCondition(ctx)) {
+                ctx.setNode(new Node.Container(currentNode, getClass()));
+                orchestration(ctx);
+            }
 
-	public Map<String, Object> getParameters() {
-		final Map<String, Object> parameters = new HashMap<String, Object>();
-		parameters.put("element", this.element);
-		return parameters;
-	}
+        }
+        ctx.setNode(currentNode);
+        if (ctx.useReporter()) {
+            ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
+        }
 
-	protected void method_genStatusAndReview(final StringBuffer stringBuffer, final PatternContext ctx)
-			throws Exception {
+        stringBuffer.append(TEXT_6);
+        stringBuffer.append(TEXT_6);
+        return stringBuffer.toString();
+    }
 
-		EnumerationPropertyLiteral status = element.getStatus();
-		String review = element.getReview();
-		if (status != null || (review != null && !review.isEmpty())) {
-			stringBuffer.append(TEXT_1);
-			if (status != null) {
-				String name = status.getName();
-				stringBuffer.append(TEXT_2);
-				stringBuffer.append(name);
-				stringBuffer.append(TEXT_3);
-			}
-			if (review != null && !review.isEmpty()) {
-				stringBuffer.append(TEXT_4);
-				review = review.replace("\n", "").replace("\r", "</br>");
-				stringBuffer.append(TEXT_5);
-				stringBuffer.append(review);
-				stringBuffer.append(TEXT_3);
-			}
-		}
+    public String orchestration(PatternContext ctx) throws Exception {
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
 
-		stringBuffer.append(TEXT_6);
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "genStatusAndReview", stringBuffer.toString());
-	}
+        method_genStatusAndReview(new StringBuffer(), ictx);
 
-	protected void method_genProgressOverview(final StringBuffer stringBuffer, final PatternContext ctx)
-			throws Exception {
+        method_genProgressOverview(new StringBuffer(), ictx);
 
-		String projectName = ctx.getValue("projectName").toString();
-		String outputFolder = ctx.getValue("outputFolder").toString();
+        if (ictx.useReporter()) {
+            Map<String, Object> parameterValues = new HashMap<String, Object>();
+            parameterValues.put("element", this.element);
+            String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
+            String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
+            ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
+        }
+        return null;
+    }
 
-		stringBuffer.append(TEXT_6);
-		if (element instanceof Project) {
-			stringBuffer.append(TEXT_7);
-			EnumerationPropertyType progressStatus = CapellaProjectHelper.getEnumerationPropertyType(element,
-					CapellaProjectHelper.PROGRESS_STATUS_KEYWORD);
-			if (progressStatus != null) {
-				stringBuffer.append(TEXT_6);
-				stringBuffer.append(new ProgressHelper(projectName, outputFolder).generateProgressTable(element));
-			} else {
-				stringBuffer.append(TEXT_8);
-			}
-		}
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "genProgressOverview", stringBuffer.toString());
-	}
+    protected org.polarsys.capella.core.data.capellacore.CapellaElement element = null;
 
-	public boolean preCondition(PatternContext ctx) throws Exception {
-		return CapellaDocgenPreferenceHelper.isExportStatusAndReview();
-	}
+    public void set_element(org.polarsys.capella.core.data.capellacore.CapellaElement object) {
+        this.element = object;
+    }
+
+    public Map<String, Object> getParameters() {
+        final Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("element", this.element);
+        return parameters;
+    }
+
+    protected void method_genStatusAndReview(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+
+        EnumerationPropertyLiteral status = element.getStatus();
+        String review = element.getReview();
+        if (status != null || (review != null && !review.isEmpty())) {
+            stringBuffer.append(TEXT_1);
+            if (status != null) {
+                String name = status.getName();
+                stringBuffer.append(TEXT_2);
+                stringBuffer.append(name);
+                stringBuffer.append(TEXT_3);
+            }
+            if (review != null && !review.isEmpty()) {
+                stringBuffer.append(TEXT_4);
+                review = review.replace("\n", "").replace("\r", "</br>");
+                stringBuffer.append(TEXT_5);
+                stringBuffer.append(review);
+                stringBuffer.append(TEXT_3);
+            }
+        }
+
+        stringBuffer.append(TEXT_6);
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "genStatusAndReview", stringBuffer.toString());
+    }
+
+    protected void method_genProgressOverview(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+
+        String projectName = ctx.getValue("projectName").toString();
+        String outputFolder = ctx.getValue("outputFolder").toString();
+
+        stringBuffer.append(TEXT_6);
+        if (element instanceof Project) {
+            stringBuffer.append(TEXT_7);
+            EnumerationPropertyType progressStatus = CapellaProjectHelper.getEnumerationPropertyType(element, CapellaProjectHelper.PROGRESS_STATUS_KEYWORD);
+            if (progressStatus != null) {
+                stringBuffer.append(TEXT_6);
+                stringBuffer.append(new ProgressHelper(projectName, outputFolder).generateProgressTable(element));
+            } else {
+                stringBuffer.append(TEXT_8);
+            }
+        }
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "genProgressOverview", stringBuffer.toString());
+    }
+
+    public boolean preCondition(PatternContext ctx) throws Exception {
+        return CapellaDocgenPreferenceHelper.isExportStatusAndReview();
+    }
 }

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/foundations/SummaryAndDescriptionGeneration.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/foundations/SummaryAndDescriptionGeneration.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.1.201906060805
+//Generated with EGF 1.6.3.202110291409
 package org.polarsys.capella.docgen.foundations;
 
 import org.eclipse.egf.common.helper.*;
@@ -10,113 +10,118 @@ import org.eclipse.egf.pattern.query.*;
 import org.polarsys.capella.docgen.util.StringUtil;
 
 public class SummaryAndDescriptionGeneration {
-	protected static String nl;
+    protected static String nl;
 
-	public static synchronized SummaryAndDescriptionGeneration create(String lineSeparator) {
-		nl = lineSeparator;
-		SummaryAndDescriptionGeneration result = new SummaryAndDescriptionGeneration();
-		nl = null;
-		return result;
-	}
+    public static synchronized SummaryAndDescriptionGeneration create(String lineSeparator) {
+        nl = lineSeparator;
+        SummaryAndDescriptionGeneration result = new SummaryAndDescriptionGeneration();
+        nl = null;
+        return result;
+    }
 
-	public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
-	protected final String TEXT_1 = "<em style=\"margin-top:5px;\">";
-	protected final String TEXT_2 = "</em>";
-	protected final String TEXT_3 = NL + "<p>";
-	protected final String TEXT_4 = NL;
-	protected final String TEXT_5 = NL + "No description.";
-	protected final String TEXT_6 = NL + "</p>";
+    public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
 
-	public SummaryAndDescriptionGeneration() {
-		//Here is the constructor
-		StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_1 = "<em style=\"margin-top:5px;\">";
 
-		// add initialisation of the pattern variables (declaration has been already done).
+    protected final String TEXT_2 = "</em>";
 
-	}
+    protected final String TEXT_3 = NL + "<p>";
 
-	public String generate(Object argument) throws Exception {
-		final StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_4 = NL;
 
-		InternalPatternContext ctx = (InternalPatternContext) argument;
-		Map<String, String> queryCtx = null;
-		IQuery.ParameterDescription paramDesc = null;
-		Node.Container currentNode = ctx.getNode();
+    protected final String TEXT_5 = NL + "No description.";
 
-		List<Object> elementList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
+    protected final String TEXT_6 = NL + "</p>";
 
-		for (Object elementParameter : elementList) {
+    public SummaryAndDescriptionGeneration() {
+        //Here is the constructor
+        StringBuffer stringBuffer = new StringBuffer();
 
-			this.element = (org.polarsys.capella.core.data.capellacore.CapellaElement) elementParameter;
+        // add initialisation of the pattern variables (declaration has been already done).
 
-			if (preCondition(ctx)) {
-				ctx.setNode(new Node.Container(currentNode, getClass()));
-				orchestration(ctx);
-			}
+    }
 
-		}
-		ctx.setNode(currentNode);
-		if (ctx.useReporter()) {
-			ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
-		}
+    public String generate(Object argument) throws Exception {
+        final StringBuffer stringBuffer = new StringBuffer();
 
-		stringBuffer.append(TEXT_4);
-		stringBuffer.append(TEXT_4);
-		return stringBuffer.toString();
-	}
+        InternalPatternContext ctx = (InternalPatternContext) argument;
+        Map<String, String> queryCtx = null;
+        IQuery.ParameterDescription paramDesc = null;
+        Node.Container currentNode = ctx.getNode();
 
-	public String orchestration(PatternContext ctx) throws Exception {
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
+        List<Object> elementList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
 
-		method_body(new StringBuffer(), ictx);
+        for (Object elementParameter : elementList) {
 
-		if (ictx.useReporter()) {
-			Map<String, Object> parameterValues = new HashMap<String, Object>();
-			parameterValues.put("element", this.element);
-			String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
-			String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
-			ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
-		}
-		return null;
-	}
+            this.element = (org.polarsys.capella.core.data.capellacore.CapellaElement) elementParameter;
 
-	protected org.polarsys.capella.core.data.capellacore.CapellaElement element = null;
+            if (preCondition(ctx)) {
+                ctx.setNode(new Node.Container(currentNode, getClass()));
+                orchestration(ctx);
+            }
 
-	public void set_element(org.polarsys.capella.core.data.capellacore.CapellaElement object) {
-		this.element = object;
-	}
+        }
+        ctx.setNode(currentNode);
+        if (ctx.useReporter()) {
+            ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
+        }
 
-	public Map<String, Object> getParameters() {
-		final Map<String, Object> parameters = new HashMap<String, Object>();
-		parameters.put("element", this.element);
-		return parameters;
-	}
+        stringBuffer.append(TEXT_4);
+        stringBuffer.append(TEXT_4);
+        return stringBuffer.toString();
+    }
 
-	protected void method_body(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+    public String orchestration(PatternContext ctx) throws Exception {
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
 
-		String projectName = ctx.getValue("projectName").toString();
-		String outputFolder = ctx.getValue("outputFolder").toString();
-		if (element.getSummary() != null && element.getSummary().length() > 0) {
-			stringBuffer.append(TEXT_1);
-			stringBuffer.append(element.getSummary());
-			stringBuffer.append(TEXT_2);
-		}
-		stringBuffer.append(TEXT_3);
-		if (element.getDescription() != null && element.getDescription().length() > 0) {
-			stringBuffer.append(TEXT_4);
-			stringBuffer.append(TEXT_4);
-			stringBuffer.append(
-					StringUtil.transformAREFString(element, element.getDescription(), projectName, outputFolder));
-		} else {
-			stringBuffer.append(TEXT_5);
-		}
-		stringBuffer.append(TEXT_6);
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "body", stringBuffer.toString());
-	}
+        method_body(new StringBuffer(), ictx);
 
-	public boolean preCondition(PatternContext ctx) throws Exception {
-		return true;
-	}
+        if (ictx.useReporter()) {
+            Map<String, Object> parameterValues = new HashMap<String, Object>();
+            parameterValues.put("element", this.element);
+            String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
+            String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
+            ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
+        }
+        return null;
+    }
+
+    protected org.polarsys.capella.core.data.capellacore.CapellaElement element = null;
+
+    public void set_element(org.polarsys.capella.core.data.capellacore.CapellaElement object) {
+        this.element = object;
+    }
+
+    public Map<String, Object> getParameters() {
+        final Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("element", this.element);
+        return parameters;
+    }
+
+    protected void method_body(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+
+        String projectName = ctx.getValue("projectName").toString();
+        String outputFolder = ctx.getValue("outputFolder").toString();
+        if (element.getSummary() != null && element.getSummary().length() > 0) {
+            stringBuffer.append(TEXT_1);
+            stringBuffer.append(element.getSummary());
+            stringBuffer.append(TEXT_2);
+        }
+        stringBuffer.append(TEXT_3);
+        if (element.getDescription() != null && element.getDescription().length() > 0) {
+            stringBuffer.append(TEXT_4);
+            stringBuffer.append(TEXT_4);
+            stringBuffer.append(StringUtil.transformAREFString(element, element.getDescription(), projectName, outputFolder));
+        } else {
+            stringBuffer.append(TEXT_5);
+        }
+        stringBuffer.append(TEXT_6);
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "body", stringBuffer.toString());
+    }
+
+    public boolean preCondition(PatternContext ctx) throws Exception {
+        return true;
+    }
 }

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/foundations/SummaryGenerate.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/foundations/SummaryGenerate.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.1.201906060805
+//Generated with EGF 1.6.3.202110291409
 package org.polarsys.capella.docgen.foundations;
 
 import org.eclipse.egf.common.helper.*;
@@ -9,118 +9,121 @@ import org.eclipse.egf.pattern.execution.*;
 import org.eclipse.egf.pattern.query.*;
 
 public class SummaryGenerate extends org.polarsys.kitalpha.doc.gen.business.core.generic.ElementGenerateByPropterty {
-	protected static String nl;
+    protected static String nl;
 
-	public static synchronized SummaryGenerate create(String lineSeparator) {
-		nl = lineSeparator;
-		SummaryGenerate result = new SummaryGenerate();
-		nl = null;
-		return result;
-	}
+    public static synchronized SummaryGenerate create(String lineSeparator) {
+        nl = lineSeparator;
+        SummaryGenerate result = new SummaryGenerate();
+        nl = null;
+        return result;
+    }
 
-	public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
-	protected final String TEXT_1 = "<em>";
-	protected final String TEXT_2 = "</em>";
-	protected final String TEXT_3 = NL;
+    public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
 
-	public SummaryGenerate() {
-		//Here is the constructor
-		StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_1 = "<em>";
 
-		// add initialisation of the pattern variables (declaration has been already done).
+    protected final String TEXT_2 = "</em>";
 
-	}
+    protected final String TEXT_3 = NL;
 
-	public String generate(Object argument) throws Exception {
-		final StringBuffer stringBuffer = new StringBuffer();
+    public SummaryGenerate() {
+        //Here is the constructor
+        StringBuffer stringBuffer = new StringBuffer();
 
-		InternalPatternContext ctx = (InternalPatternContext) argument;
-		Map<String, String> queryCtx = null;
-		IQuery.ParameterDescription paramDesc = null;
-		Node.Container currentNode = ctx.getNode();
+        // add initialisation of the pattern variables (declaration has been already done).
 
-		List<Object> elementList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
-		List<Object> propertyList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
-		List<Object> titleList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
-		List<Object> eObjectList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
+    }
 
-		for (Object elementParameter : elementList) {
-			for (Object propertyParameter : propertyList) {
-				for (Object titleParameter : titleList) {
-					for (Object eObjectParameter : eObjectList) {
+    public String generate(Object argument) throws Exception {
+        final StringBuffer stringBuffer = new StringBuffer();
 
-						this.element = (org.polarsys.capella.core.data.capellacore.CapellaElement) elementParameter;
-						this.property = (java.lang.String) propertyParameter;
-						this.title = (java.lang.String) titleParameter;
-						this.eObject = (org.eclipse.emf.ecore.EObject) eObjectParameter;
+        InternalPatternContext ctx = (InternalPatternContext) argument;
+        Map<String, String> queryCtx = null;
+        IQuery.ParameterDescription paramDesc = null;
+        Node.Container currentNode = ctx.getNode();
 
-						if (preCondition(ctx)) {
-							ctx.setNode(new Node.Container(currentNode, getClass()));
-							orchestration(ctx);
-						}
+        List<Object> elementList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
+        List<Object> propertyList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
+        List<Object> titleList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
+        List<Object> eObjectList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
 
-					}
-				}
-			}
-		}
-		ctx.setNode(currentNode);
-		if (ctx.useReporter()) {
-			ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
-		}
+        for (Object elementParameter : elementList) {
+            for (Object propertyParameter : propertyList) {
+                for (Object titleParameter : titleList) {
+                    for (Object eObjectParameter : eObjectList) {
 
-		stringBuffer.append(TEXT_3);
-		stringBuffer.append(TEXT_3);
-		return stringBuffer.toString();
-	}
+                        this.element = (org.polarsys.capella.core.data.capellacore.CapellaElement) elementParameter;
+                        this.property = (java.lang.String) propertyParameter;
+                        this.title = (java.lang.String) titleParameter;
+                        this.eObject = (org.eclipse.emf.ecore.EObject) eObjectParameter;
 
-	public String orchestration(PatternContext ctx) throws Exception {
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
+                        if (preCondition(ctx)) {
+                            ctx.setNode(new Node.Container(currentNode, getClass()));
+                            orchestration(ctx);
+                        }
 
-		super.orchestration(new SuperOrchestrationContext(ictx));
+                    }
+                }
+            }
+        }
+        ctx.setNode(currentNode);
+        if (ctx.useReporter()) {
+            ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
+        }
 
-		if (ictx.useReporter()) {
-			Map<String, Object> parameterValues = new HashMap<String, Object>();
-			parameterValues.put("element", this.element);
-			parameterValues.put("property", this.property);
-			parameterValues.put("title", this.title);
-			parameterValues.put("eObject", this.eObject);
-			String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
-			String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
-			ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
-		}
-		return null;
-	}
+        stringBuffer.append(TEXT_3);
+        stringBuffer.append(TEXT_3);
+        return stringBuffer.toString();
+    }
 
-	protected org.polarsys.capella.core.data.capellacore.CapellaElement element = null;
+    public String orchestration(PatternContext ctx) throws Exception {
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
 
-	public void set_element(org.polarsys.capella.core.data.capellacore.CapellaElement object) {
-		this.element = object;
-	}
+        super.orchestration(new SuperOrchestrationContext(ictx));
 
-	public Map<String, Object> getParameters() {
-		final Map<String, Object> parameters = new HashMap<String, Object>();
-		parameters.put("element", this.element);
-		parameters.put("property", this.property);
-		parameters.put("title", this.title);
-		parameters.put("eObject", this.eObject);
-		return parameters;
-	}
+        if (ictx.useReporter()) {
+            Map<String, Object> parameterValues = new HashMap<String, Object>();
+            parameterValues.put("element", this.element);
+            parameterValues.put("property", this.property);
+            parameterValues.put("title", this.title);
+            parameterValues.put("eObject", this.eObject);
+            String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
+            String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
+            ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
+        }
+        return null;
+    }
 
-	protected void method_openDescription(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+    protected org.polarsys.capella.core.data.capellacore.CapellaElement element = null;
 
-		stringBuffer.append(TEXT_1);
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "openDescription", stringBuffer.toString());
-	}
+    public void set_element(org.polarsys.capella.core.data.capellacore.CapellaElement object) {
+        this.element = object;
+    }
 
-	protected void method_closeDescription(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+    public Map<String, Object> getParameters() {
+        final Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("element", this.element);
+        parameters.put("property", this.property);
+        parameters.put("title", this.title);
+        parameters.put("eObject", this.eObject);
+        return parameters;
+    }
 
-		stringBuffer.append(TEXT_2);
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "closeDescription", stringBuffer.toString());
-	}
+    protected void method_openDescription(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+
+        stringBuffer.append(TEXT_1);
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "openDescription", stringBuffer.toString());
+    }
+
+    protected void method_closeDescription(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+
+        stringBuffer.append(TEXT_2);
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "closeDescription", stringBuffer.toString());
+    }
 }

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/index/indexBuilder.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/index/indexBuilder.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.2.202001031546
+//Generated with EGF 1.6.3.202110291409
 package org.polarsys.capella.docgen.index;
 
 import org.eclipse.egf.common.helper.*;
@@ -12,97 +12,93 @@ import org.polarsys.capella.docgen.util.DocGenHtmlCapellaUtil;
 import org.polarsys.capella.core.data.capellamodeller.ModelRoot;
 
 public class indexBuilder extends org.polarsys.kitalpha.doc.gen.business.core.index.IndexBuilder {
-	protected static String nl;
+    protected static String nl;
 
-	public static synchronized indexBuilder create(String lineSeparator) {
-		nl = lineSeparator;
-		indexBuilder result = new indexBuilder();
-		nl = null;
-		return result;
-	}
+    public static synchronized indexBuilder create(String lineSeparator) {
+        nl = lineSeparator;
+        indexBuilder result = new indexBuilder();
+        nl = null;
+        return result;
+    }
 
-	public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
-	protected final String TEXT_1 = "  <script type=\"text/javascript\">" + NL
-			+ "document.write('<frameset rows=\"63,*,40\" frameborder=\"0\" framespacing=\"0\" border=\"0\">');" + NL
-			+ "document.write('<frame src=\"header.html\" name=\"header\" marginheight=\"0\" marginwidth=\"0\" scrolling=\"no\" noresize=\"0\"/>');"
-			+ NL + "document.write('<frameset cols=\"22%,*\" border=\"5\" frameborder=\"1\" framespacing=\"1\">');" + NL
-			+ "document.write('<frame src=\"sidebar.html\" name=\"sideBar\"/>');" + NL + "var locationText = \"\";" + NL
-			+ "var anchorText = \"\";" + NL + "if (location.search) {" + NL
-			+ "\tlocationText = location.search.substring(1);" + NL + "\tif (location.href.lastIndexOf(\"#\")>0) {" + NL
-			+ "\t\tanchorText = anchorText + \"#\" + location.href.substring(location.href.lastIndexOf(\"#\")+1);" + NL
-			+ "\t}" + NL + "} else {" + NL + "\tlocationText = \"";
-	protected final String TEXT_2 = "\";" + NL + "}" + NL
-			+ "document.write('<frame src=\"'+ locationText +'.html' + anchorText + '\" name=\"content\"\\/>');" + NL
-			+ "document.write('<noframes>');" + NL + "document.write('Your browser cannot display this page !');" + NL
-			+ "  document.write('</noframes>');" + NL + "document.write('</frameset>');" + NL
-			+ "document.write('<frame src=\"footer.html\" name=\"footer\" scrolling=\"no\" frameborder=\"0\" noresize=\"noresize\"/>');"
-			+ NL + "document.write('<noframes>');" + NL + "document.write('Your browser cannot display this page !');"
-			+ NL + "document.write('</noframes>');" + NL + "document.write('</frameset>');" + NL + "</script>";
-	protected final String TEXT_3 = NL;
+    public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
 
-	public indexBuilder() {
-		//Here is the constructor
-		StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_1 = "  <script type=\"text/javascript\">" + NL + "document.write('<frameset rows=\"63,*,40\" frameborder=\"0\" framespacing=\"0\" border=\"0\">');" + NL
+            + "document.write('<frame src=\"header.html\" name=\"header\" marginheight=\"0\" marginwidth=\"0\" scrolling=\"no\" noresize=\"0\"/>');" + NL
+            + "document.write('<frameset cols=\"22%,*\" border=\"5\" frameborder=\"1\" framespacing=\"1\">');" + NL + "document.write('<frame src=\"sidebar.html\" name=\"sideBar\"/>');" + NL
+            + "var locationText = \"\";" + NL + "var anchorText = \"\";" + NL + "if (location.search) {" + NL + "\tlocationText = location.search.substring(1);" + NL
+            + "\tif (location.href.lastIndexOf(\"#\")>0) {" + NL + "\t\tanchorText = anchorText + \"#\" + location.href.substring(location.href.lastIndexOf(\"#\")+1);" + NL + "\t}" + NL + "} else {"
+            + NL + "\tlocationText = \"";
 
-		// add initialisation of the pattern variables (declaration has been already done).
+    protected final String TEXT_2 = "\";" + NL + "}" + NL + "document.write('<frame src=\"'+ locationText +'.html' + anchorText + '\" name=\"content\"\\/>');" + NL + "document.write('<noframes>');"
+            + NL + "document.write('Your browser cannot display this page !');" + NL + "  document.write('</noframes>');" + NL + "document.write('</frameset>');" + NL
+            + "document.write('<frame src=\"footer.html\" name=\"footer\" scrolling=\"no\" frameborder=\"0\" noresize=\"noresize\"/>');" + NL + "document.write('<noframes>');" + NL
+            + "document.write('Your browser cannot display this page !');" + NL + "document.write('</noframes>');" + NL + "document.write('</frameset>');" + NL + "</script>";
 
-	}
+    protected final String TEXT_3 = NL;
 
-	public String generate(Object argument) throws Exception {
-		final StringBuffer stringBuffer = new StringBuffer();
+    public indexBuilder() {
+        //Here is the constructor
+        StringBuffer stringBuffer = new StringBuffer();
 
-		InternalPatternContext ctx = (InternalPatternContext) argument;
-		Map<String, String> queryCtx = null;
-		IQuery.ParameterDescription paramDesc = null;
-		Node.Container currentNode = ctx.getNode();
+        // add initialisation of the pattern variables (declaration has been already done).
 
-		if (preCondition(ctx)) {
-			ctx.setNode(new Node.Container(currentNode, getClass()));
-			orchestration(ctx);
-		}
+    }
 
-		ctx.setNode(currentNode);
-		if (ctx.useReporter()) {
-			ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
-		}
+    public String generate(Object argument) throws Exception {
+        final StringBuffer stringBuffer = new StringBuffer();
 
-		stringBuffer.append(TEXT_3);
-		stringBuffer.append(TEXT_3);
-		return stringBuffer.toString();
-	}
+        InternalPatternContext ctx = (InternalPatternContext) argument;
+        Map<String, String> queryCtx = null;
+        IQuery.ParameterDescription paramDesc = null;
+        Node.Container currentNode = ctx.getNode();
 
-	public String orchestration(PatternContext ctx) throws Exception {
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
+        if (preCondition(ctx)) {
+            ctx.setNode(new Node.Container(currentNode, getClass()));
+            orchestration(ctx);
+        }
 
-		super.orchestration(new SuperOrchestrationContext(ictx));
+        ctx.setNode(currentNode);
+        if (ctx.useReporter()) {
+            ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
+        }
 
-		return null;
-	}
+        stringBuffer.append(TEXT_3);
+        stringBuffer.append(TEXT_3);
+        return stringBuffer.toString();
+    }
 
-	public Map<String, Object> getParameters() {
-		final Map<String, Object> parameters = new HashMap<String, Object>();
-		return parameters;
-	}
+    public String orchestration(PatternContext ctx) throws Exception {
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
 
-	protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+        super.orchestration(new SuperOrchestrationContext(ictx));
 
-		List<Object> model = (List<Object>) ctx.getValue(PatternContext.DOMAIN_OBJECTS);
-		String fileName = "";
-		for (Object currentObject : model) {
-			if (currentObject instanceof org.polarsys.capella.core.data.capellamodeller.Project) {
-				EList<ModelRoot> children = ((org.polarsys.capella.core.data.capellamodeller.Project) currentObject)
-						.getOwnedModelRoots();
-				if (children.get(0) instanceof org.polarsys.capella.core.data.capellamodeller.SystemEngineering) {
-					fileName = DocGenHtmlCapellaUtil.SERVICE.getFileName(children.get(0));
-					break;
-				}
-			}
-		}
+        return null;
+    }
 
-		stringBuffer.append(TEXT_1);
-		stringBuffer.append(fileName);
-		stringBuffer.append(TEXT_2);
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
-	}
+    public Map<String, Object> getParameters() {
+        final Map<String, Object> parameters = new HashMap<String, Object>();
+        return parameters;
+    }
+
+    protected void method_content(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+
+        List<Object> model = (List<Object>) ctx.getValue(PatternContext.DOMAIN_OBJECTS);
+        String fileName = "";
+        for (Object currentObject : model) {
+            if (currentObject instanceof org.polarsys.capella.core.data.capellamodeller.Project) {
+                EList<ModelRoot> children = ((org.polarsys.capella.core.data.capellamodeller.Project) currentObject).getOwnedModelRoots();
+                if (children.get(0) instanceof org.polarsys.capella.core.data.capellamodeller.SystemEngineering) {
+                    fileName = DocGenHtmlCapellaUtil.SERVICE.getFileName(children.get(0));
+                    break;
+                }
+            }
+        }
+
+        stringBuffer.append(TEXT_1);
+        stringBuffer.append(fileName);
+        stringBuffer.append(TEXT_2);
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "content", stringBuffer.toString());
+    }
 }

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/index/items/builder/CollectCapellaItems.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/index/items/builder/CollectCapellaItems.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.2.202001031546
+//Generated with EGF 1.6.3.202110291409
 package org.polarsys.capella.docgen.index.items.builder;
 
 import org.polarsys.kitalpha.doc.gen.business.core.services.IndexItem;
@@ -15,132 +15,132 @@ import org.polarsys.kitalpha.doc.gen.business.core.util.DefaultFileNameService;
 import org.polarsys.capella.common.data.modellingcore.ModelElement;
 
 public class CollectCapellaItems {
-	protected static String nl;
+    protected static String nl;
 
-	public static synchronized CollectCapellaItems create(String lineSeparator) {
-		nl = lineSeparator;
-		CollectCapellaItems result = new CollectCapellaItems();
-		nl = null;
-		return result;
-	}
+    public static synchronized CollectCapellaItems create(String lineSeparator) {
+        nl = lineSeparator;
+        CollectCapellaItems result = new CollectCapellaItems();
+        nl = null;
+        return result;
+    }
 
-	public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
-	protected final String TEXT_1 = "";
-	protected final String TEXT_2 = NL;
+    public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
 
-	public CollectCapellaItems() {
-		//Here is the constructor
-		StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_1 = "";
 
-		// add initialisation of the pattern variables (declaration has been already done).
+    protected final String TEXT_2 = NL;
 
-	}
+    public CollectCapellaItems() {
+        //Here is the constructor
+        StringBuffer stringBuffer = new StringBuffer();
 
-	public String generate(Object argument) throws Exception {
-		final StringBuffer stringBuffer = new StringBuffer();
+        // add initialisation of the pattern variables (declaration has been already done).
 
-		InternalPatternContext ctx = (InternalPatternContext) argument;
-		Map<String, String> queryCtx = null;
-		IQuery.ParameterDescription paramDesc = null;
-		Node.Container currentNode = ctx.getNode();
+    }
 
-		List<Object> parameterList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
+    public String generate(Object argument) throws Exception {
+        final StringBuffer stringBuffer = new StringBuffer();
 
-		for (Object parameterParameter : parameterList) {
+        InternalPatternContext ctx = (InternalPatternContext) argument;
+        Map<String, String> queryCtx = null;
+        IQuery.ParameterDescription paramDesc = null;
+        Node.Container currentNode = ctx.getNode();
 
-			this.parameter = (org.eclipse.emf.ecore.EObject) parameterParameter;
+        List<Object> parameterList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
 
-			if (preCondition(ctx)) {
-				ctx.setNode(new Node.Container(currentNode, getClass()));
-				orchestration(ctx);
-			}
+        for (Object parameterParameter : parameterList) {
 
-		}
-		ctx.setNode(currentNode);
-		if (ctx.useReporter()) {
-			ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
-		}
+            this.parameter = (org.eclipse.emf.ecore.EObject) parameterParameter;
 
-		stringBuffer.append(TEXT_1);
-		stringBuffer.append(TEXT_2);
-		return stringBuffer.toString();
-	}
+            if (preCondition(ctx)) {
+                ctx.setNode(new Node.Container(currentNode, getClass()));
+                orchestration(ctx);
+            }
 
-	public String orchestration(PatternContext ctx) throws Exception {
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
+        }
+        ctx.setNode(currentNode);
+        if (ctx.useReporter()) {
+            ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
+        }
 
-		method_setContext(new StringBuffer(), ictx);
+        stringBuffer.append(TEXT_1);
+        stringBuffer.append(TEXT_2);
+        return stringBuffer.toString();
+    }
 
-		method_body(new StringBuffer(), ictx);
+    public String orchestration(PatternContext ctx) throws Exception {
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
 
-		if (ictx.useReporter()) {
-			Map<String, Object> parameterValues = new HashMap<String, Object>();
-			parameterValues.put("parameter", this.parameter);
-			String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
-			String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
-			ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
-		}
-		return null;
-	}
+        method_setContext(new StringBuffer(), ictx);
 
-	protected org.polarsys.kitalpha.doc.gen.business.core.util.IFileNameService fileNameService = null;
+        method_body(new StringBuffer(), ictx);
 
-	public void set_fileNameService(org.polarsys.kitalpha.doc.gen.business.core.util.IFileNameService object) {
-		this.fileNameService = object;
-	}
+        if (ictx.useReporter()) {
+            Map<String, Object> parameterValues = new HashMap<String, Object>();
+            parameterValues.put("parameter", this.parameter);
+            String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
+            String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
+            ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
+        }
+        return null;
+    }
 
-	protected org.eclipse.emf.ecore.EObject parameter = null;
+    protected org.polarsys.kitalpha.doc.gen.business.core.util.IFileNameService fileNameService = null;
 
-	public void set_parameter(org.eclipse.emf.ecore.EObject object) {
-		this.parameter = object;
-	}
+    public void set_fileNameService(org.polarsys.kitalpha.doc.gen.business.core.util.IFileNameService object) {
+        this.fileNameService = object;
+    }
 
-	public Map<String, Object> getParameters() {
-		final Map<String, Object> parameters = new HashMap<String, Object>();
-		parameters.put("parameter", this.parameter);
-		return parameters;
-	}
+    protected org.eclipse.emf.ecore.EObject parameter = null;
 
-	protected void method_setContext(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+    public void set_parameter(org.eclipse.emf.ecore.EObject object) {
+        this.parameter = object;
+    }
 
-		fileNameService = DocGenHtmlCapellaUtil.SERVICE;
+    public Map<String, Object> getParameters() {
+        final Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("parameter", this.parameter);
+        return parameters;
+    }
 
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "setContext", stringBuffer.toString());
-	}
+    protected void method_setContext(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-	protected void method_body(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+        fileNameService = DocGenHtmlCapellaUtil.SERVICE;
 
-		List<IConceptsHelper> conceptsHelperList = ExtensionService.INSTANCE.getConceptsHelpersList();
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "setContext", stringBuffer.toString());
+    }
 
-		String projectName = (String) ctx.getValue("projectName");
-		String outputFolder = (String) ctx.getValue("outputFolder");
+    protected void method_body(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-		for (IConceptsHelper iConceptsHelper : conceptsHelperList) {
-			if (iConceptsHelper.accept(parameter)) {
-				String conceptLabel = iConceptsHelper.getConceptLabel(parameter);
-				String linkTagTowardPageElement = CapellaServices.getIndexHyperlinkFromElement(parameter);
-				String iconTagOfElement = CapellaServices.getIndexImageLinkFromElement(parameter, projectName,
-						outputFolder);
-				String fileName = DocGenHtmlCapellaUtil.SERVICE.getFileName(parameter);
-				IndexItem item = new IndexItem(conceptLabel, parameter.eClass().getName(), iconTagOfElement,
-						linkTagTowardPageElement, fileName);
-				// Check if the default indexer have already indexed the element
-				String defaultFileName = DefaultFileNameService.INSTANCE.getFileName(parameter);
-				if (IndexerService.INSTANCE.getElementsToIndexItems().get(defaultFileName) != null) {
-					IndexerService.INSTANCE.getElementsToIndexItems().remove(defaultFileName);
-				}
-				IndexerService.INSTANCE.getElementsToIndexItems().put(fileName, item);
-				break;
-			}
-		}
+        List<IConceptsHelper> conceptsHelperList = ExtensionService.INSTANCE.getConceptsHelpersList();
 
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "body", stringBuffer.toString());
-	}
+        String projectName = (String) ctx.getValue("projectName");
+        String outputFolder = (String) ctx.getValue("outputFolder");
 
-	public boolean preCondition(PatternContext ctx) throws Exception {
-		return parameter instanceof ModelElement;
-	}
+        for (IConceptsHelper iConceptsHelper : conceptsHelperList) {
+            if (iConceptsHelper.accept(parameter)) {
+                String conceptLabel = iConceptsHelper.getConceptLabel(parameter);
+                String linkTagTowardPageElement = CapellaServices.getIndexHyperlinkFromElement(parameter);
+                String iconTagOfElement = CapellaServices.getIndexImageLinkFromElement(parameter, projectName, outputFolder);
+                String fileName = DocGenHtmlCapellaUtil.SERVICE.getFileName(parameter);
+                IndexItem item = new IndexItem(conceptLabel, parameter.eClass().getName(), iconTagOfElement, linkTagTowardPageElement, fileName);
+                // Check if the default indexer have already indexed the element
+                String defaultFileName = DefaultFileNameService.INSTANCE.getFileName(parameter);
+                if (IndexerService.INSTANCE.getElementsToIndexItems().get(defaultFileName) != null) {
+                    IndexerService.INSTANCE.getElementsToIndexItems().remove(defaultFileName);
+                }
+                IndexerService.INSTANCE.getElementsToIndexItems().put(fileName, item);
+                break;
+            }
+        }
+
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "body", stringBuffer.toString());
+    }
+
+    public boolean preCondition(PatternContext ctx) throws Exception {
+        return parameter instanceof ModelElement;
+    }
 }

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/search/searchIndexExtension.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/search/searchIndexExtension.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.1.201906060805
+//Generated with EGF 1.6.3.202110291409
 package org.polarsys.capella.docgen.search;
 
 import org.eclipse.egf.common.helper.*;
@@ -9,69 +9,70 @@ import org.eclipse.egf.pattern.execution.*;
 import org.eclipse.egf.pattern.query.*;
 
 public class searchIndexExtension extends org.polarsys.kitalpha.doc.gen.business.core.searchIndex.SearchIndex {
-	protected static String nl;
+    protected static String nl;
 
-	public static synchronized searchIndexExtension create(String lineSeparator) {
-		nl = lineSeparator;
-		searchIndexExtension result = new searchIndexExtension();
-		nl = null;
-		return result;
-	}
+    public static synchronized searchIndexExtension create(String lineSeparator) {
+        nl = lineSeparator;
+        searchIndexExtension result = new searchIndexExtension();
+        nl = null;
+        return result;
+    }
 
-	public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
-	protected final String TEXT_1 = "";
-	protected final String TEXT_2 = NL;
+    public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
 
-	public searchIndexExtension() {
-		//Here is the constructor
-		StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_1 = "";
 
-		// add initialisation of the pattern variables (declaration has been already done).
+    protected final String TEXT_2 = NL;
 
-	}
+    public searchIndexExtension() {
+        //Here is the constructor
+        StringBuffer stringBuffer = new StringBuffer();
 
-	public String generate(Object argument) throws Exception {
-		final StringBuffer stringBuffer = new StringBuffer();
+        // add initialisation of the pattern variables (declaration has been already done).
 
-		InternalPatternContext ctx = (InternalPatternContext) argument;
-		Map<String, String> queryCtx = null;
-		IQuery.ParameterDescription paramDesc = null;
-		Node.Container currentNode = ctx.getNode();
+    }
 
-		if (preCondition(ctx)) {
-			ctx.setNode(new Node.Container(currentNode, getClass()));
-			orchestration(ctx);
-		}
+    public String generate(Object argument) throws Exception {
+        final StringBuffer stringBuffer = new StringBuffer();
 
-		ctx.setNode(currentNode);
-		if (ctx.useReporter()) {
-			ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
-		}
+        InternalPatternContext ctx = (InternalPatternContext) argument;
+        Map<String, String> queryCtx = null;
+        IQuery.ParameterDescription paramDesc = null;
+        Node.Container currentNode = ctx.getNode();
 
-		stringBuffer.append(TEXT_1);
-		stringBuffer.append(TEXT_2);
-		return stringBuffer.toString();
-	}
+        if (preCondition(ctx)) {
+            ctx.setNode(new Node.Container(currentNode, getClass()));
+            orchestration(ctx);
+        }
 
-	public String orchestration(PatternContext ctx) throws Exception {
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
+        ctx.setNode(currentNode);
+        if (ctx.useReporter()) {
+            ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
+        }
 
-		super.orchestration(new SuperOrchestrationContext(ictx));
+        stringBuffer.append(TEXT_1);
+        stringBuffer.append(TEXT_2);
+        return stringBuffer.toString();
+    }
 
-		return null;
-	}
+    public String orchestration(PatternContext ctx) throws Exception {
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
 
-	public Map<String, Object> getParameters() {
-		final Map<String, Object> parameters = new HashMap<String, Object>();
-		return parameters;
-	}
+        super.orchestration(new SuperOrchestrationContext(ictx));
 
-	protected void method_setFileNameService(final StringBuffer stringBuffer, final PatternContext ctx)
-			throws Exception {
+        return null;
+    }
 
-		fileNameService = org.polarsys.capella.docgen.util.DocGenHtmlCapellaUtil.SERVICE;
+    public Map<String, Object> getParameters() {
+        final Map<String, Object> parameters = new HashMap<String, Object>();
+        return parameters;
+    }
 
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "setFileNameService", stringBuffer.toString());
-	}
+    protected void method_setFileNameService(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+
+        fileNameService = org.polarsys.capella.docgen.util.DocGenHtmlCapellaUtil.SERVICE;
+
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "setFileNameService", stringBuffer.toString());
+    }
 }

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/sidebar/AnyNamedElementSideBar.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/generated/org/polarsys/capella/docgen/sidebar/AnyNamedElementSideBar.java
@@ -1,4 +1,4 @@
-//Generated with EGF 1.6.1.201906060805
+//Generated with EGF 1.6.3.202110291409
 package org.polarsys.capella.docgen.sidebar;
 
 import org.eclipse.egf.common.helper.*;
@@ -11,126 +11,124 @@ import org.polarsys.capella.core.data.capellacore.CapellaElement;
 import org.polarsys.capella.docgen.util.DocGenHtmlCapellaControl;
 import org.polarsys.capella.docgen.util.DocGenHtmlCapellaUtil;;
 
-public class AnyNamedElementSideBar
-		extends org.polarsys.kitalpha.doc.gen.business.core.doccontent.ElementSideBarContent {
-	protected static String nl;
+public class AnyNamedElementSideBar extends org.polarsys.kitalpha.doc.gen.business.core.doccontent.ElementSideBarContent {
+    protected static String nl;
 
-	public static synchronized AnyNamedElementSideBar create(String lineSeparator) {
-		nl = lineSeparator;
-		AnyNamedElementSideBar result = new AnyNamedElementSideBar();
-		nl = null;
-		return result;
-	}
+    public static synchronized AnyNamedElementSideBar create(String lineSeparator) {
+        nl = lineSeparator;
+        AnyNamedElementSideBar result = new AnyNamedElementSideBar();
+        nl = null;
+        return result;
+    }
 
-	public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
-	protected final String TEXT_1 = "";
-	protected final String TEXT_2 = NL;
+    public final String NL = nl == null ? (System.getProperties().getProperty("line.separator")) : nl;
 
-	public AnyNamedElementSideBar() {
-		//Here is the constructor
-		StringBuffer stringBuffer = new StringBuffer();
+    protected final String TEXT_1 = "";
 
-		// add initialisation of the pattern variables (declaration has been already done).
+    protected final String TEXT_2 = NL;
 
-	}
+    public AnyNamedElementSideBar() {
+        //Here is the constructor
+        StringBuffer stringBuffer = new StringBuffer();
 
-	public String generate(Object argument) throws Exception {
-		final StringBuffer stringBuffer = new StringBuffer();
+        // add initialisation of the pattern variables (declaration has been already done).
 
-		InternalPatternContext ctx = (InternalPatternContext) argument;
-		Map<String, String> queryCtx = null;
-		IQuery.ParameterDescription paramDesc = null;
-		Node.Container currentNode = ctx.getNode();
+    }
 
-		List<Object> parameterList = null;
-		//this pattern can only be called by another (i.e. it's not an entry point in execution)
+    public String generate(Object argument) throws Exception {
+        final StringBuffer stringBuffer = new StringBuffer();
 
-		for (Object parameterParameter : parameterList) {
+        InternalPatternContext ctx = (InternalPatternContext) argument;
+        Map<String, String> queryCtx = null;
+        IQuery.ParameterDescription paramDesc = null;
+        Node.Container currentNode = ctx.getNode();
 
-			this.parameter = (org.polarsys.capella.core.data.capellacore.CapellaElement) parameterParameter;
+        List<Object> parameterList = null;
+        //this pattern can only be called by another (i.e. it's not an entry point in execution)
 
-			if (preCondition(ctx)) {
-				ctx.setNode(new Node.Container(currentNode, getClass()));
-				orchestration(ctx);
-			}
+        for (Object parameterParameter : parameterList) {
 
-		}
-		ctx.setNode(currentNode);
-		if (ctx.useReporter()) {
-			ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
-		}
+            this.parameter = (org.polarsys.capella.core.data.capellacore.CapellaElement) parameterParameter;
 
-		stringBuffer.append(TEXT_1);
-		stringBuffer.append(TEXT_2);
-		return stringBuffer.toString();
-	}
+            if (preCondition(ctx)) {
+                ctx.setNode(new Node.Container(currentNode, getClass()));
+                orchestration(ctx);
+            }
 
-	public String orchestration(PatternContext ctx) throws Exception {
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
+        }
+        ctx.setNode(currentNode);
+        if (ctx.useReporter()) {
+            ctx.getReporter().executionFinished(OutputManager.computeExecutionOutput(ctx), ctx);
+        }
 
-		super.orchestration(new SuperOrchestrationContext(ictx));
+        stringBuffer.append(TEXT_1);
+        stringBuffer.append(TEXT_2);
+        return stringBuffer.toString();
+    }
 
-		if (ictx.useReporter()) {
-			Map<String, Object> parameterValues = new HashMap<String, Object>();
-			parameterValues.put("parameter", this.parameter);
-			String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
-			String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
-			ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
-		}
-		return null;
-	}
+    public String orchestration(PatternContext ctx) throws Exception {
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
 
-	protected org.polarsys.capella.core.data.capellacore.CapellaElement parameter = null;
+        super.orchestration(new SuperOrchestrationContext(ictx));
 
-	public void set_parameter(org.polarsys.capella.core.data.capellacore.CapellaElement object) {
-		this.parameter = object;
-	}
+        if (ictx.useReporter()) {
+            Map<String, Object> parameterValues = new HashMap<String, Object>();
+            parameterValues.put("parameter", this.parameter);
+            String outputWithCallBack = OutputManager.computeLoopOutput(ictx);
+            String loop = OutputManager.computeLoopOutputWithoutCallback(ictx);
+            ictx.getReporter().loopFinished(loop, outputWithCallBack, ictx, parameterValues);
+        }
+        return null;
+    }
 
-	public Map<String, Object> getParameters() {
-		final Map<String, Object> parameters = new HashMap<String, Object>();
-		parameters.put("parameter", this.parameter);
-		return parameters;
-	}
+    protected org.polarsys.capella.core.data.capellacore.CapellaElement parameter = null;
 
-	protected void method_setCurrentObject(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
+    public void set_parameter(org.polarsys.capella.core.data.capellacore.CapellaElement object) {
+        this.parameter = object;
+    }
 
-		currentObject = parameter;
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "setCurrentObject", stringBuffer.toString());
-	}
+    public Map<String, Object> getParameters() {
+        final Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("parameter", this.parameter);
+        return parameters;
+    }
 
-	protected void method_setFileNameService(final StringBuffer stringBuffer, final PatternContext ctx)
-			throws Exception {
+    protected void method_setCurrentObject(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-		fileNameService = DocGenHtmlCapellaUtil.SERVICE;
+        currentObject = parameter;
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "setCurrentObject", stringBuffer.toString());
+    }
 
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "setFileNameService", stringBuffer.toString());
-	}
+    protected void method_setFileNameService(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-	protected void method_startSidebarSubElement(final StringBuffer stringBuffer, final PatternContext ctx)
-			throws Exception {
+        fileNameService = DocGenHtmlCapellaUtil.SERVICE;
 
-		if (DocGenHtmlCapellaUtil.hasChildren(parameter)) {
-			super.method_startSidebarSubElement(new StringBuffer(), ctx);
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "setFileNameService", stringBuffer.toString());
+    }
 
-		}
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "startSidebarSubElement", stringBuffer.toString());
-	}
+    protected void method_startSidebarSubElement(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-	protected void method_endSidebarSubElement(final StringBuffer stringBuffer, final PatternContext ctx)
-			throws Exception {
+        if (DocGenHtmlCapellaUtil.hasChildren(parameter)) {
+            super.method_startSidebarSubElement(new StringBuffer(), ctx);
 
-		if (DocGenHtmlCapellaUtil.hasChildren(parameter)) {
-			super.method_endSidebarSubElement(new StringBuffer(), ctx);
+        }
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "startSidebarSubElement", stringBuffer.toString());
+    }
 
-		}
-		InternalPatternContext ictx = (InternalPatternContext) ctx;
-		new Node.DataLeaf(ictx.getNode(), getClass(), "endSidebarSubElement", stringBuffer.toString());
-	}
+    protected void method_endSidebarSubElement(final StringBuffer stringBuffer, final PatternContext ctx) throws Exception {
 
-	public boolean preCondition(PatternContext ctx) throws Exception {
-		return DocGenHtmlCapellaControl.isPageCandidate((CapellaElement) parameter);
-	}
+        if (DocGenHtmlCapellaUtil.hasChildren(parameter)) {
+            super.method_endSidebarSubElement(new StringBuffer(), ctx);
+
+        }
+        InternalPatternContext ictx = (InternalPatternContext) ctx;
+        new Node.DataLeaf(ictx.getNode(), getClass(), "endSidebarSubElement", stringBuffer.toString());
+    }
+
+    public boolean preCondition(PatternContext ctx) throws Exception {
+        return DocGenHtmlCapellaControl.isPageCandidate((CapellaElement) parameter);
+    }
 }

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/src/org/polarsys/capella/docgen/Messages.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/src/org/polarsys/capella/docgen/Messages.java
@@ -18,6 +18,8 @@ public class Messages extends NLS {
 	
 	public static String docgenDiagramTargetNull;
 	public static String elementTypeNotHandled;
+	public static String capellaVersionMismatch;
+	public static String docgenVersionNotFound;
 	
 	static {
 		// initialize resource bundle

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/src/org/polarsys/capella/docgen/helper/CapellaVersionHelper.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/src/org/polarsys/capella/docgen/helper/CapellaVersionHelper.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2021 THALES GLOBAL SERVICES.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *  
+ * Contributors:
+ *   Thales - initial API and implementation
+ ******************************************************************************/
+package org.polarsys.capella.docgen.helper;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.Version;
+import org.polarsys.capella.docgen.Messages;
+
+/**
+ * Utility class including Capella version related checks
+ * 
+ * @author <a href="mailto:arnaud.dieumegard@obeo.fr">Arnaud Dieumegard</a>
+ *
+ */
+public class CapellaVersionHelper {
+
+    private static String DOT = ".";
+
+    CapellaVersionHelper() {
+    }
+
+    /**
+     * Checks that current Capella version is the same as the docgen version.
+     * 
+     * @return true if the version major value are the same.
+     */
+    public static boolean isSupportedCapellaVersion() {
+        Boolean result = false;
+        Bundle capellaPerspectiveBundle = FrameworkUtil.getBundle(org.polarsys.capella.core.model.helpers.CapellaElementExt.class);
+        Version docgenBundleVersion = getDocgenBundleVersion();
+        if (capellaPerspectiveBundle != null && docgenBundleVersion != null) {
+            Version capellaPerspectiveBundleVersion = capellaPerspectiveBundle.getVersion();
+            if (capellaPerspectiveBundleVersion.getMajor() == docgenBundleVersion.getMajor()) {
+                result = true;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Get the Docgen {@link Version}
+     * 
+     * @return The current {@code org.polarsys.capella.docgen} bundle version. We assume that all docgen bundles versions
+     *         matches this version.
+     */
+    public static Version getDocgenBundleVersion() {
+        Bundle docgenBundle = FrameworkUtil.getBundle(org.polarsys.capella.docgen.Activator.class);
+        if (docgenBundle != null) {
+            return docgenBundle.getVersion();
+        }
+        return null;
+    }
+
+    /**
+     * Get the Docgen bundle version as string (without qualifier). The format is Major.Minor.Mico.
+     * 
+     * @return The Docgen bundle version as a string.
+     */
+    public static String getDocgenBundleVersionWithoutQualifier() {
+        Version docgenBundleVersion = getDocgenBundleVersion();
+        if (docgenBundleVersion != null) {
+            return docgenBundleVersion.getMajor() + DOT + "x";
+        }
+        return Messages.docgenVersionNotFound;
+    }
+
+}

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/src/org/polarsys/capella/docgen/messages.properties
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/src/org/polarsys/capella/docgen/messages.properties
@@ -13,3 +13,5 @@
 ###############################################################################
 docgenDiagramTargetNull=Representation {0} is invalid: null target semantic element. Representation ignored in the documentation generation process.
 elementTypeNotHandled=Elements of type {0} are not handled in the generation.
+capellaVersionMismatch=Capella version mismatches with XHTML Docgen version. Expected version is {0}.
+docgenVersionNotFound=HTML Docgen version not found

--- a/docgenhtml/plugins/org.polarsys.capella.docgen/src/org/polarsys/capella/docgen/task/CheckCapellaVersionTask.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/src/org/polarsys/capella/docgen/task/CheckCapellaVersionTask.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2021 THALES GLOBAL SERVICES.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *  
+ * Contributors:
+ *   Thales - initial API and implementation
+ ******************************************************************************/
+package org.polarsys.capella.docgen.task;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.egf.core.producer.InvocationException;
+import org.eclipse.egf.ftask.producer.context.ITaskProductionContext;
+import org.eclipse.egf.ftask.producer.invocation.ITaskProduction;
+import org.eclipse.osgi.util.NLS;
+import org.polarsys.capella.docgen.Messages;
+import org.polarsys.capella.docgen.helper.CapellaVersionHelper;
+
+/**
+ * 
+ * @author <a href="mailto:arnaud.dieumegard@obeo.fr">Arnaud Dieumegard</a>
+ *
+ */
+public class CheckCapellaVersionTask implements ITaskProduction {
+	
+	@Override
+	public void doExecute(ITaskProductionContext productionContext, IProgressMonitor monitor) throws InvocationException {
+	    if (!CapellaVersionHelper.isSupportedCapellaVersion()) {
+	        throw new OperationCanceledException(NLS.bind(Messages.capellaVersionMismatch, CapellaVersionHelper.getDocgenBundleVersionWithoutQualifier()));
+	    }
+	}
+
+	@Override
+	public void preExecute(ITaskProductionContext productionContext, IProgressMonitor monitor) throws InvocationException {
+	}
+	
+	@Override
+	public void postExecute(ITaskProductionContext productionContext, IProgressMonitor monitor) throws InvocationException {
+	}
+
+}

--- a/releng/org.polarsys.capella.docgen.target/tp/capella.target-definition.target
+++ b/releng/org.polarsys.capella.docgen.target/tp/capella.target-definition.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="CapellaXHTMLDocGenAddon" sequenceNumber="1639041432">
+<target name="CapellaXHTMLDocGenAddon" sequenceNumber="1639994123">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.gmf.runtime.notation.sdk.feature.group" version="0.0.0"/>
@@ -83,6 +83,11 @@
       <repository id="kitalpha-runtime-core-master" location="https://download.eclipse.org/kitalpha/updates/stable/runtime/6.0.0.S202112081913/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.polarsys.kitalpha.doc.feature.feature.group" version="6.0.0.202112081913"/>
+      <unit id="org.polarsys.kitalpha.emde.sdk.feature.source.feature.group" version="6.0.0.202112081913"/>
+      <repository id="kitalpha-sdk-master" location="https://download.eclipse.org/kitalpha/updates/stable/sdk/6.0.0.S202112081913/"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.emf.diffmerge.feature.source.feature.group" version="0.14.0.202109160952"/>
       <unit id="org.eclipse.emf.diffmerge.sirius.feature.source.feature.group" version="0.14.0.202109160952"/>
       <unit id="org.eclipse.emf.diffmerge.gmf.feature.source.feature.group" version="0.14.0.202109160952"/>
@@ -114,14 +119,12 @@
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.polarsys.capella.rcp.feature.group" version="0.0.0"/>
       <unit id="org.polarsys.capella.core.re.feature.feature.group" version="0.0.0"/>
-      <repository id="capella-master" location="https://download.eclipse.org/capella/core/updates/nightly/master-6.0-PR-2283-4/org.polarsys.capella.rcp.site/"/>
+      <repository id="capella-master" location="https://download.eclipse.org/capella/core/updates/nightly/master-6.0/org.polarsys.capella.rcp.site/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.polarsys.kitalpha.doc.gen.business.core.feature.feature.group" version="0.0.0"/>
       <unit id="org.polarsys.kitalpha.doc.gen.business.core.feature.source.feature.group" version="0.0.0"/>
-      <unit id="org.polarsys.kitalpha.doc.feature.feature.group" version="6.0.0.202112081913"/>
-      <unit id="org.polarsys.kitalpha.emde.sdk.feature.source.feature.group" version="6.0.0.202112081913"/>
-      <repository id="kitalpha-sdk-master" location="https://download.eclipse.org/kitalpha/updates/stable/sdk/6.0.0.S202112081913/"/>
+      <repository id="kitalpha-sdk-master-stable" location="https://download.eclipse.org/kitalpha/updates/stable/sdk/6.0.0.S202112171603/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.emf.query.feature.group" version="0.0.0"/>

--- a/releng/org.polarsys.capella.docgen.target/tp/capella.target-definition.target
+++ b/releng/org.polarsys.capella.docgen.target/tp/capella.target-definition.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="CapellaXHTMLDocGenAddon" sequenceNumber="1633425766">
+<target name="CapellaXHTMLDocGenAddon" sequenceNumber="1639041432">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.gmf.runtime.notation.sdk.feature.group" version="0.0.0"/>
@@ -40,17 +40,17 @@
       <repository id="eclipse" location="http://download.eclipse.org/releases/2021-06"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.sirius.doc.feature.feature.group" version="7.0.0.202109081424"/>
-      <unit id="org.eclipse.sirius.doc.feature.source.feature.group" version="7.0.0.202109081424"/>
-      <unit id="org.eclipse.sirius.runtime.source.feature.group" version="7.0.0.202109081424"/>
-      <unit id="org.eclipse.sirius.runtime.aql.source.feature.group" version="7.0.0.202109081424"/>
-      <unit id="org.eclipse.sirius.runtime.ide.ui.source.feature.group" version="7.0.0.202109081424"/>
-      <unit id="org.eclipse.sirius.interpreter.feature.source.feature.group" version="7.0.0.202109081424"/>
+      <unit id="org.eclipse.sirius.doc.feature.feature.group" version="7.0.0.202111230750"/>
+      <unit id="org.eclipse.sirius.doc.feature.source.feature.group" version="7.0.0.202111230750"/>
+      <unit id="org.eclipse.sirius.runtime.source.feature.group" version="7.0.0.202111230750"/>
+      <unit id="org.eclipse.sirius.runtime.aql.source.feature.group" version="7.0.0.202111230750"/>
+      <unit id="org.eclipse.sirius.runtime.ide.ui.source.feature.group" version="7.0.0.202111230750"/>
+      <unit id="org.eclipse.sirius.interpreter.feature.source.feature.group" version="7.0.0.202111230750"/>
       <unit id="org.eclipse.acceleo.ui.interpreter.source.feature.group" version="3.7.11.202102190929"/>
-      <unit id="org.eclipse.sirius.aql.source.feature.group" version="7.0.0.202109081424"/>
+      <unit id="org.eclipse.sirius.aql.source.feature.group" version="7.0.0.202111230750"/>
       <unit id="org.eclipse.acceleo.query.source.feature.group" version="7.0.0.202102190929"/>
-      <unit id="org.eclipse.sirius.runtime.ide.ui.acceleo.source.feature.group" version="7.0.0.202109081424"/>
-      <repository id="sirius" location="https://download.eclipse.org/sirius/updates/stable/7.0.0-S20210908-102403/2021-06"/>
+      <unit id="org.eclipse.sirius.runtime.ide.ui.acceleo.source.feature.group" version="7.0.0.202111230750"/>
+      <repository id="sirius" location="https://download.eclipse.org/sirius/updates/stable/7.0.0-S20211123-024920/2021-06"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.apache.batik.bridge.source" version="0.0.0"/>
@@ -58,28 +58,29 @@
       <repository id="Orbit" location="https://download.eclipse.org/tools/orbit/downloads/drops/R20210602031627/repository"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.polarsys.kitalpha.ad.runtime.feature.source.feature.group" version="6.0.0.202109200942"/>
-      <unit id="org.polarsys.kitalpha.cadence.feature.source.feature.group" version="6.0.0.202109200942"/>
-      <unit id="org.polarsys.kitalpha.common.feature.source.feature.group" version="6.0.0.202109200942"/>
-      <unit id="org.polarsys.kitalpha.emde.feature.source.feature.group" version="6.0.0.202109200942"/>
-      <unit id="org.polarsys.kitalpha.emde.ui.feature.source.feature.group" version="6.0.0.202109200942"/>
-      <unit id="org.polarsys.kitalpha.massactions.feature.source.feature.group" version="6.0.0.202109200942"/>
-      <unit id="org.polarsys.kitalpha.model.common.share.feature.source.feature.group" version="6.0.0.202109200942"/>
-      <unit id="org.polarsys.kitalpha.model.common.commands.feature.source.feature.group" version="6.0.0.202109200942"/>
-      <unit id="org.polarsys.kitalpha.model.common.scrutiny.feature.source.feature.group" version="6.0.0.202109200942"/>
-      <unit id="org.polarsys.kitalpha.model.detachment.contrib.viewpoints.feature.source.feature.group" version="6.0.0.202109200942"/>
-      <unit id="org.polarsys.kitalpha.model.detachment.feature.source.feature.group" version="6.0.0.202109200942"/>
-      <unit id="org.polarsys.kitalpha.model.detachment.ui.feature.source.feature.group" version="6.0.0.202109200942"/>
-      <unit id="org.polarsys.kitalpha.report.feature.source.feature.group" version="6.0.0.202109200942"/>
-      <unit id="org.polarsys.kitalpha.report.ui.feature.source.feature.group" version="6.0.0.202109200942"/>
-      <unit id="org.polarsys.kitalpha.resourcereuse.emfscheme.feature.source.feature.group" version="6.0.0.202109200942"/>
-      <unit id="org.polarsys.kitalpha.resourcereuse.emfscheme.ui.feature.source.feature.group" version="6.0.0.202109200942"/>
-      <unit id="org.polarsys.kitalpha.resourcereuse.feature.source.feature.group" version="6.0.0.202109200942"/>
-      <unit id="org.polarsys.kitalpha.resourcereuse.ui.feature.source.feature.group" version="6.0.0.202109200942"/>
-      <unit id="org.polarsys.kitalpha.richtext.widget.feature.source.feature.group" version="6.0.0.202109200942"/>
-      <unit id="org.polarsys.kitalpha.richtext.widget.ext.feature.source.feature.group" version="6.0.0.202109200942"/>
-      <unit id="org.polarsys.kitalpha.transposer.feature.source.feature.group" version="6.0.0.202109200942"/>
-      <repository id="kitalpha-runtime-core-master" location="https://download.eclipse.org/kitalpha/updates/stable/runtime/6.0.0-S202109200942"/>
+      <unit id="org.polarsys.kitalpha.ad.runtime.feature.source.feature.group" version="6.0.0.202112081913"/>
+      <unit id="org.polarsys.kitalpha.cadence.feature.source.feature.group" version="6.0.0.202112081913"/>
+      <unit id="org.polarsys.kitalpha.common.feature.source.feature.group" version="6.0.0.202112081913"/>
+      <unit id="org.polarsys.kitalpha.emde.feature.source.feature.group" version="6.0.0.202112081913"/>
+      <unit id="org.polarsys.kitalpha.emde.ui.feature.source.feature.group" version="6.0.0.202112081913"/>
+      <unit id="org.polarsys.kitalpha.massactions.feature.source.feature.group" version="6.0.0.202112081913"/>
+      <unit id="org.polarsys.kitalpha.model.common.share.feature.source.feature.group" version="6.0.0.202112081913"/>
+      <unit id="org.polarsys.kitalpha.model.common.commands.feature.source.feature.group" version="6.0.0.202112081913"/>
+      <unit id="org.polarsys.kitalpha.model.common.scrutiny.feature.source.feature.group" version="6.0.0.202112081913"/>
+      <unit id="org.polarsys.kitalpha.model.detachment.contrib.viewpoints.feature.source.feature.group" version="6.0.0.202112081913"/>
+      <unit id="org.polarsys.kitalpha.model.detachment.feature.source.feature.group" version="6.0.0.202112081913"/>
+      <unit id="org.polarsys.kitalpha.model.detachment.ui.feature.source.feature.group" version="6.0.0.202112081913"/>
+      <unit id="org.polarsys.kitalpha.report.feature.source.feature.group" version="6.0.0.202112081913"/>
+      <unit id="org.polarsys.kitalpha.report.ui.feature.source.feature.group" version="6.0.0.202112081913"/>
+      <unit id="org.polarsys.kitalpha.resourcereuse.emfscheme.feature.source.feature.group" version="6.0.0.202112081913"/>
+      <unit id="org.polarsys.kitalpha.resourcereuse.emfscheme.ui.feature.source.feature.group" version="6.0.0.202112081913"/>
+      <unit id="org.polarsys.kitalpha.resourcereuse.feature.source.feature.group" version="6.0.0.202112081913"/>
+      <unit id="org.polarsys.kitalpha.resourcereuse.ui.feature.source.feature.group" version="6.0.0.202112081913"/>
+      <unit id="org.polarsys.kitalpha.richtext.widget.feature.source.feature.group" version="6.0.0.202112081913"/>
+      <unit id="org.polarsys.kitalpha.richtext.widget.ext.feature.source.feature.group" version="6.0.0.202112081913"/>
+      <unit id="org.polarsys.kitalpha.transposer.feature.source.feature.group" version="6.0.0.202112081913"/>
+      <unit id="org.polarsys.kitalpha.sirius.rotativeimage.feature.feature.group" version="6.0.0.202112081913"/>
+      <repository id="kitalpha-runtime-core-master" location="https://download.eclipse.org/kitalpha/updates/stable/runtime/6.0.0.S202112081913/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.emf.diffmerge.feature.source.feature.group" version="0.14.0.202109160952"/>
@@ -94,8 +95,8 @@
       <repository id="amalgam" location="https://download.eclipse.org/modeling/amalgam/updates/stable/1.13.0-S20210909/capella/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.egf.sdk.feature.source.feature.group" version="1.6.2.202001031546"/>
-      <repository id="egf" location="http://download.eclipse.org/egf/updates/1.6.2/2019-06/"/>
+      <unit id="org.eclipse.egf.sdk.feature.source.feature.group" version="1.6.3.202110291409"/>
+      <repository id="egf" location="https://download.eclipse.org/egf/updates/stable/1.6.3/2021-06/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.nebula.widgets.nattable.core.feature.feature.group" version="0.0.0"/>
@@ -113,14 +114,14 @@
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.polarsys.capella.rcp.feature.group" version="0.0.0"/>
       <unit id="org.polarsys.capella.core.re.feature.feature.group" version="0.0.0"/>
-      <repository id="capella-master" location="https://download.eclipse.org/capella/core/updates/stable/6.0.0-S20210922-085001/org.polarsys.capella.rcp.site/"/>
+      <repository id="capella-master" location="https://download.eclipse.org/capella/core/updates/nightly/master-6.0-PR-2283-4/org.polarsys.capella.rcp.site/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.polarsys.kitalpha.doc.gen.business.core.feature.feature.group" version="0.0.0"/>
       <unit id="org.polarsys.kitalpha.doc.gen.business.core.feature.source.feature.group" version="0.0.0"/>
-      <unit id="org.polarsys.kitalpha.doc.feature.feature.group" version="6.0.0.202109200942"/>
-      <unit id="org.polarsys.kitalpha.emde.sdk.feature.source.feature.group" version="6.0.0.202109200942"/>
-      <repository id="kitalpha-sdk-master" location="https://download.eclipse.org/kitalpha/updates/stable/sdk/6.0.0-S202109200942/"/>
+      <unit id="org.polarsys.kitalpha.doc.feature.feature.group" version="6.0.0.202112081913"/>
+      <unit id="org.polarsys.kitalpha.emde.sdk.feature.source.feature.group" version="6.0.0.202112081913"/>
+      <repository id="kitalpha-sdk-master" location="https://download.eclipse.org/kitalpha/updates/stable/sdk/6.0.0.S202112081913/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.emf.query.feature.group" version="0.0.0"/>

--- a/releng/org.polarsys.capella.docgen.target/tp/capella.target-definition.targetplatform
+++ b/releng/org.polarsys.capella.docgen.target/tp/capella.target-definition.targetplatform
@@ -11,16 +11,16 @@
  *******************************************************************************/
 target "CapellaXHTMLDocGenAddon"
 
-include "https://raw.githubusercontent.com/eclipse/capella/master-6.0/releng/plugins/org.polarsys.capella.targets/full/capella.target-definition.targetplatform"
+include "https://raw.githubusercontent.com/arnauddieumegard/capella/rotative_svg/releng/plugins/org.polarsys.capella.targets/full/capella.target-definition.targetplatform"
 
 with source, requirements
 
-location capella-master "https://download.eclipse.org/capella/core/updates/stable/6.0.0-S20210922-085001/org.polarsys.capella.rcp.site/" {
+location capella-master "https://download.eclipse.org/capella/core/updates/nightly/master-6.0-PR-2283-4/org.polarsys.capella.rcp.site/" {
 	org.polarsys.capella.rcp.feature.group lazy
 	org.polarsys.capella.core.re.feature.feature.group lazy
 }
 
-location kitalpha-sdk-master "https://download.eclipse.org/kitalpha/updates/stable/sdk/6.0.0-S202109200942/" {
+location kitalpha-sdk-master "https://download.eclipse.org/kitalpha/updates/stable/sdk/6.0.0.S202112081913/" {
 	org.polarsys.kitalpha.doc.gen.business.core.feature.feature.group lazy
 	org.polarsys.kitalpha.doc.gen.business.core.feature.source.feature.group lazy
 }

--- a/releng/org.polarsys.capella.docgen.target/tp/capella.target-definition.targetplatform
+++ b/releng/org.polarsys.capella.docgen.target/tp/capella.target-definition.targetplatform
@@ -11,16 +11,16 @@
  *******************************************************************************/
 target "CapellaXHTMLDocGenAddon"
 
-include "https://raw.githubusercontent.com/arnauddieumegard/capella/rotative_svg/releng/plugins/org.polarsys.capella.targets/full/capella.target-definition.targetplatform"
+include "https://raw.githubusercontent.com/eclipse/capella/master-6.0/releng/plugins/org.polarsys.capella.targets/full/capella.target-definition.targetplatform"
 
 with source, requirements
 
-location capella-master "https://download.eclipse.org/capella/core/updates/nightly/master-6.0-PR-2283-4/org.polarsys.capella.rcp.site/" {
+location capella-master "https://download.eclipse.org/capella/core/updates/nightly/master-6.0/org.polarsys.capella.rcp.site/" {
 	org.polarsys.capella.rcp.feature.group lazy
 	org.polarsys.capella.core.re.feature.feature.group lazy
 }
 
-location kitalpha-sdk-master "https://download.eclipse.org/kitalpha/updates/stable/sdk/6.0.0.S202112081913/" {
+location kitalpha-sdk-master-stable "https://download.eclipse.org/kitalpha/updates/stable/sdk/6.0.0.S202112171603/" {
 	org.polarsys.kitalpha.doc.gen.business.core.feature.feature.group lazy
 	org.polarsys.kitalpha.doc.gen.business.core.feature.source.feature.group lazy
 }


### PR DESCRIPTION
Capella M2 has been bumped to 6.0.0, changes are reflected.
To avoid M2 migrations, replaced fcore references to Capella M2 metaclasses through URIs by references to Generated classes qualified names. Thus avoiding future version number migrations impacts and improving API modifications impacts handling.

Added Capella version check to ensure version consistency between Docgen and Capella.